### PR TITLE
Add warnings for missing parts

### DIFF
--- a/Translation Editor/translation_bg.json
+++ b/Translation Editor/translation_bg.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Нулиране завършено",
 		"YourGainMessage": "Усилване:",
 		"SettingsResetMessage": "Настройките бяха\nнулирани!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_cs.json
+++ b/Translation Editor/translation_cs.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Zisk:",
 		"SettingsResetMessage": "Tov. nas. obnov.",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_da.json
+++ b/Translation Editor/translation_da.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
 		"SettingsResetMessage": "Settings were\nreset!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_de.json
+++ b/Translation Editor/translation_de.json
@@ -25,6 +25,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your Gain:",
 		"SettingsResetMessage": "Einstellungen\nzurück gesetzt!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_en.json
+++ b/Translation Editor/translation_en.json
@@ -25,6 +25,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
 		"SettingsResetMessage": "Settings were\nreset!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_es.json
+++ b/Translation Editor/translation_es.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Hecho.       ",
 		"YourGainMessage": "Gananc.:",
 		"SettingsResetMessage": "Ajustes borrados",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_fi.json
+++ b/Translation Editor/translation_fi.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
 		"SettingsResetMessage": "Settings were\nreset!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_fr.json
+++ b/Translation Editor/translation_fr.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Gain :",
 		"SettingsResetMessage": "Réglage réinit. !",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": "VERROUIL",
 		"UnlockingKeysString": "DEVERROU",
 		"WarningKeysLockedString": "! VERR. !"

--- a/Translation Editor/translation_hr.json
+++ b/Translation Editor/translation_hr.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
 		"SettingsResetMessage": "Settings were\nreset!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_hu.json
+++ b/Translation Editor/translation_hu.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
 		"SettingsResetMessage": "Settings were\nreset!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_it.json
+++ b/Translation Editor/translation_it.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Guad.: ",
 		"SettingsResetMessage": "Reset effettuato",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": "Blocc.",
 		"UnlockingKeysString": "Sblocc.",
 		"WarningKeysLockedString": "BLOCCATO"

--- a/Translation Editor/translation_lt.json
+++ b/Translation Editor/translation_lt.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Gain:",
 		"SettingsResetMessage": "Nust. atstatyti!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " UŽRAKIN",
 		"UnlockingKeysString": "ATRAKIN",
 		"WarningKeysLockedString": "!UŽRAK!"

--- a/Translation Editor/translation_nl.json
+++ b/Translation Editor/translation_nl.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Niveau:",
 		"SettingsResetMessage": "Instellingen zijn\ngereset!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " GEBLOKKEERD",
 		"UnlockingKeysString": "GEDEBLOKKEERD",
 		"WarningKeysLockedString": "!GEBLOKKEERD!"

--- a/Translation Editor/translation_nl_be.json
+++ b/Translation Editor/translation_nl_be.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
 		"SettingsResetMessage": "Settings were\nreset!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_no.json
+++ b/Translation Editor/translation_no.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
 		"SettingsResetMessage": "Settings were\nreset!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_pl.json
+++ b/Translation Editor/translation_pl.json
@@ -25,6 +25,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Us.zysk:",
 		"SettingsResetMessage": "Ust. zresetowane",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " ZABLOK.",
 		"UnlockingKeysString": "ODBLOK.",
 		"WarningKeysLockedString": "!ZABLOK!"

--- a/Translation Editor/translation_pt.json
+++ b/Translation Editor/translation_pt.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
 		"SettingsResetMessage": "Settings were\nreset!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_ru.json
+++ b/Translation Editor/translation_ru.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Сброс OK",
 		"YourGainMessage": "Прирост:",
 		"SettingsResetMessage": "Настройки сброшены!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_sk.json
+++ b/Translation Editor/translation_sk.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Zisk:",
 		"SettingsResetMessage": "Nast. Obnovené!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_sl.json
+++ b/Translation Editor/translation_sl.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Ojačan.:",
 		"SettingsResetMessage": "Settings were\nreset!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_sr_cyrl.json
+++ b/Translation Editor/translation_sr_cyrl.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
 		"SettingsResetMessage": "Settings were\nreset!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_sr_latn.json
+++ b/Translation Editor/translation_sr_latn.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
 		"SettingsResetMessage": "Settings were\nreset!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_sv.json
+++ b/Translation Editor/translation_sv.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
 		"SettingsResetMessage": "Settings were\nreset!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translation_tr.json
+++ b/Translation Editor/translation_tr.json
@@ -23,7 +23,9 @@
 		"OffString": "Kapalı",
 		"ResetOKMessage": "Sıfırlama Tamam",
 		"YourGainMessage": "Kazancınız:",
-		"SettingsResetMessage": "Ayarlar Sıfırlandı"
+		"SettingsResetMessage": "Ayarlar Sıfırlandı",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!"
 	},
 	"characters": {
 		"SettingRightChar": "R",

--- a/Translation Editor/translation_uk.json
+++ b/Translation Editor/translation_uk.json
@@ -24,6 +24,8 @@
 		"ResetOKMessage": "Скидання OK",
 		"YourGainMessage": "Приріст:",
 		"SettingsResetMessage": "Налаштування скинуті!",
+		"NoAccelerometerMessage": "No accelerometer\ndetected!",
+		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"

--- a/Translation Editor/translations_def.js
+++ b/Translation Editor/translations_def.js
@@ -96,6 +96,16 @@ var def =
 			"default": "Settings were\nreset!"
 		},
 		{
+			"id": "NoAccelerometerMessage",
+			"maxLen": 16,
+			"default": "No accelerometer\ndetected!"
+		},
+		{
+			"id": "NoPowerDeliveryMessage",
+			"maxLen": 16,
+			"default": "No USB-PD IC\ndetected!"
+		},
+		{
 			"id": "LockingKeysString",
 			"maxLen": 8,
 			"default": "LOCKING"

--- a/workspace/TS100/Core/Drivers/OLED.cpp
+++ b/workspace/TS100/Core/Drivers/OLED.cpp
@@ -22,6 +22,7 @@ bool OLED::inLeftHandedMode;   // Whether the screen is in left or not (used for
 OLED::DisplayState OLED::displayState;
 uint8_t OLED::fontWidth, OLED::fontHeight;
 int16_t OLED::cursor_x, OLED::cursor_y;
+bool OLED::initDone = false;
 uint8_t OLED::displayOffset;
 uint8_t OLED::screenBuffer[16 + (OLED_WIDTH * 2) + 10];  // The data buffer
 uint8_t OLED::secondFrameBuffer[OLED_WIDTH * 2];
@@ -102,6 +103,7 @@ void OLED::initialize() {
 		}
 	}
 	setDisplayState(DisplayState::ON);
+	initDone = true;
 }
 void OLED::setFramebuffer(uint8_t *buffer) {
 	if (buffer == NULL) {
@@ -390,16 +392,14 @@ void OLED::drawAreaSwapped(int16_t x, int8_t y, uint8_t wide, uint8_t height, co
 
 	if (y == 0) {
 // Splat first line of data
-		for (uint8_t xx = visibleStart; xx < visibleEnd; xx += 2) {
+		for (uint8_t xx = visibleStart; xx < visibleEnd; xx ++) {
 			firstStripPtr[xx + x] = ptr[xx + 1];
-			firstStripPtr[xx + x + 1] = ptr[xx];
 		}
 	}
 	if (y == 8 || height == 16) {
 // Splat the second line
-		for (uint8_t xx = visibleStart; xx < visibleEnd; xx += 2) {
+		for (uint8_t xx = visibleStart; xx < visibleEnd; xx++) {
 			secondStripPtr[x + xx] = ptr[xx + 1 + (height == 16 ? wide : 0)];
-			secondStripPtr[x + xx + 1] = ptr[xx + (height == 16 ? wide : 0)];
 		}
 	}
 }
@@ -480,4 +480,8 @@ void OLED::drawHeatSymbol(uint8_t state) {
 	uint8_t cursor_x_temp = cursor_x;
 	drawSymbol(14);
 	drawFilledRect(cursor_x_temp, 0, cursor_x_temp + 12, 2 + (8 - state), true);
+}
+
+bool OLED::isInitDone() {
+	return initDone;
 }

--- a/workspace/TS100/Core/Drivers/OLED.hpp
+++ b/workspace/TS100/Core/Drivers/OLED.hpp
@@ -34,7 +34,7 @@ public:
 	};
 
 	static void initialize(); // Startup the I2C coms (brings screen out of reset etc)
-
+	static bool isInitDone();
 	// Draw the buffer out to the LCD using the DMA Channel
 	static void refresh() {
 		FRToSI2C::Transmit( DEVICEADDR_OLED, screenBuffer,
@@ -56,7 +56,7 @@ public:
 	static int16_t getCursorX() {
 		return cursor_x;
 	}
-	static void print(const char *string);// Draw a string to the current location, with current font
+	static void print(const char *string);	// Draw a string to the current location, with current font
 	// Set the cursor location by pixels
 	static void setCursor(int16_t x, int16_t y) {
 		cursor_x = x;
@@ -73,8 +73,7 @@ public:
 		drawArea(x, 0, width, 16, buffer);
 	}
 	// Draws an image to the buffer, at x offset from top to bottom (fixed height renders)
-	static void printNumber(uint16_t number, uint8_t places,
-			bool noLeaderZeros = true);
+	static void printNumber(uint16_t number, uint8_t places, bool noLeaderZeros = true);
 	// Draws a number at the current cursor location
 	// Clears the buffer
 	static void clearScreen() {
@@ -89,15 +88,11 @@ public:
 		drawSymbol((state) ? 16 : 17);
 	}
 	static void debugNumber(int32_t val);
-	static void drawSymbol(uint8_t symbolID);//Used for drawing symbols of a predictable width
-	static void drawArea(int16_t x, int8_t y, uint8_t wide, uint8_t height,
-			const uint8_t *ptr); //Draw an area, but y must be aligned on 0/8 offset
-	static void drawAreaSwapped(int16_t x, int8_t y, uint8_t wide,
-			uint8_t height, const uint8_t *ptr); //Draw an area, but y must be aligned on 0/8 offset
-	static void fillArea(int16_t x, int8_t y, uint8_t wide, uint8_t height,
-			const uint8_t value); //Fill an area, but y must be aligned on 0/8 offset
-	static void drawFilledRect(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1,
-			bool clear);
+	static void drawSymbol(uint8_t symbolID);	//Used for drawing symbols of a predictable width
+	static void drawArea(int16_t x, int8_t y, uint8_t wide, uint8_t height, const uint8_t *ptr); //Draw an area, but y must be aligned on 0/8 offset
+	static void drawAreaSwapped(int16_t x, int8_t y, uint8_t wide, uint8_t height, const uint8_t *ptr); //Draw an area, but y must be aligned on 0/8 offset
+	static void fillArea(int16_t x, int8_t y, uint8_t wide, uint8_t height, const uint8_t value); //Fill an area, but y must be aligned on 0/8 offset
+	static void drawFilledRect(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1, bool clear);
 	static void drawHeatSymbol(uint8_t state);
 	static void drawScrollIndicator(uint8_t p, uint8_t h); // Draws a scrolling position indicator
 	static void transitionSecondaryFramebuffer(bool forwardNavigation);
@@ -109,6 +104,7 @@ private:
 	static uint8_t *firstStripPtr; // Pointers to the strips to allow for buffer having extra content
 	static uint8_t *secondStripPtr;	//Pointers to the strips
 	static bool inLeftHandedMode; // Whether the screen is in left or not (used for offsets in GRAM)
+	static bool initDone;
 	static DisplayState displayState;
 	static uint8_t fontWidth, fontHeight;
 	static int16_t cursor_x, cursor_y;

--- a/workspace/TS100/Core/Drivers/TipThermoModel.cpp
+++ b/workspace/TS100/Core/Drivers/TipThermoModel.cpp
@@ -239,7 +239,7 @@ uint32_t TipThermoModel::getTipInF(bool sampleNow) {
 #endif
 
 uint32_t TipThermoModel::getTipMaxInC() {
-	uint32_t maximumTipTemp = TipThermoModel::convertTipRawADCToDegC(0x7FFF - (80 * 5)); //back off approx 5 deg c from ADC max
+	uint32_t maximumTipTemp = TipThermoModel::convertTipRawADCToDegC(0x7FFF - (21 * 5)); //back off approx 5 deg c from ADC max
 	maximumTipTemp += getHandleTemperature() / 10; //Add handle offset
 	return maximumTipTemp - 1;
 }

--- a/workspace/TS100/Core/Inc/Settings.h
+++ b/workspace/TS100/Core/Inc/Settings.h
@@ -11,7 +11,7 @@
 #define SETTINGS_H_
 #include <stdint.h>
 #include "unit.h"
-#define SETTINGSVERSION (0x23)
+#define SETTINGSVERSION (0x24)
 /*Change this if you change the struct below to prevent people getting \
           out of sync*/
 
@@ -38,7 +38,7 @@ typedef struct {
 	uint8_t detailedIDLE :1;	  // Detailed idle screen
 	uint8_t detailedSoldering :1; // Detailed soldering screens
 #ifdef ENABLED_FAHRENHEIT_SUPPORT
-	uint8_t temperatureInF : 1;   // Should the temp be in F or C (true is F)
+	uint8_t temperatureInF :1;   // Should the temp be in F or C (true is F)
 #endif
 	uint8_t descriptionScrollSpeed :1; // Description scroll speed
 	uint8_t lockingMode :2;	      // Store the locking mode
@@ -51,11 +51,12 @@ typedef struct {
 
 	uint8_t powerLimit; // Maximum power iron allowed to output
 
-
 	uint8_t ReverseButtonTempChangeEnabled; // Change the plus and minus button assigment
 	uint16_t TempChangeLongStep;			// Change the plus and minus button assigment
 	uint16_t TempChangeShortStep;			// Change the plus and minus button assigment
 	uint8_t hallEffectSensitivity;			//Operating mode of the hall effect sensor
+	uint8_t accelMissingWarningCounter; // Counter of how many times we have warned we cannot detect the accelerometer
+	uint8_t pdMissingWarningCounter; // Counter of how many times we have warned we cannot detect the pd interface
 
 	uint32_t padding; // This is here for in case we are not an even divisor so
 					  // that nothing gets cut off

--- a/workspace/TS100/Core/Inc/Translation.h
+++ b/workspace/TS100/Core/Inc/Translation.h
@@ -38,6 +38,8 @@ extern const char *OffString;
 extern const char *ResetOKMessage;
 extern const char *YourGainMessage;
 extern const char *SettingsResetMessage;
+extern const char *NoAccelerometerMessage;
+extern const char *NoPowerDeliveryMessage;
 extern const char *LockingKeysString;
 extern const char *UnlockingKeysString;
 extern const char *WarningKeysLockedString;

--- a/workspace/TS100/Core/Inc/main.hpp
+++ b/workspace/TS100/Core/Inc/main.hpp
@@ -14,6 +14,7 @@ extern "C" {
 void vApplicationStackOverflowHook(TaskHandle_t *pxTask,
 		signed portCHAR *pcTaskName);
 
+#define NO_DETECTED_ACCELEROMETER 99
 //Threads
 void startGUITask(void const *argument);
 void startPIDTask(void const *argument);

--- a/workspace/TS100/Core/Inc/main.hpp
+++ b/workspace/TS100/Core/Inc/main.hpp
@@ -15,6 +15,7 @@ void vApplicationStackOverflowHook(TaskHandle_t *pxTask,
 		signed portCHAR *pcTaskName);
 
 #define NO_DETECTED_ACCELEROMETER 99
+#define ACCELEROMETERS_SCANNING 100
 //Threads
 void startGUITask(void const *argument);
 void startPIDTask(void const *argument);

--- a/workspace/TS100/Core/Inc/main.hpp
+++ b/workspace/TS100/Core/Inc/main.hpp
@@ -3,7 +3,7 @@
 
 #include "OLED.hpp"
 #include "Setup.h"
-extern uint8_t PCBVersion;
+extern uint8_t DetectedAccelerometerVersion;
 extern uint32_t currentTempTargetDegC;
 extern bool settingsWereReset;
 extern bool usb_pd_available;

--- a/workspace/TS100/Core/Src/Settings.cpp
+++ b/workspace/TS100/Core/Src/Settings.cpp
@@ -68,7 +68,7 @@ void resetSettings() {
 	systemSettings.lockingMode = LOCKING_MODE; // Disable locking for safety
 	systemSettings.coolingTempBlink = COOLING_TEMP_BLINK; // Blink the temperature on the cooling screen when its > 50C
 #ifdef ENABLED_FAHRENHEIT_SUPPORT
-			systemSettings.temperatureInF = TEMPERATURE_INF;          // default to 0
+	systemSettings.temperatureInF = TEMPERATURE_INF;          // default to 0
 #endif
 	systemSettings.descriptionScrollSpeed = DESCRIPTION_SCROLL_SPEED; // default to slow
 	systemSettings.CalibrationOffset = CALIBRATION_OFFSET; // the adc offset in uV
@@ -78,6 +78,9 @@ void resetSettings() {
 	systemSettings.TempChangeLongStep = TEMP_CHANGE_LONG_STEP; //
 	systemSettings.KeepAwakePulse = POWER_PULSE_DEFAULT;
 	systemSettings.hallEffectSensitivity = 1;
+	systemSettings.accelMissingWarningCounter = 0;
+	systemSettings.pdMissingWarningCounter = 0;
+
 	saveSettings();  // Save defaults
 }
 

--- a/workspace/TS100/Core/Src/gui.cpp
+++ b/workspace/TS100/Core/Src/gui.cpp
@@ -371,7 +371,7 @@ static bool settings_setSleepTime(void) {
 		systemSettings.SleepTime = 0; // can't set time over 10 mins
 	}
 	// Remember that ^ is the time of no movement
-	if (DetectedAccelerometerVersion == 99)
+	if (DetectedAccelerometerVersion == NO_DETECTED_ACCELEROMETER)
 		systemSettings.SleepTime = 0; // Disable sleep on no accel
 	return systemSettings.SleepTime == 15;
 }
@@ -394,7 +394,7 @@ static bool settings_setShutdownTime(void) {
 	if (systemSettings.ShutdownTime > 60) {
 		systemSettings.ShutdownTime = 0; // wrap to off
 	}
-	if (DetectedAccelerometerVersion == 99)
+	if (DetectedAccelerometerVersion == NO_DETECTED_ACCELEROMETER)
 		systemSettings.ShutdownTime = 0; // Disable shutdown on no accel
 	return systemSettings.ShutdownTime == 60;
 }
@@ -722,7 +722,6 @@ static bool settings_setCalibrateVIN(void) {
 	// Jump to the voltage calibration subscreen
 	OLED::setFont(0);
 	OLED::clearScreen();
-	OLED::setCursor(0, 0);
 
 	for (;;) {
 		OLED::setCursor(0, 0);

--- a/workspace/TS100/Core/Src/gui.cpp
+++ b/workspace/TS100/Core/Src/gui.cpp
@@ -371,7 +371,7 @@ static bool settings_setSleepTime(void) {
 		systemSettings.SleepTime = 0; // can't set time over 10 mins
 	}
 	// Remember that ^ is the time of no movement
-	if (PCBVersion == 99)
+	if (DetectedAccelerometerVersion == 99)
 		systemSettings.SleepTime = 0; // Disable sleep on no accel
 	return systemSettings.SleepTime == 15;
 }
@@ -394,7 +394,7 @@ static bool settings_setShutdownTime(void) {
 	if (systemSettings.ShutdownTime > 60) {
 		systemSettings.ShutdownTime = 0; // wrap to off
 	}
-	if (PCBVersion == 99)
+	if (DetectedAccelerometerVersion == 99)
 		systemSettings.ShutdownTime = 0; // Disable shutdown on no accel
 	return systemSettings.ShutdownTime == 60;
 }

--- a/workspace/TS100/Core/Src/main.cpp
+++ b/workspace/TS100/Core/Src/main.cpp
@@ -11,7 +11,7 @@
 #include <power.hpp>
 #include "Settings.h"
 #include "cmsis_os.h"
-uint8_t PCBVersion = 0;
+uint8_t DetectedAccelerometerVersion = 0;
 bool settingsWereReset = false;
 // FreeRTOS variables
 

--- a/workspace/TS100/Core/Threads/MOVThread.cpp
+++ b/workspace/TS100/Core/Threads/MOVThread.cpp
@@ -85,8 +85,10 @@ inline void readAccelerometer(int16_t &tx, int16_t &ty, int16_t &tz, Orientation
 void startMOVTask(void const *argument __unused) {
 	postRToSInit();
 	detectAccelerometerVersion();
+	osDelay(50);  //wait ~50ms for setup of accel to finalise
 	lastMovementTime = 0;
-	if ((systemSettings.autoStartMode == 2 || systemSettings.autoStartMode == 3))
+	//Mask 2 seconds if we are in autostart so that if user is plugging in and then putting in stand it doesnt wake instantly
+	if (systemSettings.autoStartMode)
 		osDelay(2 * TICKS_SECOND);
 
 	int16_t datax[MOVFilter] = { 0 };

--- a/workspace/TS100/Core/Threads/MOVThread.cpp
+++ b/workspace/TS100/Core/Threads/MOVThread.cpp
@@ -24,6 +24,7 @@
 uint8_t accelInit = 0;
 TickType_t lastMovementTime = 0;
 void detectAccelerometerVersion() {
+	DetectedAccelerometerVersion = ACCELEROMETERS_SCANNING;
 #ifdef ACCEL_MMA
 	if (MMA8652FC::detect()) {
 		DetectedAccelerometerVersion = 1;
@@ -83,16 +84,11 @@ inline void readAccelerometer(int16_t &tx, int16_t &ty, int16_t &tz, Orientation
 }
 void startMOVTask(void const *argument __unused) {
 	postRToSInit();
-	while (OLED::isInitDone() == false) {
-		osDelay(1);  //Make oled init happen first
-	}
-	OLED::setRotation(systemSettings.OrientationMode & 1);
 	detectAccelerometerVersion();
 	lastMovementTime = 0;
 	if ((systemSettings.autoStartMode == 2 || systemSettings.autoStartMode == 3))
 		osDelay(2 * TICKS_SECOND);
 
-	lastMovementTime = 0;
 	int16_t datax[MOVFilter] = { 0 };
 	int16_t datay[MOVFilter] = { 0 };
 	int16_t dataz[MOVFilter] = { 0 };
@@ -102,17 +98,6 @@ void startMOVTask(void const *argument __unused) {
 	if (systemSettings.sensitivity > 9)
 		systemSettings.sensitivity = 9;
 	Orientation rotation = ORIENTATION_FLAT;
-//	OLED::setFont(1);
-//	for (;;) {
-//		OLED::clearScreen();
-//		OLED::setCursor(0, 0);
-//		readAccelerometer(tx, ty, tz, rotation);
-//		OLED::printNumber(tx, 5, 0);
-//		OLED::setCursor(0, 8);
-//		OLED::printNumber(xTaskGetTickCount() / 10, 5, 1);
-//		OLED::refresh();
-//		osDelay(50);
-//	}
 	for (;;) {
 		int32_t threshold = 1500 + (9 * 200);
 		threshold -= systemSettings.sensitivity * 200;  // 200 is the step size

--- a/workspace/TS100/Core/Threads/MOVThread.cpp
+++ b/workspace/TS100/Core/Threads/MOVThread.cpp
@@ -26,32 +26,32 @@ TickType_t lastMovementTime = 0;
 void detectAccelerometerVersion() {
 #ifdef ACCEL_MMA
 	if (MMA8652FC::detect()) {
-		PCBVersion = 1;
+		DetectedAccelerometerVersion = 1;
 		if (!MMA8652FC::initalize()) {
-			PCBVersion = 99;
+			DetectedAccelerometerVersion = 99;
 		}
 	} else
 #endif
 #ifdef ACCEL_LIS
 	if (LIS2DH12::detect()) {
-		PCBVersion = 2;
+		DetectedAccelerometerVersion = 2;
 		// Setup the ST Accelerometer
 		if (!LIS2DH12::initalize()) {
-			PCBVersion = 99;
+			DetectedAccelerometerVersion = 99;
 		}
 	} else
 #endif
 #ifdef ACCEL_BMA
 	if (BMA223::detect()) {
-		PCBVersion = 3;
+		DetectedAccelerometerVersion = 3;
 		// Setup the ST Accelerometer
 		if (!BMA223::initalize()) {
-			PCBVersion = 99;
+			DetectedAccelerometerVersion = 99;
 		}
 	} else
 #endif
 	{
-		PCBVersion = 99;
+		DetectedAccelerometerVersion = 99;
 		systemSettings.SleepTime = 0;
 		systemSettings.ShutdownTime = 0;  // No accel -> disable sleep
 		systemSettings.sensitivity = 0;
@@ -60,19 +60,19 @@ void detectAccelerometerVersion() {
 }
 inline void readAccelerometer(int16_t &tx, int16_t &ty, int16_t &tz, Orientation &rotation) {
 #ifdef ACCEL_LIS
-	if (PCBVersion == 2) {
+	if (DetectedAccelerometerVersion == 2) {
 		LIS2DH12::getAxisReadings(tx, ty, tz);
 		rotation = LIS2DH12::getOrientation();
 	} else
 #endif
 #ifdef ACCEL_MMA
-	if (PCBVersion == 1) {
+	if (DetectedAccelerometerVersion == 1) {
 		MMA8652FC::getAxisReadings(tx, ty, tz);
 		rotation = MMA8652FC::getOrientation();
 	} else
 #endif
 #ifdef ACCEL_BMA
-	if (PCBVersion == 3) {
+	if (DetectedAccelerometerVersion == 3) {
 		BMA223::getAxisReadings(tx, ty, tz);
 		rotation = BMA223::getOrientation();
 	} else

--- a/workspace/TS100/Core/Threads/MOVThread.cpp
+++ b/workspace/TS100/Core/Threads/MOVThread.cpp
@@ -28,7 +28,7 @@ void detectAccelerometerVersion() {
 	if (MMA8652FC::detect()) {
 		DetectedAccelerometerVersion = 1;
 		if (!MMA8652FC::initalize()) {
-			DetectedAccelerometerVersion = 99;
+			DetectedAccelerometerVersion = NO_DETECTED_ACCELEROMETER;
 		}
 	} else
 #endif
@@ -37,7 +37,7 @@ void detectAccelerometerVersion() {
 		DetectedAccelerometerVersion = 2;
 		// Setup the ST Accelerometer
 		if (!LIS2DH12::initalize()) {
-			DetectedAccelerometerVersion = 99;
+			DetectedAccelerometerVersion = NO_DETECTED_ACCELEROMETER;
 		}
 	} else
 #endif
@@ -46,12 +46,12 @@ void detectAccelerometerVersion() {
 		DetectedAccelerometerVersion = 3;
 		// Setup the ST Accelerometer
 		if (!BMA223::initalize()) {
-			DetectedAccelerometerVersion = 99;
+			DetectedAccelerometerVersion = NO_DETECTED_ACCELEROMETER;
 		}
 	} else
 #endif
 	{
-		DetectedAccelerometerVersion = 99;
+		DetectedAccelerometerVersion = NO_DETECTED_ACCELEROMETER;
 		systemSettings.SleepTime = 0;
 		systemSettings.ShutdownTime = 0;  // No accel -> disable sleep
 		systemSettings.sensitivity = 0;
@@ -82,8 +82,10 @@ inline void readAccelerometer(int16_t &tx, int16_t &ty, int16_t &tz, Orientation
 	}
 }
 void startMOVTask(void const *argument __unused) {
-	osDelay(1);  //Make oled init happen first
 	postRToSInit();
+	while (OLED::isInitDone() == false) {
+		osDelay(1);  //Make oled init happen first
+	}
 	OLED::setRotation(systemSettings.OrientationMode & 1);
 	detectAccelerometerVersion();
 	lastMovementTime = 0;
@@ -148,7 +150,7 @@ void startMOVTask(void const *argument __unused) {
 		// So now we have averages, we want to look if these are different by more
 		// than the threshold
 
-		// If error has occurred then we update the tick timer
+		// If movement has occurred then we update the tick timer
 		if (error > threshold) {
 			lastMovementTime = xTaskGetTickCount();
 		}

--- a/workspace/TS100A/.gitignore
+++ b/workspace/TS100A/.gitignore
@@ -1,5 +1,0 @@
-/Release/
-/TS100/
-/TS100_LOCAL/
-/ReleaseTS80/
-/ReleaseTS100/


### PR DESCRIPTION
Have tested on a few units.
Seems to do the thing :) 

This adds two extra warnings on startup, one for missing accelerometer and one for missing PD-ic when they are expected.
These will only be shown twice (unless settings are reset)