### PR TITLE
TS100: fix make dependency computation

### DIFF
--- a/workspace/TS100/Makefile
+++ b/workspace/TS100/Makefile
@@ -85,8 +85,8 @@ CPUFLAGS= -march=rv32imac \
 DEV_LDFLAGS= -lstdc++ -nostartfiles -Xlinker --gc-sections --specs=nosys.specs -u _isatty -u _write -u _sbrk -u _read -u _close -u _fstat -u _lseek
 DEV_AFLAGS= -nostartfiles -ffreestanding -fno-common -Os -flto 
 DEV_GLOBAL_DEFS=
-DEV_CFLAGS= -MMD -MP -MF "$(@:%.o=%.d)" -MT "$(@:%.o=%.d)" 
-DEV_CXXFLAGS= -MMD -MP -MF "$(@:%.o=%.d)" -MT "$(@:%.o=%.d)" 
+DEV_CFLAGS= -MMD -MP -MF "$(@:%.o=%.d)" -MT "$@"
+DEV_CXXFLAGS= -MMD -MP -MF "$(@:%.o=%.d)" -MT "$@"
 endif
 
 INCLUDES = -I$(APP_INC_DIR)	\


### PR DESCRIPTION
Change the generated targets to be the actual object files to be build.
Previously the target name was the dependency file itself. As no other
targets required the dependency file, those computed dependencies were
never used.


Please try and fill out this template where possible, not all fields are required and can be removed.

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**

Build system bugfix.

* **What is the current behavior?**

No automatic source file dependencies are used during build.

* **What is the new behavior (if this is a feature change)?**

Automatic source file dependencies are taken into account.

* **Steps to reproduce**:

```sh
$ make
...
Lots of output
$ make
Building for Pine64 
 
make: Nothing to be done for 'all'.
$ touch Core/Inc/Settings.h
$ make  # without this patch
Building for Pine64 
 
make: Nothing to be done for 'all'.
$ make  # with this patch
Building for Pine64 
 
Compiling ./Core/Threads/MOVThread.cpp
Compiling ./Core/Threads/GUIThread.cpp
Compiling ./Core/Threads/PIDThread.cpp
Compiling ./Core/Src/gui.cpp
Compiling ./Core/Src/main.cpp
Compiling ./Core/Src/power.cpp
Compiling ./Core/Src/Settings.cpp
Compiling ./Core/Drivers/TipThermoModel.cpp
Compiling ./Core/Drivers/Buttons.cpp
Compiling ./Core/BSP/Pine64/postRTOS.cpp
Compiling ./Core/BSP/Pine64/QC_GPIO.cpp
Compiling ./Core/BSP/Pine64/Power.cpp
Linking Pinecil_EN.elf
riscv64-elf-objcopy Hexfile/Pinecil_EN.elf -O ihex Hexfile/Pinecil_EN.hex
riscv64-elf-size  --format=berkeley  Hexfile/Pinecil_EN.elf
   text	   data	    bss	    dec	    hex	filename
  48146	    608	  14732	  63486	   f7fe	Hexfile/Pinecil_EN.elf
riscv64-elf-objcopy Hexfile/Pinecil_EN.elf -O binary Hexfile/Pinecil_EN.bin
```