### PR TITLE
Updated Lithuanian translation. Fixed some offscreen texts.

### DIFF
--- a/Translations/translation_lt.json
+++ b/Translations/translation_lt.json
@@ -15,17 +15,17 @@
 		"SleepingAdvancedString": "Miegu...",
 		"WarningSimpleString": "KRŠ!",
 		"WarningAdvancedString": "ANTGALIS KARŠTAS",
-		"SleepingTipAdvancedString": "Angal:",
+		"SleepingTipAdvancedString": "Antg: ",
 		"IdleTipString": "Ant:",
 		"IdleSetString": " Nust:",
 		"TipDisconnectedString": "NĖRA ANTGALIO",
 		"SolderingAdvancedPowerPrompt": "Galia: ",
 		"OffString": "Išj",
-		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Gain:",
+		"ResetOKMessage": "Atstatytas OK",
+		"YourGainMessage": "Greitis:",
 		"SettingsResetMessage": "Nust. atstatyti!",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
+		"NoAccelerometerMessage": "Nerastas\nakselerometras!",
+		"NoPowerDeliveryMessage": "Nerastas\nUSB-PD IC !",
 		"LockingKeysString": " UŽRAKIN",
 		"UnlockingKeysString": "ATRAKIN",
 		"WarningKeysLockedString": "!UŽRAK!"
@@ -214,8 +214,8 @@
 		},
 		"QCMaxVoltage": {
 			"text2": [
-				"QC maitinimo",
-				"bloko įtampa"
+				"QC mait.",
+				"įtampa"
 			],
 			"desc": "Maksimali QC maitinimo bloko įtampa"
 		},
@@ -235,31 +235,31 @@
 		},
 		"TempChangeShortStep": {
 			"text2": [
-				"Temp. keitimas",
-				"trumpas spust."
+				"Temp.keitim.",
+				"trump.spust."
 			],
 			"desc": "Temperatūros keitimo žingsnis trumpai spustėlėjus mygtuką!"
 		},
 		"TempChangeLongStep": {
 			"text2": [
-				"Temp. keitimas",
+				"Temp.keitim.",
 				"ilgas pasp."
 			],
 			"desc": "Temperatūros keitimo žingsnis ilgai paspaudus mygtuką!"
 		},
 		"PowerPulsePower": {
 			"text2": [
-				"Power",
-				"Pulse W"
+				"Galios",
+				"Pulso W"
 			],
-			"desc": "Keep awake pulse power intensity"
+			"desc": "Periodinis galios pulso intensyvumas maitinblokiui, neleidžiantis jam užmigti."
 		},
 		"TipGain": {
 			"text2": [
-				"Modify",
-				"tip gain"
+				"Keisti",
+				"antgreit"
 			],
-			"desc": "Tip gain"
+			"desc": "Antgalio pokyčio greitis"
 		},
 		"HallEffSensitivity": {
 			"text2": [


### PR DESCRIPTION
o The changes have been tested locally on both TS80P (PCB4) and TS100 (PCB2).

o No offscreen texts, everything fits.

o "Gain" was named to "Speed" in LT, because "Gain" only translates to money-gain or achievement-gain. Haven't found it menus, so couldn't test it visually...

Have a nice day!