### PR TITLE
Fix temp. adjust menu button behaviour

### DIFF
--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -184,13 +184,25 @@ static void gui_solderingTempAdjust() {
   currentTempTargetDegC           = 0;
   uint32_t autoRepeatTimer        = 0;
   uint8_t  autoRepeatAcceleration = 0;
+  bool waitForRelease = false;
+  ButtonState buttons = getButtonState();
+  if (buttons != BUTTON_NONE) {
+    // Temp adjust entered by long-pressing F button.
+    waitForRelease = true;
+  }
   for (;;) {
     OLED::setCursor(0, 0);
     OLED::clearScreen();
     OLED::setFont(0);
-    ButtonState buttons = getButtonState();
-    if (buttons)
+    buttons = getButtonState();
+    if (buttons) {
+      if (waitForRelease) {
+        buttons = BUTTON_NONE;
+      }
       lastChange = xTaskGetTickCount();
+    } else {
+      waitForRelease = false;
+    }
     switch (buttons) {
     case BUTTON_NONE:
       // stay

--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -194,6 +194,7 @@ static void gui_solderingTempAdjust() {
     switch (buttons) {
     case BUTTON_NONE:
       // stay
+      autoRepeatAcceleration = 0;
       break;
     case BUTTON_BOTH:
       // exit

--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -180,12 +180,12 @@ static void gui_drawBatteryIcon() {
 #endif
 }
 static void gui_solderingTempAdjust() {
-  uint32_t lastChange             = xTaskGetTickCount();
-  currentTempTargetDegC           = 0;
-  uint32_t autoRepeatTimer        = 0;
-  uint8_t  autoRepeatAcceleration = 0;
-  bool waitForRelease = false;
-  ButtonState buttons = getButtonState();
+  uint32_t lastChange                = xTaskGetTickCount();
+  currentTempTargetDegC              = 0;
+  uint32_t    autoRepeatTimer        = 0;
+  uint8_t     autoRepeatAcceleration = 0;
+  bool        waitForRelease         = false;
+  ButtonState buttons                = getButtonState();
   if (buttons != BUTTON_NONE) {
     // Temp adjust entered by long-pressing F button.
     waitForRelease = true;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
  - The changes have been tested locally
  - There are no breaking changes

* **What kind of change does this PR introduce?**
(Bug fix, feature, ~~docs update~~, ~~...~~)



* **What is the current behavior?**

  - #825
  - The long-press temperature change acceleration does not reset after releasing the button.

* **What is the new behavior (if this is a feature change)?**

  - Long-pressing to enter temp. adjust mode now waits for a button state change before handling more button input.
  - The long-press temperature change acceleration resets after releasing the button.

* **Other information**:
