### PR TITLE
Add copyright and license notices to release

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,6 +29,11 @@ jobs:
       - name: build TS80
         run: cd source && ./build.sh -m TS80
 
+      - name: copy license text
+        run: |
+          cp LICENSE source/Hexfile/LICENSE
+          cp LICENSE_RELEASE.md source/Hexfile/LICENSE_RELEASE.md
+
       - name: Archive TS80 artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -36,6 +41,8 @@ jobs:
           path: |
             source/Hexfile/TS80_*.hex
             source/Hexfile/TS80_*.bin
+            source/Hexfile/LICENSE
+            source/Hexfile/LICENSE_RELEASE.md
           if-no-files-found: error
   build_TS80P:
     runs-on: ubuntu-latest
@@ -63,6 +70,11 @@ jobs:
       - name: build TS80P
         run: cd source && ./build.sh -m TS80P
 
+      - name: copy license text
+        run: |
+          cp LICENSE source/Hexfile/LICENSE
+          cp LICENSE_RELEASE.md source/Hexfile/LICENSE_RELEASE.md
+
       - name: Archive TS80P artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -70,6 +82,8 @@ jobs:
           path: |
             source/Hexfile/TS80P_*.hex
             source/Hexfile/TS80P_*.bin
+            source/Hexfile/LICENSE
+            source/Hexfile/LICENSE_RELEASE.md
           if-no-files-found: error
   build_TS100:
     runs-on: ubuntu-latest
@@ -97,6 +111,11 @@ jobs:
       - name: build TS100
         run: cd source && ./build.sh -m TS100
 
+      - name: copy license text
+        run: |
+          cp LICENSE source/Hexfile/LICENSE
+          cp LICENSE_RELEASE.md source/Hexfile/LICENSE_RELEASE.md
+
       - name: Archive TS100 artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -104,6 +123,8 @@ jobs:
           path: |
             source/Hexfile/TS100_*.hex
             source/Hexfile/TS100_*.bin
+            source/Hexfile/LICENSE
+            source/Hexfile/LICENSE_RELEASE.md
           if-no-files-found: error
 
   build_Pinecil:
@@ -132,6 +153,11 @@ jobs:
       - name: build Pinecil
         run: cd source && ./build.sh -m Pinecil
 
+      - name: copy license text
+        run: |
+          cp LICENSE source/Hexfile/LICENSE
+          cp LICENSE_RELEASE.md source/Hexfile/LICENSE_RELEASE.md
+
       - name: Archive Pinecil artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -139,4 +165,6 @@ jobs:
           path: |
             source/Hexfile/Pinecil_*.hex
             source/Hexfile/Pinecil_*.bin
+            source/Hexfile/LICENSE
+            source/Hexfile/LICENSE_RELEASE.md
           if-no-files-found: error

--- a/LICENSE_RELEASE.md
+++ b/LICENSE_RELEASE.md
@@ -1,0 +1,155 @@
+This document outlines the license of IronOS and its dependencies.
+
+- IronOS: GPL-3.0-only
+- FreeRTOS Kernel: MIT
+- FUSB302 driver: Apache-2.0
+- CMSIS + STM32F1xx HAL driver: BSD-3-Clause
+- NMSIS: Apache-2.0
+- GD32VF103 board files: BSD-3-Clause
+
+The source code of IronOS can be obtained on the [IronOS GitHub repo][gh].
+
+[gh]: https://github.com/Ralim/IronOS
+
+
+IronOS
+---
+
+Copyright (c) 2016-2020 Ben V. Brown and contributors
+
+For the license text, see `LICENSE` file.
+
+
+FreeRTOS Kernel
+---
+
+```
+Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in al
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITN
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS O
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHE
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+```
+
+
+FUSB302 driver
+---
+
+```
+PD Buddy Firmware Library - USB Power Delivery for everyone
+Copyright 2017-2018 Clayton G. Hobbs
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
+
+
+CMSIS + STM32F1xx HAL driver
+---
+
+* Only applies to TS100, TS80 and TS80P releases.
+
+```
+COPYRIGHT(c) 2017 STMicroelectronics
+
+Redistribution and use in source and binary forms, with or without dification,
+are permitted provided that the following conditions are met:
+  1. Redistributions of source code must retain the above copyright notice,
+     this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+  3. Neither the name of STMicroelectronics nor the names of its contributors
+     may be used to endorse or promote products derived from this software
+     without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+
+NMSIS
+---
+
+* Only applies to Pinecil releases.
+
+```
+Copyright (c) 2019 Nuclei Limited. All rights reserved.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the License); you may
+not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an AS IS BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+```
+
+GD32VF103 board files
+---
+
+* Only applies to Pinecil releases.
+
+```
+Copyright (c) 2019, GigaDevice Semiconductor Inc.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of its contributors
+    may be used to endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+```
+


### PR DESCRIPTION
This adds `LICENSE` and a new `LICENSE_RELEASE.md` to the GitHub action workflow artifact outputs.

@Ralim  I think this should be appropriate, but if you find any issues, feel free to edit the files before merging

Closes #824