### PR TITLE
Fix docker build on Fedora and other SELinux enabled systems

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,5 +7,5 @@ services:
       context: .
     command: /bin/bash
     volumes:
-      - ./ci:/build/ci
-      - ./:/build/source
+      - ./ci:/build/ci:Z
+      - ./:/build/source:Z


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] The changes have been tested locally
- [X] There are no breaking changes

* **What kind of change does this PR introduce?**
Bug fix in the build environment.

* **What is the current behavior?**
On SELinux enabled Linux systems like Fedora, `build.sh` fails with the following error:
  
  ```
  Creating ironos_builder_run ... done
  /bin/bash: /build/ci/buildAll.sh: Permission denied
  ```

  This is because SELinux forbids to mount `/home` directories in a Docker container.

* **What is the new behavior (if this is a feature change)?**
`build.sh` runs on SELinux machines because Docker is explicity permitted to mount the `/home` directory. See [here](https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label).