### PR TITLE
Change temperature steps for long step config

### DIFF
--- a/source/Core/Src/gui.cpp
+++ b/source/Core/Src/gui.cpp
@@ -822,9 +822,15 @@ static void settings_displayTempChangeShortStep(void) {
 }
 
 static bool settings_setTempChangeLongStep(void) {
-  systemSettings.TempChangeLongStep += TEMP_CHANGE_LONG_STEP;
+  if (systemSettings.TempChangeLongStep == TEMP_CHANGE_SHORT_STEP) {
+    systemSettings.TempChangeLongStep = TEMP_CHANGE_LONG_STEP / 2;
+  } else if (systemSettings.TempChangeLongStep == TEMP_CHANGE_LONG_STEP / 2) {
+    systemSettings.TempChangeLongStep = TEMP_CHANGE_LONG_STEP;
+  } else {
+    systemSettings.TempChangeLongStep += TEMP_CHANGE_LONG_STEP;
+  }
   if (systemSettings.TempChangeLongStep > TEMP_CHANGE_LONG_STEP_MAX) {
-    systemSettings.TempChangeLongStep = TEMP_CHANGE_LONG_STEP; // loop back at TEMP_CHANGE_LONG_STEP_MAX
+    systemSettings.TempChangeLongStep = TEMP_CHANGE_SHORT_STEP; // loop back at TEMP_CHANGE_LONG_STEP_MAX
   }
   return systemSettings.TempChangeLongStep == TEMP_CHANGE_LONG_STEP_MAX;
 }


### PR DESCRIPTION
Added two new steps in the long step config: short step (=1) and half long step (=5). This allows swapping of short and long press behavior.

* **Please check if the PR fulfills these requirements**
- [X] The changes have been tested locally
- [ ] There are no breaking changes

* **What kind of change does this PR introduce?**
Feature change

* **What is the current behavior?**
IronOS permits to change the temperature by either a short press or long press of the keys. By default, a short press changes the temperature by 1°C, while a long press changes it by 10°C.

  I wanted to swap the behavior, so the temperature is changed by 10°C steps with a short press, and can then be "fine-tuned" with a long press. To me this feels more natural than the current behavior.

  The temperature steps can be configured in the settings, although the settings only permit certain values. Short press can only be changed between 1 and 10 in 1 steps, while long press can only be changed between 10 and 90 by 10 steps. With these constaints, it is not possible to swap the long/short press behavior.

* **What is the new behavior (if this is a feature change)?**
The "long press" configuration option now also offers 1 and 5 as steps, this is: 1, 5, 10, 20, 30, ... 90. This way, I can set the "short press" configuration to 10°C, and the "long press" configuration to 1°C.