### PR TITLE
Add 18v for pinecil

### DIFF
--- a/source/Core/BSP/Pine64/BSP_PD.c
+++ b/source/Core/BSP/Pine64/BSP_PD.c
@@ -15,11 +15,12 @@ const uint16_t USB_PD_Desired_Levels[] = {
     // mV desired input, mA minimum required current
     // Tip is ~ 7.5 ohms
     20000, 2666, // 20V, 2.6A
+    18000, 2400, // 18V, 2.4A
     15000, 2000, // 15V 2A
     12000, 1600, // 12V @ 1.6A
     9000,  1200, // 9V @ 1.2A
     5000,  100,  // 5V @ whatever
 
 };
-const uint8_t USB_PD_Desired_Levels_Len = 5;
+const uint8_t USB_PD_Desired_Levels_Len = 6;
 #endif


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Add 18v @ 2.4A usb-pd.

* **What is the current behavior?**
With my adapter it falls back to 15v.

* **What is the new behavior (if this is a feature change)?**
It switches to 18v correctly.

* **Other information**:
So I got this adapter from [aliexpress](https://www.aliexpress.com/item/4001316262433.html) because it's cheap and comes with decently flexible cable.

![JPEG image 9](https://user-images.githubusercontent.com/1065521/110840766-1fb90080-8273-11eb-8181-8460fbc6cfc3.jpeg)

However, it can't use 20v @ 2.6a due to power limit, so instead I've added 18v @ 2.4a to hopefully make it a little better than 15v @ 2a.