### PR TITLE
Add user-adjustable Power Pulse's duration and delay (rate) settings

### DIFF
--- a/Translations/translation_BG.json
+++ b/Translations/translation_BG.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_CS.json
+++ b/Translations/translation_CS.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_DA.json
+++ b/Translations/translation_DA.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_DE.json
+++ b/Translations/translation_DE.json
@@ -305,6 +305,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_EN.json
+++ b/Translations/translation_EN.json
@@ -305,6 +305,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_ES.json
+++ b/Translations/translation_ES.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_FI.json
+++ b/Translations/translation_FI.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_FR.json
+++ b/Translations/translation_FR.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_HR.json
+++ b/Translations/translation_HR.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_HU.json
+++ b/Translations/translation_HU.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_IT.json
+++ b/Translations/translation_IT.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_LT.json
+++ b/Translations/translation_LT.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_NL.json
+++ b/Translations/translation_NL.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_NL_BE.json
+++ b/Translations/translation_NL_BE.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_NO.json
+++ b/Translations/translation_NO.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_PL.json
+++ b/Translations/translation_PL.json
@@ -305,6 +305,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Czas między",
+				"imp. mocy"
+			],
+			"desc": "Czas między kolejnymi impulsami mocy zapobiegającymi usypianiu powerbanku (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Długość",
+				"impulsu mocy"
+			],
+			"desc": "Długość impulsu mocy zapobiegającego usypianiu powerbanku (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_PT.json
+++ b/Translations/translation_PT.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_RU.json
+++ b/Translations/translation_RU.json
@@ -304,6 +304,20 @@
 				"анимации"
 			],
 			"desc": "Скорость анимации иконок в главном меню <Милисекунды> <О=Отключено, Н=Низкий, С=Средний, В=Высокий>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_SK.json
+++ b/Translations/translation_SK.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_SL.json
+++ b/Translations/translation_SL.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_SR_CYRL.json
+++ b/Translations/translation_SR_CYRL.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_SR_LATN.json
+++ b/Translations/translation_SR_LATN.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_SV.json
+++ b/Translations/translation_SV.json
@@ -304,6 +304,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_TR.json
+++ b/Translations/translation_TR.json
@@ -322,6 +322,20 @@
 				"speed"
 			],
 			"desc": "Speed of icon animations in menu <O=off | L=low | M=medium | H=high>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_UK.json
+++ b/Translations/translation_UK.json
@@ -304,6 +304,20 @@
 				"анімації"
 			],
 			"desc": "Швидкість анімації іконок у головному меню <Мілісекунди> <В=Вимк, Н=Низькa, С=Середня, М=Макс>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_YUE_HK.json
+++ b/Translations/translation_YUE_HK.json
@@ -311,14 +311,14 @@
 				"Power pulse",
 				"wait time"
 			],
-			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+			"desc": "Time to wait beFore triggering everY power pulse <in 2.5s>"
 		},
 		"PowerPulseDuration": {
 			"text2": [
 				"Power pulse",
 				"duration"
 			],
-			"desc": "Keep-awake-pulse duration (x 250ms)"
+			"desc": "power pulse duration <in 250ms>"
 		}
 	}
 }

--- a/Translations/translation_YUE_HK.json
+++ b/Translations/translation_YUE_HK.json
@@ -305,6 +305,20 @@
 				"動畫速度"
 			],
 			"desc": "功能表圖示動畫嘅速度 <關=不顯示動畫 | 慢=慢速 | 中=中速 | 快=快速>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_ZH_TW.json
+++ b/Translations/translation_ZH_TW.json
@@ -305,6 +305,20 @@
 				"動畫速度"
 			],
 			"desc": "功能表圖示動畫的速度 <關=不顯示動畫 | 慢=慢速 | 中=中速 | 快=快速>"
+		},
+		"PowerPulseWait": {
+			"text2": [
+				"Power pulse",
+				"wait time"
+			],
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+		},
+		"PowerPulseDuration": {
+			"text2": [
+				"Power pulse",
+				"duration"
+			],
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		}
 	}
 }

--- a/Translations/translation_ZH_TW.json
+++ b/Translations/translation_ZH_TW.json
@@ -311,14 +311,14 @@
 				"Power pulse",
 				"wait time"
 			],
-			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+			"desc": "Time to wait beFore triggering every keep-awake pulse <x 2.5s>"
 		},
 		"PowerPulseDuration": {
 			"text2": [
 				"Power pulse",
 				"duration"
 			],
-			"desc": "Keep-awake-pulse duration (x 250ms)"
+			"desc": "Keep-awake-pulse duration <x 250ms>"
 		}
 	}
 }

--- a/Translations/translations_def.js
+++ b/Translations/translations_def.js
@@ -376,6 +376,16 @@ var def =
 			"id": "AnimSpeed",
 			"maxLen": 6,
 			"maxLen2": 13
+		},
+		{
+			"id": "PowerPulseWait",
+			"maxLen": 6,
+			"maxLen2": 13
+		},
+		{
+			"id": "PowerPulseDuration",
+			"maxLen": 6,
+			"maxLen2": 13
 		}
 	]
 }

--- a/source/Core/Inc/Settings.h
+++ b/source/Core/Inc/Settings.h
@@ -10,7 +10,7 @@
 #ifndef SETTINGS_H_
 #define SETTINGS_H_
 #include <stdint.h>
-#define SETTINGSVERSION (0x28)
+#define SETTINGSVERSION (0x29)
 /*Change this if you change the struct below to prevent people getting \
           out of sync*/
 
@@ -43,6 +43,8 @@ typedef struct {
   uint8_t descriptionScrollSpeed : 1; // Description scroll speed
   uint8_t lockingMode : 2;            // Store the locking mode
   uint8_t KeepAwakePulse;             // Keep Awake pulse power in 0.1 watts (10 = 1Watt)
+  uint8_t KeepAwakePulseWait;         // Time between Keep Awake pulses in 2500 ms = 2.5 s increments
+  uint8_t KeepAwakePulseDuration;     // Duration of the Keep Awake pusle in 250 ms increments
 
   uint16_t voltageDiv;        // Voltage divisor factor
   uint16_t BoostTemp;         // Boost mode set point for the iron

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -12,8 +12,8 @@ extern const uint8_t USER_FONT_12[];
 extern const uint8_t USER_FONT_6x8[];
 extern const bool    HasFahrenheit;
 
-extern const char *SettingsShortNames[31][2];
-extern const char *SettingsDescriptions[31];
+extern const char *SettingsShortNames[33][2];
+extern const char *SettingsDescriptions[33];
 extern const char *SettingsMenuEntries[5];
 
 extern const char *SettingsCalibrationDone;

--- a/source/Core/Src/Settings.cpp
+++ b/source/Core/Src/Settings.cpp
@@ -77,7 +77,9 @@ void resetSettings() {
   systemSettings.ReverseButtonTempChangeEnabled = REVERSE_BUTTON_TEMP_CHANGE; //
   systemSettings.TempChangeShortStep            = TEMP_CHANGE_SHORT_STEP;     //
   systemSettings.TempChangeLongStep             = TEMP_CHANGE_LONG_STEP;      //
-  systemSettings.KeepAwakePulse                 = POWER_PULSE_DEFAULT;
+  systemSettings.KeepAwakePulse                 = POWER_PULSE_DEFAULT;          // Power of the power pulse
+  systemSettings.KeepAwakePulseWait             = POWER_PULSE_WAIT_DEFAULT;     // Time between Keep Awake pulses in 2.5 second increments
+  systemSettings.KeepAwakePulseDuration         = POWER_PULSE_DURATION_DEFAULT; // Duration of the Keep Awake pusle in 250ms increments
   systemSettings.hallEffectSensitivity          = 1;
   systemSettings.accelMissingWarningCounter     = 0;
   systemSettings.pdMissingWarningCounter        = 0;

--- a/source/Core/Src/gui.cpp
+++ b/source/Core/Src/gui.cpp
@@ -74,6 +74,10 @@ static void settings_displayAnimationSpeed(void);
 static bool settings_setAnimationSpeed(void);
 static void settings_displayAnimationLoop(void);
 static bool settings_setAnimationLoop(void);
+static void settings_displayPowerPulseWait(void);
+static bool settings_setPowerPulseWait(void);
+static void settings_displayPowerPulseDuration(void);
+static bool settings_setPowerPulseDuration(void);
 #ifdef HALL_SENSOR
 static void settings_displayHallEffect(void);
 static bool settings_setHallEffect(void);
@@ -221,6 +225,8 @@ const menuitem advancedMenu[] = {
      *  Power Pulse
      *  Animation Loop
      *  Animation Speed
+     *  Power Pulse Wait
+     *  Power Pulse Duration
      */
     {(const char *)SettingsDescriptions[20], settings_setPowerLimit, settings_displayPowerLimit},                             /*Power limit*/
     {(const char *)SettingsDescriptions[6], settings_setAdvancedIDLEScreens, settings_displayAdvancedIDLEScreens},            /* Advanced idle screen*/
@@ -229,6 +235,8 @@ const menuitem advancedMenu[] = {
     {(const char *)SettingsDescriptions[11], settings_setCalibrate, settings_displayCalibrate},                               /*Calibrate tip*/
     {(const char *)SettingsDescriptions[13], settings_setCalibrateVIN, settings_displayCalibrateVIN},                         /*Voltage input cal*/
     {(const char *)SettingsDescriptions[24], settings_setPowerPulse, settings_displayPowerPulse},                             /*Power Pulse adjustment */
+    {(const char *)SettingsDescriptions[31], settings_setPowerPulseWait, settings_displayPowerPulseWait},                     /*Power Pulse Wait adjustment*/
+    {(const char *)SettingsDescriptions[32], settings_setPowerPulseDuration, settings_displayPowerPulseDuration},             /*Power Pulse Duration adjustment*/
     //{ (const char *) SettingsDescriptions[25], settings_setTipGain, settings_displayTipGain }, /*TipGain*/
     {NULL, NULL, NULL} // end of menu marker. DO NOT REMOVE
 };
@@ -936,6 +944,45 @@ static void settings_displayAnimationSpeed(void) {
     break;
   }
 }
+
+static bool settings_setPowerPulseWait(void) {
+  // Constrain to range 1 to POWER_PULSE_WAIT_MAX inclusive
+  auto &wait = systemSettings.KeepAwakePulseWait;
+  if (++wait > POWER_PULSE_WAIT_MAX) {
+    wait = 1;
+  }
+
+  return wait == POWER_PULSE_WAIT_MAX;
+}
+
+static void settings_displayPowerPulseWait(void) {
+  printShortDescription(31, 7);
+  if (systemSettings.KeepAwakePulse) {
+    OLED::printNumber(systemSettings.KeepAwakePulseWait, 1);
+  } else {
+    OLED::print(SymbolMinus);
+  }
+}
+
+static bool settings_setPowerPulseDuration(void) {
+  // Constrain to range 1 to POWER_PULSE_DURATION_MAX inclusive
+  auto &duration = systemSettings.KeepAwakePulseDuration;
+  if (++duration > POWER_PULSE_DURATION_MAX) {
+    duration = 1;
+  }
+
+  return duration == POWER_PULSE_DURATION_MAX;
+}
+
+static void settings_displayPowerPulseDuration(void) {
+  printShortDescription(32, 7);
+  if (systemSettings.KeepAwakePulse) {
+    OLED::printNumber(systemSettings.KeepAwakePulseDuration, 1);
+  } else {
+    OLED::print(SymbolMinus);
+  }
+}
+
 #ifdef HALL_SENSOR
 static void settings_displayHallEffect(void) {
   printShortDescription(26, 7);

--- a/source/configuration.h
+++ b/source/configuration.h
@@ -68,14 +68,18 @@
 #define TEMP_CHANGE_LONG_STEP_MAX  90 // Temp change long step MAX value
 
 /* Power pulse for keeping power banks awake*/
-#define POWER_PULSE_INCREMENT 1
-#define POWER_PULSE_MAX       50 // x10 max watts
-#define POWER_PULSE_MAX       100 // x10 max watts
+#define POWER_PULSE_INCREMENT       1
+#define POWER_PULSE_MAX           100 // x10 max watts
+#define POWER_PULSE_WAIT_MAX        9 // 9*2.5s = 22.5 seconds
+#define POWER_PULSE_DURATION_MAX    9 // 9*250ms = 2.25 seconds
+
 #ifdef MODEL_TS100
 #define POWER_PULSE_DEFAULT 0
 #else
 #define POWER_PULSE_DEFAULT 5
 #endif
+#define POWER_PULSE_WAIT_DEFAULT      4; // Default rate of the power pulse: 4*2500 = 10000 ms = 10 s
+#define POWER_PULSE_DURATION_DEFAULT  1; // Default duration of the power pulse: 1*250 = 250 ms
 
 /**
  * OLED Orientation Sensitivity on Automatic mode!

--- a/source/configuration.h
+++ b/source/configuration.h
@@ -70,6 +70,7 @@
 /* Power pulse for keeping power banks awake*/
 #define POWER_PULSE_INCREMENT 1
 #define POWER_PULSE_MAX       50 // x10 max watts
+#define POWER_PULSE_MAX       100 // x10 max watts
 #ifdef MODEL_TS100
 #define POWER_PULSE_DEFAULT 0
 #else


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Feature: add menu items to adjust the time between Power Pulses and the duration of the Power Pulse (to keep a power-bank from sleeping).
Change: Increase `POWER_PULSE_MAX` to `100`. This allows setting maximum Power Pulse to 9.9W. It still needs 2 digits and a dot to display the value, so nothing changes in the GUI.

* **What is the current behavior?**
Fixed values:
```
static TickType_t powerPulseRate        = 10000;
static TickType_t powerPulseDuration    = 250;
```

* **What is the new behavior (if this is a feature change)?**
Those values are now user-adjustable, using the Advanced menu.

* **Other information**:

I have two power-banks supporting QC3.0:
 - [UTRAI Jstar One 22000mAh](https://www.utrai.com/products/jstar-one) - in QC 12V mode delivers over 24W of power, but has a ~10 seconds time-out!
 - Vinsic Terminator P3 20000mAh VSPB303 - in QC 9V mode delivers ~15W of power, ~30s timeout

The most problematic situation is the cool-down time after boosting the temperature of a tip. The power consumption decreases to 0W until the tip cools down. The "Power Pulse" option with hard-coded settings didn't prevent those devices from sleeping:
 - Vinsic required `0.7W` pulse for `1750` ticks every `20000` ticks to keep awake. Shorter pulses didn't prevent this power-bank from sleeping.
 - UTRAI  was happy with `7.0W` pulse for `250` ticks every `7500` ticks (`10000` wasn't frequent enough).

I have added two options to the `Advanced` menu "Power pulse wait time" and "Power pulse duration" so that the user can change those values without re-compiling the code and re-flashing the device.

Merging this PR has a strong chance to increase the number of supported power-banks. especially those marked with `30sec t/o`. It might be a good idea to extend the power-sources table with a recommended `Pulse Power`, `Rate` and `Duration` settings to avoid time-out.

I've also added Polish translation for the new strings.