### PR TITLE
Fix: no hold time on the last value when incrementing

### DIFF
--- a/source/Core/Src/gui.cpp
+++ b/source/Core/Src/gui.cpp
@@ -1149,7 +1149,7 @@ void gui_Menu(const menuitem *menu) {
         descriptionStart = 0;
       break;
     case BUTTON_F_LONG:
-      if ((xTaskGetTickCount() - autoRepeatTimer + autoRepeatAcceleration) > PRESS_ACCEL_INTERVAL_MAX) {
+      if (xTaskGetTickCount() + autoRepeatAcceleration > autoRepeatTimer + PRESS_ACCEL_INTERVAL_MAX) {
         if ((lastValue = menu[currentScreen].incrementHandler()))
           autoRepeatTimer = 1000;
         else


### PR DESCRIPTION
Please try and fill out this template where possible, not all fields are required and can be removed.

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What is the current behavior?**
Regression: No hold time on the last value when incrementing an option

* **What is the new behavior (if this is a feature change)?**
Fixes https://github.com/Ralim/IronOS/issues/881
