### PR TITLE
Fix: misaligned options in animation speed

### DIFF
--- a/source/Core/Src/gui.cpp
+++ b/source/Core/Src/gui.cpp
@@ -920,7 +920,8 @@ static bool settings_setAnimationSpeed(void) {
 }
 
 static void settings_displayAnimationSpeed(void) {
-  printShortDescription(30, 5);
+  const bool isAnimationOff = systemSettings.animationSpeed==settingOffSpeed_t::OFF;
+  printShortDescription(30, isAnimationOff?5:7);
   switch (systemSettings.animationSpeed) {
   case settingOffSpeed_t::SLOW:
     OLED::print(SettingSlowChar);


### PR DESCRIPTION
When the option is OFF, we need a space for 3 characters from
the right (spacing of 5). For other options we need only one
character (spacing of 7).

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Fixes: https://github.com/Ralim/IronOS/issues/881



* **What is the current behavior?**
```
[Anim      Off]
 speed

[Anim      S  ]
 speed

[Anim      M  ]
 speed

[Anim      F  ]
 speed
```

* **What is the new behavior (if this is a feature change)?**
```
[Anim      Off]
 speed

[Anim        S]
 speed

[Anim        M]
 speed

[Anim        F]
 speed
```
