### PR TITLE
In detailed soldering view add '+' for boost

### DIFF
--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -547,7 +547,13 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
       OLED::setCursor(0, 8);
       OLED::print(SleepingTipAdvancedString);
       gui_drawTipTemp(true);
-      OLED::print(SymbolSpace);
+
+      if (boostModeOn) {
+        OLED::print(SymbolPlus);
+      } else {
+        OLED::print(SymbolSpace);
+      }
+
       printVoltage();
       OLED::print(SymbolVolts);
     } else {


### PR DESCRIPTION
In detailed soldering view add '+' symbol after the temperature to indicate active boost mode (when active)

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Feature

* **What is the current behavior?**
No indication of boost mode in detailed soldering view

* **What is the new behavior (if this is a feature change)?**
Indication added as a '+' character displayed after the tip temperature.

* **Other information**:
I've used existing glyph. '+' made the most sense.
Maybe we want to introduce smaller version of symbol 2 (up arrow) to be consistent with the normal view?
On the other hand - the detailed view is not used very often, so maybe "+" will suffice?