### PR TITLE
Refactor font style to be set when printing

### DIFF
--- a/source/Core/Drivers/OLED.hpp
+++ b/source/Core/Drivers/OLED.hpp
@@ -26,6 +26,12 @@ extern "C" {
 #define OLED_HEIGHT       16
 #define FRAMEBUFFER_START 17
 
+enum class FontStyle {
+  SMALL,
+  LARGE,
+  EXTRAS,
+};
+
 class OLED {
 public:
   enum DisplayState : bool { OFF = false, ON = true };
@@ -48,30 +54,23 @@ public:
   // Get the current rotation of the LCD
   static bool    getRotation() { return inLeftHandedMode; }
   static int16_t getCursorX() { return cursor_x; }
-  static void    print(const char *string); // Draw a string to the current location, with current font
+  static void    print(const char *string, FontStyle fontStyle); // Draw a string to the current location, with selected font
   // Set the cursor location by pixels
   static void setCursor(int16_t x, int16_t y) {
     cursor_x = x;
     cursor_y = y;
   }
-  // Set cursor location by chars in current font
-  static void setCharCursor(int16_t x, int16_t y) {
-    cursor_x = x * fontWidth;
-    cursor_y = y * fontHeight;
-  }
-  static void    setFont(uint8_t fontNumber); // (Future) Set the font that is being used
-  static uint8_t getFont();
-  static void    drawImage(const uint8_t *buffer, uint8_t x, uint8_t width) { drawArea(x, 0, width, 16, buffer); }
   // Draws an image to the buffer, at x offset from top to bottom (fixed height renders)
-  static void printNumber(uint16_t number, uint8_t places, bool noLeaderZeros = true);
+  static void drawImage(const uint8_t *buffer, uint8_t x, uint8_t width) { drawArea(x, 0, width, 16, buffer); }
   // Draws a number at the current cursor location
+  static void printNumber(uint16_t number, uint8_t places, FontStyle fontStyle, bool noLeaderZeros = true);
   // Clears the buffer
   static void clearScreen() { memset(firstStripPtr, 0, OLED_WIDTH * 2); }
   // Draws the battery level symbol
   static void drawBattery(uint8_t state) { drawSymbol(3 + (state > 10 ? 10 : state)); }
   // Draws a checkbox
   static void drawCheckbox(bool state) { drawSymbol((state) ? 16 : 17); }
-  static void debugNumber(int32_t val);
+  static void debugNumber(int32_t val, FontStyle fontStyle);
   static void drawSymbol(uint8_t symbolID);                                                           // Used for drawing symbols of a predictable width
   static void drawArea(int16_t x, int8_t y, uint8_t wide, uint8_t height, const uint8_t *ptr);        // Draw an area, but y must be aligned on 0/8 offset
   static void drawAreaSwapped(int16_t x, int8_t y, uint8_t wide, uint8_t height, const uint8_t *ptr); // Draw an area, but y must be aligned on 0/8 offset
@@ -83,19 +82,17 @@ public:
   static void useSecondaryFramebuffer(bool useSecondary);
 
 private:
-  static void           drawChar(const uint16_t charCode); // Draw a character to the current cursor location
-  static void           setFramebuffer(uint8_t *buffer);
-  static const uint8_t *currentFont;      // Pointer to the current font used for rendering to the buffer
-  static uint8_t *      firstStripPtr;    // Pointers to the strips to allow for buffer having extra content
-  static uint8_t *      secondStripPtr;   // Pointers to the strips
-  static bool           inLeftHandedMode; // Whether the screen is in left or not (used for offsets in GRAM)
-  static bool           initDone;
-  static DisplayState   displayState;
-  static uint8_t        fontWidth, fontHeight;
-  static int16_t        cursor_x, cursor_y;
-  static uint8_t        displayOffset;
-  static uint8_t        screenBuffer[16 + (OLED_WIDTH * 2) + 10]; // The data buffer
-  static uint8_t        secondFrameBuffer[OLED_WIDTH * 2];
+  static void         drawChar(uint16_t charCode, FontStyle fontStyle); // Draw a character to the current cursor location
+  static void         setFramebuffer(uint8_t *buffer);
+  static uint8_t *    firstStripPtr;    // Pointers to the strips to allow for buffer having extra content
+  static uint8_t *    secondStripPtr;   // Pointers to the strips
+  static bool         inLeftHandedMode; // Whether the screen is in left or not (used for offsets in GRAM)
+  static bool         initDone;
+  static DisplayState displayState;
+  static int16_t      cursor_x, cursor_y;
+  static uint8_t      displayOffset;
+  static uint8_t      screenBuffer[16 + (OLED_WIDTH * 2) + 10]; // The data buffer
+  static uint8_t      secondFrameBuffer[OLED_WIDTH * 2];
 };
 
 #endif /* OLED_HPP_ */

--- a/source/Core/Src/gui.cpp
+++ b/source/Core/Src/gui.cpp
@@ -243,15 +243,13 @@ const menuitem advancedMenu[] = {
 static void printShortDescriptionDoubleLine(uint32_t shortDescIndex) {
   if (SettingsShortNames[shortDescIndex][0][0] == '\x00') {
     // Empty first line means that this uses large font (for CJK).
-    OLED::setFont(0);
-    OLED::setCharCursor(0, 0);
-    OLED::print(SettingsShortNames[shortDescIndex][1]);
+    OLED::setCursor(0, 0);
+    OLED::print(SettingsShortNames[shortDescIndex][1], FontStyle::LARGE);
   } else {
-    OLED::setFont(1);
-    OLED::setCharCursor(0, 0);
-    OLED::print(SettingsShortNames[shortDescIndex][0]);
-    OLED::setCharCursor(0, 1);
-    OLED::print(SettingsShortNames[shortDescIndex][1]);
+    OLED::setCursor(0, 0);
+    OLED::print(SettingsShortNames[shortDescIndex][0], FontStyle::SMALL);
+    OLED::setCursor(0, 8);
+    OLED::print(SettingsShortNames[shortDescIndex][1], FontStyle::SMALL);
   }
 }
 
@@ -267,10 +265,8 @@ static void printShortDescription(uint32_t shortDescIndex, uint16_t cursorCharPo
   printShortDescriptionDoubleLine(shortDescIndex);
 
   // prepare cursor for value
-  OLED::setFont(0);
-  OLED::setCharCursor(cursorCharPosition, 0);
   // make room for scroll indicator
-  OLED::setCursor(OLED::getCursorX() - 2, 0);
+  OLED::setCursor(cursorCharPosition * FONT_12_WIDTH - 2, 0);
 }
 
 /**
@@ -302,7 +298,6 @@ static int userConfirmation(const char *message) {
   uint16_t messageWidth = FONT_12_WIDTH * (str_display_len(message) + 7);
   uint32_t messageStart = xTaskGetTickCount();
 
-  OLED::setFont(0);
   OLED::setCursor(0, 0);
   int16_t lastOffset = -1;
   bool    lcdRefresh = true;
@@ -316,7 +311,7 @@ static int userConfirmation(const char *message) {
 
       //^ Rolling offset based on time
       OLED::setCursor((OLED_WIDTH - messageOffset), 0);
-      OLED::print(message);
+      OLED::print(message, FontStyle::LARGE);
       lastOffset = messageOffset;
       lcdRefresh = true;
     }
@@ -357,10 +352,10 @@ static bool settings_displayInputVRange(void) {
   printShortDescription(0, 6);
 
   if (systemSettings.minDCVoltageCells) {
-    OLED::printNumber(2 + systemSettings.minDCVoltageCells, 1);
-    OLED::print(SymbolCellCount);
+    OLED::printNumber(2 + systemSettings.minDCVoltageCells, 1, FontStyle::LARGE);
+    OLED::print(SymbolCellCount, FontStyle::LARGE);
   } else {
-    OLED::print(SymbolDC);
+    OLED::print(SymbolDC, FontStyle::LARGE);
   }
   return false;
 }
@@ -377,12 +372,12 @@ static bool settings_setInputMinVRange(void) {
 static bool settings_displayInputMinVRange(void) {
   if (systemSettings.minDCVoltageCells) {
     printShortDescription(28, 4);
-    OLED::printNumber(systemSettings.minVoltageCells / 10, 2);
-    OLED::print(SymbolDot);
-    OLED::printNumber(systemSettings.minVoltageCells % 10, 1);
+    OLED::printNumber(systemSettings.minVoltageCells / 10, 2, FontStyle::LARGE);
+    OLED::print(SymbolDot, FontStyle::LARGE);
+    OLED::printNumber(systemSettings.minVoltageCells % 10, 1, FontStyle::LARGE);
   } else {
     printShortDescription(28, 5);
-    OLED::print(SettingNAChar);
+    OLED::print(SettingNAChar, FontStyle::LARGE);
   }
   return false;
 }
@@ -404,16 +399,16 @@ static bool settings_displayQCInputV(void) {
   // These are only used in QC modes
   switch (systemSettings.QCIdealVoltage) {
   case 0:
-    OLED::printNumber(9, 2);
-    OLED::print(SymbolVolts);
+    OLED::printNumber(9, 2, FontStyle::LARGE);
+    OLED::print(SymbolVolts, FontStyle::LARGE);
     break;
   case 1:
-    OLED::printNumber(12, 2);
-    OLED::print(SymbolVolts);
+    OLED::printNumber(12, 2, FontStyle::LARGE);
+    OLED::print(SymbolVolts, FontStyle::LARGE);
     break;
   case 2:
-    OLED::printNumber(20, 2);
-    OLED::print(SymbolVolts);
+    OLED::printNumber(20, 2, FontStyle::LARGE);
+    OLED::print(SymbolVolts, FontStyle::LARGE);
     break;
   default:
     break;
@@ -439,7 +434,7 @@ static bool settings_setSleepTemp(void) {
 
 static bool settings_displaySleepTemp(void) {
   printShortDescription(1, 5);
-  OLED::printNumber(systemSettings.SleepTemp, 3);
+  OLED::printNumber(systemSettings.SleepTemp, 3, FontStyle::LARGE);
   return false;
 }
 
@@ -457,13 +452,13 @@ static bool settings_setSleepTime(void) {
 static bool settings_displaySleepTime(void) {
   printShortDescription(2, 5);
   if (systemSettings.SleepTime == 0) {
-    OLED::print(OffString);
+    OLED::print(OffString, FontStyle::LARGE);
   } else if (systemSettings.SleepTime < 6) {
-    OLED::printNumber(systemSettings.SleepTime * 10, 2);
-    OLED::print(SymbolSeconds);
+    OLED::printNumber(systemSettings.SleepTime * 10, 2, FontStyle::LARGE);
+    OLED::print(SymbolSeconds, FontStyle::LARGE);
   } else {
-    OLED::printNumber(systemSettings.SleepTime - 5, 2);
-    OLED::print(SymbolMinutes);
+    OLED::printNumber(systemSettings.SleepTime - 5, 2, FontStyle::LARGE);
+    OLED::print(SymbolMinutes, FontStyle::LARGE);
   }
   return false;
 }
@@ -481,10 +476,10 @@ static bool settings_setShutdownTime(void) {
 static bool settings_displayShutdownTime(void) {
   printShortDescription(3, 5);
   if (systemSettings.ShutdownTime == 0) {
-    OLED::print(OffString);
+    OLED::print(OffString, FontStyle::LARGE);
   } else {
-    OLED::printNumber(systemSettings.ShutdownTime, 2);
-    OLED::print(SymbolMinutes);
+    OLED::printNumber(systemSettings.ShutdownTime, 2, FontStyle::LARGE);
+    OLED::print(SymbolMinutes, FontStyle::LARGE);
   }
   return false;
 }
@@ -516,7 +511,7 @@ static bool settings_setTempF(void) {
 static bool settings_displayTempF(void) {
   printShortDescription(5, 7);
 
-  OLED::print((systemSettings.temperatureInF) ? SymbolDegF : SymbolDegC);
+  OLED::print((systemSettings.temperatureInF) ? SymbolDegF : SymbolDegC, FontStyle::LARGE);
   return false;
 }
 
@@ -528,7 +523,7 @@ static bool settings_setSensitivity(void) {
 
 static bool settings_displaySensitivity(void) {
   printShortDescription(4, 7);
-  OLED::printNumber(systemSettings.sensitivity, 1, false);
+  OLED::printNumber(systemSettings.sensitivity, 1, FontStyle::LARGE, false);
   return false;
 }
 
@@ -566,10 +561,10 @@ static bool settings_setPowerLimit(void) {
 static bool settings_displayPowerLimit(void) {
   printShortDescription(20, 5);
   if (systemSettings.powerLimit == 0) {
-    OLED::print(OffString);
+    OLED::print(OffString, FontStyle::LARGE);
   } else {
-    OLED::printNumber(systemSettings.powerLimit, 2);
-    OLED::print(SymbolWatts);
+    OLED::printNumber(systemSettings.powerLimit, 2, FontStyle::LARGE);
+    OLED::print(SymbolWatts, FontStyle::LARGE);
   }
   return false;
 }
@@ -584,7 +579,7 @@ static bool settings_setScrollSpeed(void) {
 
 static bool settings_displayScrollSpeed(void) {
   printShortDescription(15, 7);
-  OLED::print((systemSettings.descriptionScrollSpeed) ? SettingFastChar : SettingSlowChar);
+  OLED::print((systemSettings.descriptionScrollSpeed) ? SettingFastChar : SettingSlowChar, FontStyle::LARGE);
   return false;
 }
 
@@ -612,16 +607,16 @@ static bool settings_displayDisplayRotation(void) {
 
   switch (systemSettings.OrientationMode) {
   case 0:
-    OLED::print(SettingRightChar);
+    OLED::print(SettingRightChar, FontStyle::LARGE);
     break;
   case 1:
-    OLED::print(SettingLeftChar);
+    OLED::print(SettingLeftChar, FontStyle::LARGE);
     break;
   case 2:
-    OLED::print(SettingAutoChar);
+    OLED::print(SettingAutoChar, FontStyle::LARGE);
     break;
   default:
-    OLED::print(SettingRightChar);
+    OLED::print(SettingRightChar, FontStyle::LARGE);
     break;
   }
   return false;
@@ -655,9 +650,9 @@ static bool settings_setBoostTemp(void) {
 static bool settings_displayBoostTemp(void) {
   printShortDescription(8, 5);
   if (systemSettings.BoostTemp) {
-    OLED::printNumber(systemSettings.BoostTemp, 3);
+    OLED::printNumber(systemSettings.BoostTemp, 3, FontStyle::LARGE);
   } else {
-    OLED::print(OffString);
+    OLED::print(OffString, FontStyle::LARGE);
   }
   return false;
 }
@@ -673,19 +668,19 @@ static bool settings_displayAutomaticStartMode(void) {
 
   switch (systemSettings.autoStartMode) {
   case 0:
-    OLED::print(SettingStartNoneChar);
+    OLED::print(SettingStartNoneChar, FontStyle::LARGE);
     break;
   case 1:
-    OLED::print(SettingStartSolderingChar);
+    OLED::print(SettingStartSolderingChar, FontStyle::LARGE);
     break;
   case 2:
-    OLED::print(SettingStartSleepChar);
+    OLED::print(SettingStartSleepChar, FontStyle::LARGE);
     break;
   case 3:
-    OLED::print(SettingStartSleepOffChar);
+    OLED::print(SettingStartSleepOffChar, FontStyle::LARGE);
     break;
   default:
-    OLED::print(SettingStartNoneChar);
+    OLED::print(SettingStartNoneChar, FontStyle::LARGE);
     break;
   }
   return false;
@@ -702,16 +697,16 @@ static bool settings_displayLockingMode(void) {
 
   switch (systemSettings.lockingMode) {
   case 0:
-    OLED::print(SettingLockDisableChar);
+    OLED::print(SettingLockDisableChar, FontStyle::LARGE);
     break;
   case 1:
-    OLED::print(SettingLockBoostChar);
+    OLED::print(SettingLockBoostChar, FontStyle::LARGE);
     break;
   case 2:
-    OLED::print(SettingLockFullChar);
+    OLED::print(SettingLockFullChar, FontStyle::LARGE);
     break;
   default:
-    OLED::print(SettingLockDisableChar);
+    OLED::print(SettingLockDisableChar, FontStyle::LARGE);
     break;
   }
   return false;
@@ -732,10 +727,9 @@ static bool settings_setResetSettings(void) {
   if (userConfirmation(SettingsResetWarning)) {
     resetSettings();
 
-    OLED::setFont(0);
     OLED::clearScreen();
     OLED::setCursor(0, 0);
-    OLED::print(ResetOKMessage);
+    OLED::print(ResetOKMessage, FontStyle::LARGE);
     OLED::refresh();
 
     waitForButtonPressOrTimeout(2000); // 2 second timeout
@@ -761,9 +755,9 @@ static void setTipOffset() {
       // cycle through the filter a fair bit to ensure we're stable.
       OLED::clearScreen();
       OLED::setCursor(0, 0);
-      OLED::print(SymbolDot);
+      OLED::print(SymbolDot, FontStyle::LARGE);
       for (uint8_t x = 0; x < (i / 4); x++)
-        OLED::print(SymbolDot);
+        OLED::print(SymbolDot, FontStyle::LARGE);
       OLED::refresh();
       osDelay(100);
     }
@@ -772,7 +766,7 @@ static void setTipOffset() {
   OLED::clearScreen();
   OLED::setCursor(0, 0);
   OLED::drawCheckbox(true);
-  OLED::printNumber(systemSettings.CalibrationOffset, 4);
+  OLED::printNumber(systemSettings.CalibrationOffset, 4, FontStyle::LARGE);
   OLED::refresh();
   osDelay(1200);
 }
@@ -796,15 +790,14 @@ static bool settings_displayCalibrate(void) {
 
 static bool settings_setCalibrateVIN(void) {
   // Jump to the voltage calibration subscreen
-  OLED::setFont(0);
   OLED::clearScreen();
 
   for (;;) {
     OLED::setCursor(0, 0);
-    OLED::printNumber(getInputVoltageX10(systemSettings.voltageDiv, 0) / 10, 2);
-    OLED::print(SymbolDot);
-    OLED::printNumber(getInputVoltageX10(systemSettings.voltageDiv, 0) % 10, 1, false);
-    OLED::print(SymbolVolts);
+    OLED::printNumber(getInputVoltageX10(systemSettings.voltageDiv, 0) / 10, 2, FontStyle::LARGE);
+    OLED::print(SymbolDot, FontStyle::LARGE);
+    OLED::printNumber(getInputVoltageX10(systemSettings.voltageDiv, 0) % 10, 1, FontStyle::LARGE, false);
+    OLED::print(SymbolVolts, FontStyle::LARGE);
 
     ButtonState buttons = getButtonState();
     switch (buttons) {
@@ -821,7 +814,7 @@ static bool settings_setCalibrateVIN(void) {
     case BUTTON_B_LONG:
       saveSettings();
       OLED::setCursor(0, 0);
-      OLED::printNumber(systemSettings.voltageDiv, 3);
+      OLED::printNumber(systemSettings.voltageDiv, 3, FontStyle::LARGE);
       OLED::refresh();
       waitForButtonPressOrTimeout(1000);
       return false;
@@ -872,7 +865,7 @@ static bool settings_setTempChangeShortStep(void) {
 
 static bool settings_displayTempChangeShortStep(void) {
   printShortDescription(22, 6);
-  OLED::printNumber(systemSettings.TempChangeShortStep, 2);
+  OLED::printNumber(systemSettings.TempChangeShortStep, 2, FontStyle::LARGE);
   return false;
 }
 
@@ -892,7 +885,7 @@ static bool settings_setTempChangeLongStep(void) {
 
 static bool settings_displayTempChangeLongStep(void) {
   printShortDescription(23, 6);
-  OLED::printNumber(systemSettings.TempChangeLongStep, 2);
+  OLED::printNumber(systemSettings.TempChangeLongStep, 2, FontStyle::LARGE);
   return false;
 }
 
@@ -905,11 +898,11 @@ static bool settings_setPowerPulse(void) {
 static bool settings_displayPowerPulse(void) {
   printShortDescription(24, 5);
   if (systemSettings.KeepAwakePulse) {
-    OLED::printNumber(systemSettings.KeepAwakePulse / 10, 1);
-    OLED::print(SymbolDot);
-    OLED::printNumber(systemSettings.KeepAwakePulse % 10, 1);
+    OLED::printNumber(systemSettings.KeepAwakePulse / 10, 1, FontStyle::LARGE);
+    OLED::print(SymbolDot, FontStyle::LARGE);
+    OLED::printNumber(systemSettings.KeepAwakePulse % 10, 1, FontStyle::LARGE);
   } else {
-    OLED::print(OffString);
+    OLED::print(OffString, FontStyle::LARGE);
   }
   return false;
 }
@@ -935,16 +928,16 @@ static bool settings_displayAnimationSpeed(void) {
   printShortDescription(30, 7);
   switch (systemSettings.animationSpeed) {
   case settingOffSpeed_t::SLOW:
-    OLED::print(SettingSlowChar);
+    OLED::print(SettingSlowChar, FontStyle::LARGE);
     break;
   case settingOffSpeed_t::MEDIUM:
-    OLED::print(SettingMediumChar);
+    OLED::print(SettingMediumChar, FontStyle::LARGE);
     break;
   case settingOffSpeed_t::FAST:
-    OLED::print(SettingFastChar);
+    OLED::print(SettingFastChar, FontStyle::LARGE);
     break;
   default:
-    OLED::print(SettingOffChar);
+    OLED::print(SettingOffChar, FontStyle::LARGE);
     break;
   }
   return false;
@@ -963,7 +956,7 @@ static bool settings_setPowerPulseWait(void) {
 static bool settings_displayPowerPulseWait(void) {
   if (systemSettings.KeepAwakePulse) {
     printShortDescription(31, 7);
-    OLED::printNumber(systemSettings.KeepAwakePulseWait, 1);
+    OLED::printNumber(systemSettings.KeepAwakePulseWait, 1, FontStyle::LARGE);
     return false;
   } else {
     return true; // skip
@@ -983,7 +976,7 @@ static bool settings_setPowerPulseDuration(void) {
 static bool settings_displayPowerPulseDuration(void) {
   if (systemSettings.KeepAwakePulse) {
     printShortDescription(32, 7);
-    OLED::printNumber(systemSettings.KeepAwakePulseDuration, 1);
+    OLED::printNumber(systemSettings.KeepAwakePulseDuration, 1, FontStyle::LARGE);
     return false;
   } else {
     return true; // skip
@@ -995,17 +988,17 @@ static bool settings_displayHallEffect(void) {
   printShortDescription(26, 7);
   switch (systemSettings.hallEffectSensitivity) {
   case 1:
-    OLED::print(SettingSensitivityLow);
+    OLED::print(SettingSensitivityLow, FontStyle::LARGE);
     break;
   case 2:
-    OLED::print(SettingSensitivityMedium);
+    OLED::print(SettingSensitivityMedium, FontStyle::LARGE);
     break;
   case 3:
-    OLED::print(SettingSensitivityHigh);
+    OLED::print(SettingSensitivityHigh, FontStyle::LARGE);
     break;
   case 0:
   default:
-    OLED::print(SettingSensitivityOff);
+    OLED::print(SettingSensitivityOff, FontStyle::LARGE);
     break;
   }
   return false;
@@ -1024,16 +1017,17 @@ static bool animOpenState = false;
 static void displayMenu(size_t index) {
   // Call into the menu
   const char *textPtr = SettingsMenuEntries[index];
+  FontStyle   font;
   if (textPtr[0] == '\x01') { // `\x01` is used as newline.
     // Empty first line means that this uses large font (for CJK).
-    OLED::setFont(0);
+    font = FontStyle::LARGE;
     textPtr++;
   } else {
-    OLED::setFont(1);
+    font = FontStyle::SMALL;
   }
   OLED::setCursor(0, 0);
   // Draw title
-  OLED::print(textPtr);
+  OLED::print(textPtr, font);
   // Draw symbol
   // 16 pixel wide image
   // 2 pixel wide scrolling indicator
@@ -1135,7 +1129,6 @@ void gui_Menu(const menuitem *menu) {
     // The extra buffer is discarded at the end of the transition.
     animOpenState = true;
     OLED::useSecondaryFramebuffer(true);
-    OLED::setFont(0);
     OLED::setCursor(0, 0);
     OLED::clearScreen();
     menu[currentScreen].draw();
@@ -1145,7 +1138,6 @@ void gui_Menu(const menuitem *menu) {
   }
 
   while ((menu[currentScreen].draw != NULL) && earlyExit == false) {
-    OLED::setFont(0);
     OLED::setCursor(0, 0);
     // If the user has hesitated for >=3 seconds, show the long text
     // Otherwise "draw" the option
@@ -1174,7 +1166,7 @@ void gui_Menu(const menuitem *menu) {
       if (lastOffset != descriptionOffset) {
         OLED::clearScreen();
         OLED::setCursor((OLED_WIDTH - descriptionOffset), 0);
-        OLED::print(menu[currentScreen].description);
+        OLED::print(menu[currentScreen].description, FontStyle::LARGE);
         lastOffset = descriptionOffset;
         lcdRefresh = true;
       }

--- a/source/Core/Src/main.cpp
+++ b/source/Core/Src/main.cpp
@@ -41,7 +41,6 @@ int main(void) {
   preRToSInit();
   setTipX10Watts(0); // force tip off
   resetWatchdog();
-  OLED::setFont(0); // default to bigger font
   // Testing for which accelerometer is mounted
   settingsWereReset = restoreSettings(); // load the settings from flash
   resetWatchdog();

--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -43,20 +43,19 @@ static uint16_t   min(uint16_t a, uint16_t b) {
   else
     return a;
 }
-void warnUser(const char *warning, const int font, const int timeout) {
-  OLED::setFont(font);
+void warnUser(const char *warning, const FontStyle font, const int timeout) {
   OLED::clearScreen();
   OLED::setCursor(0, 0);
-  OLED::print(warning);
+  OLED::print(warning, font);
   OLED::refresh();
   waitForButtonPressOrTimeout(timeout);
 }
 
 void printVoltage() {
   uint32_t volt = getInputVoltageX10(systemSettings.voltageDiv, 0);
-  OLED::printNumber(volt / 10, 2);
-  OLED::print(SymbolDot);
-  OLED::printNumber(volt % 10, 1);
+  OLED::printNumber(volt / 10, 2, FontStyle::SMALL);
+  OLED::print(SymbolDot, FontStyle::SMALL);
+  OLED::printNumber(volt % 10, 1, FontStyle::SMALL);
 }
 void GUIDelay() {
   // Called in all UI looping tasks,
@@ -65,7 +64,7 @@ void GUIDelay() {
   // prevent the movement detection from running
   osDelay(50);
 }
-void gui_drawTipTemp(bool symbol) {
+void gui_drawTipTemp(bool symbol, const FontStyle font) {
   // Draw tip temp handling unit conversion & tolerance near setpoint
   uint32_t Temp = 0;
   if (systemSettings.temperatureInF) {
@@ -74,9 +73,9 @@ void gui_drawTipTemp(bool symbol) {
     Temp = TipThermoModel::getTipInC();
   }
 
-  OLED::printNumber(Temp, 3); // Draw the tip temp out
+  OLED::printNumber(Temp, 3, font); // Draw the tip temp out
   if (symbol) {
-    if (OLED::getFont() == 0) {
+    if (font == FontStyle::LARGE) {
       // Big font, can draw nice symbols
       if (systemSettings.temperatureInF)
         OLED::drawSymbol(0);
@@ -85,9 +84,9 @@ void gui_drawTipTemp(bool symbol) {
     } else {
       // Otherwise fall back to chars
       if (systemSettings.temperatureInF)
-        OLED::print(SymbolDegF);
+        OLED::print(SymbolDegF, FontStyle::SMALL);
       else
-        OLED::print(SymbolDegC);
+        OLED::print(SymbolDegC, FontStyle::SMALL);
     }
   }
 }
@@ -108,15 +107,13 @@ static bool checkVoltageForExit() {
       OLED::clearScreen();
       OLED::setCursor(0, 0);
       if (systemSettings.detailedSoldering) {
-        OLED::setFont(1);
-        OLED::print(UndervoltageString);
+        OLED::print(UndervoltageString, FontStyle::SMALL);
         OLED::setCursor(0, 8);
-        OLED::print(InputVoltageString);
+        OLED::print(InputVoltageString, FontStyle::SMALL);
         printVoltage();
-        OLED::print(SymbolVolts);
+        OLED::print(SymbolVolts, FontStyle::SMALL);
       } else {
-        OLED::setFont(0);
-        OLED::print(UVLOWarningString);
+        OLED::print(UVLOWarningString, FontStyle::LARGE);
       }
 
       OLED::refresh();
@@ -140,14 +137,12 @@ static void gui_drawBatteryIcon() {
       V = V / 10;
     if (V >= 10) {
       int16_t xPos = OLED::getCursorX();
-      OLED::setFont(1);
-      OLED::printNumber(V / 10, 1);
+      OLED::printNumber(V / 10, 1, FontStyle::SMALL);
       OLED::setCursor(xPos, 8);
-      OLED::printNumber(V % 10, 1);
-      OLED::setFont(0);
+      OLED::printNumber(V % 10, 1, FontStyle::SMALL);
       OLED::setCursor(xPos + 12, 0); // need to reset this as if we drew a wide char
     } else {
-      OLED::printNumber(V, 1);
+      OLED::printNumber(V, 1, FontStyle::LARGE);
     }
     return;
   }
@@ -185,7 +180,6 @@ static void gui_solderingTempAdjust() {
   for (;;) {
     OLED::setCursor(0, 0);
     OLED::clearScreen();
-    OLED::setFont(0);
     buttons = getButtonState();
     if (buttons) {
       if (waitForRelease) {
@@ -264,27 +258,27 @@ static void gui_solderingTempAdjust() {
 #else
     if (OLED::getRotation()) {
 #endif
-      OLED::print(systemSettings.ReverseButtonTempChangeEnabled ? SymbolPlus : SymbolMinus);
+      OLED::print(systemSettings.ReverseButtonTempChangeEnabled ? SymbolPlus : SymbolMinus, FontStyle::LARGE);
     } else {
-      OLED::print(systemSettings.ReverseButtonTempChangeEnabled ? SymbolMinus : SymbolPlus);
+      OLED::print(systemSettings.ReverseButtonTempChangeEnabled ? SymbolMinus : SymbolPlus, FontStyle::LARGE);
     }
 
-    OLED::print(SymbolSpace);
-    OLED::printNumber(systemSettings.SolderingTemp, 3);
+    OLED::print(SymbolSpace, FontStyle::LARGE);
+    OLED::printNumber(systemSettings.SolderingTemp, 3, FontStyle::LARGE);
     if (systemSettings.temperatureInF)
       OLED::drawSymbol(0);
     else {
       OLED::drawSymbol(1);
     }
-    OLED::print(SymbolSpace);
+    OLED::print(SymbolSpace, FontStyle::LARGE);
 #ifdef OLED_FLIP
     if (!OLED::getRotation()) {
 #else
     if (OLED::getRotation()) {
 #endif
-      OLED::print(systemSettings.ReverseButtonTempChangeEnabled ? SymbolMinus : SymbolPlus);
+      OLED::print(systemSettings.ReverseButtonTempChangeEnabled ? SymbolMinus : SymbolPlus, FontStyle::LARGE);
     } else {
-      OLED::print(systemSettings.ReverseButtonTempChangeEnabled ? SymbolPlus : SymbolMinus);
+      OLED::print(systemSettings.ReverseButtonTempChangeEnabled ? SymbolPlus : SymbolMinus, FontStyle::LARGE);
     }
     OLED::refresh();
     GUIDelay();
@@ -332,24 +326,22 @@ static int gui_SolderingSleepingMode(bool stayOff, bool autoStarted) {
     OLED::clearScreen();
     OLED::setCursor(0, 0);
     if (systemSettings.detailedSoldering) {
-      OLED::setFont(1);
-      OLED::print(SleepingAdvancedString);
+      OLED::print(SleepingAdvancedString, FontStyle::SMALL);
       OLED::setCursor(0, 8);
-      OLED::print(SleepingTipAdvancedString);
-      OLED::printNumber(tipTemp, 3);
+      OLED::print(SleepingTipAdvancedString, FontStyle::SMALL);
+      OLED::printNumber(tipTemp, 3, FontStyle::SMALL);
       if (systemSettings.temperatureInF)
-        OLED::print(SymbolDegF);
+        OLED::print(SymbolDegF, FontStyle::SMALL);
       else {
-        OLED::print(SymbolDegC);
+        OLED::print(SymbolDegC, FontStyle::SMALL);
       }
 
-      OLED::print(SymbolSpace);
+      OLED::print(SymbolSpace, FontStyle::SMALL);
       printVoltage();
-      OLED::print(SymbolVolts);
+      OLED::print(SymbolVolts, FontStyle::SMALL);
     } else {
-      OLED::setFont(0);
-      OLED::print(SleepingSimpleString);
-      OLED::printNumber(tipTemp, 3);
+      OLED::print(SleepingSimpleString, FontStyle::LARGE);
+      OLED::printNumber(tipTemp, 3, FontStyle::LARGE);
       if (systemSettings.temperatureInF)
         OLED::drawSymbol(0);
       else {
@@ -379,11 +371,11 @@ static void display_countdown(int sleepThres) {
   int        lastEventTime = lastButtonTime < lastMovementTime ? lastMovementTime : lastButtonTime;
   TickType_t downCount     = sleepThres - xTaskGetTickCount() + lastEventTime;
   if (downCount > (99 * TICKS_SECOND)) {
-    OLED::printNumber(downCount / 60000 + 1, 2);
-    OLED::print(SymbolMinutes);
+    OLED::printNumber(downCount / 60000 + 1, 2, FontStyle::SMALL);
+    OLED::print(SymbolMinutes, FontStyle::SMALL);
   } else {
-    OLED::printNumber(downCount / 1000 + 1, 2);
-    OLED::print(SymbolSeconds);
+    OLED::printNumber(downCount / 1000 + 1, 2, FontStyle::SMALL);
+    OLED::print(SymbolSeconds, FontStyle::SMALL);
   }
 }
 static uint32_t getSleepTimeout() {
@@ -470,7 +462,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
       case BUTTON_BOTH_LONG:
         // Unlock buttons
         buttonsLocked = false;
-        warnUser(UnlockingKeysString, 0, TICKS_SECOND);
+        warnUser(UnlockingKeysString, FontStyle::LARGE, TICKS_SECOND);
         break;
       case BUTTON_F_LONG:
         // if boost mode is enabled turn it on
@@ -484,7 +476,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
       case BUTTON_F_SHORT:
       case BUTTON_B_SHORT:
         // Do nothing and display a lock warming
-        warnUser(WarningKeysLockedString, 0, TICKS_SECOND / 2);
+        warnUser(WarningKeysLockedString, FontStyle::LARGE, TICKS_SECOND / 2);
         break;
       default:
         break;
@@ -519,7 +511,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
         if (systemSettings.lockingMode != 0) {
           // Lock buttons
           buttonsLocked = true;
-          warnUser(LockingKeysString, 0, TICKS_SECOND);
+          warnUser(LockingKeysString, FontStyle::LARGE, TICKS_SECOND);
         }
         break;
       default:
@@ -529,47 +521,45 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
     // else we update the screen information
     OLED::setCursor(0, 0);
     OLED::clearScreen();
-    OLED::setFont(0);
     // Draw in the screen details
     if (systemSettings.detailedSoldering) {
-      OLED::setFont(1);
-      OLED::print(SolderingAdvancedPowerPrompt); // Power:
-      OLED::printNumber(x10WattHistory.average() / 10, 2);
-      OLED::print(SymbolDot);
-      OLED::printNumber(x10WattHistory.average() % 10, 1);
-      OLED::print(SymbolWatts);
+      OLED::print(SolderingAdvancedPowerPrompt, FontStyle::SMALL); // Power:
+      OLED::printNumber(x10WattHistory.average() / 10, 2, FontStyle::SMALL);
+      OLED::print(SymbolDot, FontStyle::SMALL);
+      OLED::printNumber(x10WattHistory.average() % 10, 1, FontStyle::SMALL);
+      OLED::print(SymbolWatts, FontStyle::SMALL);
 
       if (systemSettings.sensitivity && systemSettings.SleepTime) {
-        OLED::print(SymbolSpace);
+        OLED::print(SymbolSpace, FontStyle::SMALL);
         display_countdown(getSleepTimeout());
       }
 
       OLED::setCursor(0, 8);
-      OLED::print(SleepingTipAdvancedString);
-      gui_drawTipTemp(true);
+      OLED::print(SleepingTipAdvancedString, FontStyle::SMALL);
+      gui_drawTipTemp(true, FontStyle::SMALL);
 
       if (boostModeOn) {
-        OLED::print(SymbolPlus);
+        OLED::print(SymbolPlus, FontStyle::SMALL);
       } else {
-        OLED::print(SymbolSpace);
+        OLED::print(SymbolSpace, FontStyle::SMALL);
       }
 
       printVoltage();
-      OLED::print(SymbolVolts);
+      OLED::print(SymbolVolts, FontStyle::SMALL);
     } else {
       // We switch the layout direction depending on the orientation of the oled
       if (OLED::getRotation()) {
         // battery
         gui_drawBatteryIcon();
-        OLED::print(SymbolSpace); // Space out gap between battery <-> temp
-        gui_drawTipTemp(true);    // Draw current tip temp
+        OLED::print(SymbolSpace, FontStyle::LARGE); // Space out gap between battery <-> temp
+        gui_drawTipTemp(true, FontStyle::LARGE);    // Draw current tip temp
 
         // We draw boost arrow if boosting, or else gap temp <-> heat
         // indicator
         if (boostModeOn)
           OLED::drawSymbol(2);
         else
-          OLED::print(SymbolSpace);
+          OLED::print(SymbolSpace, FontStyle::LARGE);
 
         // Draw heating/cooling symbols
         OLED::drawHeatSymbol(X10WattsToPWM(x10WattHistory.average()));
@@ -581,10 +571,10 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
         if (boostModeOn)
           OLED::drawSymbol(2);
         else
-          OLED::print(SymbolSpace);
-        gui_drawTipTemp(true); // Draw current tip temp
+          OLED::print(SymbolSpace, FontStyle::LARGE);
+        gui_drawTipTemp(true, FontStyle::LARGE); // Draw current tip temp
 
-        OLED::print(SymbolSpace); // Space out gap between battery <-> temp
+        OLED::print(SymbolSpace, FontStyle::LARGE); // Space out gap between battery <-> temp
 
         gui_drawBatteryIcon();
       }
@@ -627,47 +617,46 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
 void showDebugMenu(void) {
   uint8_t     screen = 0;
   ButtonState b;
-  OLED::setFont(1); // small font
   for (;;) {
-    OLED::clearScreen();              // Ensure the buffer starts clean
-    OLED::setCursor(0, 0);            // Position the cursor at the 0,0 (top left)
-    OLED::print(SymbolVersionNumber); // Print version number
-    OLED::setCursor(0, 8);            // second line
-    OLED::print(DebugMenu[screen]);
+    OLED::clearScreen();                                // Ensure the buffer starts clean
+    OLED::setCursor(0, 0);                              // Position the cursor at the 0,0 (top left)
+    OLED::print(SymbolVersionNumber, FontStyle::SMALL); // Print version number
+    OLED::setCursor(0, 8);                              // second line
+    OLED::print(DebugMenu[screen], FontStyle::SMALL);
     switch (screen) {
     case 0: // Just prints date
       break;
     case 1:
       // High water mark for GUI
-      OLED::printNumber(uxTaskGetStackHighWaterMark(GUITaskHandle), 5);
+      OLED::printNumber(uxTaskGetStackHighWaterMark(GUITaskHandle), 5, FontStyle::SMALL);
       break;
     case 2:
       // High water mark for the Movement task
-      OLED::printNumber(uxTaskGetStackHighWaterMark(MOVTaskHandle), 5);
+      OLED::printNumber(uxTaskGetStackHighWaterMark(MOVTaskHandle), 5, FontStyle::SMALL);
       break;
     case 3:
       // High water mark for the PID task
-      OLED::printNumber(uxTaskGetStackHighWaterMark(PIDTaskHandle), 5);
+      OLED::printNumber(uxTaskGetStackHighWaterMark(PIDTaskHandle), 5, FontStyle::SMALL);
       break;
     case 4:
       // system up time stamp
-      OLED::printNumber(xTaskGetTickCount() / TICKS_100MS, 5);
+      OLED::printNumber(xTaskGetTickCount() / TICKS_100MS, 5, FontStyle::SMALL);
       break;
     case 5:
       // Movement time stamp
-      OLED::printNumber(lastMovementTime / TICKS_100MS, 5);
+      OLED::printNumber(lastMovementTime / TICKS_100MS, 5, FontStyle::SMALL);
       break;
     case 6:
       // Raw Tip
-      { OLED::printNumber(TipThermoModel::convertTipRawADCTouV(getTipRawTemp(0), true), 6); }
+      { OLED::printNumber(TipThermoModel::convertTipRawADCTouV(getTipRawTemp(0), true), 6, FontStyle::SMALL); }
       break;
     case 7:
       // Temp in C
-      OLED::printNumber(TipThermoModel::getTipInC(), 5);
+      OLED::printNumber(TipThermoModel::getTipInC(), 5, FontStyle::SMALL);
       break;
     case 8:
       // Handle Temp
-      OLED::printNumber(getHandleTemperature(), 3);
+      OLED::printNumber(getHandleTemperature(), 3, FontStyle::SMALL);
       break;
     case 9:
       // Voltage input
@@ -675,12 +664,12 @@ void showDebugMenu(void) {
       break;
     case 10:
       // Print PCB ID number
-      OLED::printNumber(DetectedAccelerometerVersion, 2);
+      OLED::printNumber(DetectedAccelerometerVersion, 2, FontStyle::SMALL);
       break;
     case 11:
       // Power negotiation status
       if (getIsPoweredByDCIN()) {
-        OLED::printNumber(0, 1);
+        OLED::printNumber(0, 1, FontStyle::SMALL);
       } else {
         // We are not powered via DC, so want to display the appropriate state for PD or QC
         bool poweredbyPD = false;
@@ -694,16 +683,16 @@ void showDebugMenu(void) {
         }
 #endif
         if (poweredbyPD) {
-          OLED::printNumber(2, 1);
+          OLED::printNumber(2, 1, FontStyle::SMALL);
         } else {
 
-          OLED::printNumber(1, 1);
+          OLED::printNumber(1, 1, FontStyle::SMALL);
         }
       }
       break;
     case 12:
       // Max deg C limit
-      OLED::printNumber(TipThermoModel::getTipMaxInC(), 3);
+      OLED::printNumber(TipThermoModel::getTipMaxInC(), 3, FontStyle::SMALL);
       break;
     default:
       break;
@@ -726,9 +715,9 @@ void showWarnings() {
   if (settingsWereReset) {
     if (SettingsResetMessage[0] == '\x01') { // `\x01` is used as newline.
       // Empty first line means that this uses large font (for CJK).
-      warnUser(SettingsResetMessage + 1, 0, 10 * TICKS_SECOND);
+      warnUser(SettingsResetMessage + 1, FontStyle::LARGE, 10 * TICKS_SECOND);
     } else {
-      warnUser(SettingsResetMessage, 1, 10 * TICKS_SECOND);
+      warnUser(SettingsResetMessage, FontStyle::SMALL, 10 * TICKS_SECOND);
     }
   }
 #ifndef NO_WARN_MISSING
@@ -743,7 +732,7 @@ void showWarnings() {
     if (systemSettings.accelMissingWarningCounter < 2) {
       systemSettings.accelMissingWarningCounter++;
       saveSettings();
-      warnUser(NoAccelerometerMessage, 1, 10 * TICKS_SECOND);
+      warnUser(NoAccelerometerMessage, FontStyle::SMALL, 10 * TICKS_SECOND);
     }
   }
 #ifdef POW_PD
@@ -752,7 +741,7 @@ void showWarnings() {
     if (systemSettings.pdMissingWarningCounter < 2) {
       systemSettings.pdMissingWarningCounter++;
       saveSettings();
-      warnUser(NoPowerDeliveryMessage, 1, 10 * TICKS_SECOND);
+      warnUser(NoPowerDeliveryMessage, FontStyle::SMALL, 10 * TICKS_SECOND);
     }
   }
 #endif
@@ -802,7 +791,6 @@ void startGUITask(void const *argument __unused) {
     ButtonState buttons = getButtonState();
     if (buttons != BUTTON_NONE) {
       OLED::setDisplayState(OLED::DisplayState::ON);
-      OLED::setFont(0);
     }
     if (tempWarningState == 2)
       buttons = BUTTON_F_SHORT;
@@ -860,22 +848,20 @@ void startGUITask(void const *argument __unused) {
     OLED::clearScreen();
     OLED::setCursor(0, 0);
     if (systemSettings.detailedIDLE) {
-      OLED::setFont(1);
       if (tipTemp > tipDisconnectedThres) {
-        OLED::print(TipDisconnectedString);
+        OLED::print(TipDisconnectedString, FontStyle::SMALL);
       } else {
-        OLED::print(IdleTipString);
-        gui_drawTipTemp(false);
-        OLED::print(IdleSetString);
-        OLED::printNumber(systemSettings.SolderingTemp, 3);
+        OLED::print(IdleTipString, FontStyle::SMALL);
+        gui_drawTipTemp(false, FontStyle::SMALL);
+        OLED::print(IdleSetString, FontStyle::SMALL);
+        OLED::printNumber(systemSettings.SolderingTemp, 3, FontStyle::SMALL);
       }
       OLED::setCursor(0, 8);
 
-      OLED::print(InputVoltageString);
+      OLED::print(InputVoltageString, FontStyle::SMALL);
       printVoltage();
 
     } else {
-      OLED::setFont(0);
 #ifdef OLED_FLIP
       if (!OLED::getRotation()) {
 #else
@@ -919,7 +905,7 @@ void startGUITask(void const *argument __unused) {
         if (!tipDisconnectedDisplay) {
           // draw in the temp
           if (!(systemSettings.coolingTempBlink && (xTaskGetTickCount() % 260 < 160)))
-            gui_drawTipTemp(false); // draw in the temp
+            gui_drawTipTemp(false, FontStyle::LARGE); // draw in the temp
         } else {
           // Draw in missing tip symbol
 


### PR DESCRIPTION
Please try and fill out this template where possible, not all fields are required and can be removed.

* **Please check if the PR fulfills these requirements**
- The changes have been tested locally
- There are no breaking changes

* **What kind of change does this PR introduce?**

Refactoring.

The font style is now passed as a parameter when printing the chars/strings instead of being a global state set by `setFont`.


* **Other information**:

**Motivations:**

1. I don't like the font setting being a global state. Keeping track of the current font is not so straightforward.
2. Moving the font size handling to `drawChar` makes it easier to make it draw chars in different width in the future.
3. Just messing around really

**Impact on build size:**
This change appears to have shrunk the binaries by some tens of bytes, so there should be no regression on binary size.