### PR TITLE
Refactoring of text handling (on using large font when starting with \n)

### DIFF
--- a/Translations/TranslationEditor.html
+++ b/Translations/TranslationEditor.html
@@ -193,41 +193,59 @@
 					return str;
 				},
 
-				validateWholeScreenMessage: function(valMap, id) {
-					var d = defMap[id];
-					if (this.isSmall(valMap[id])) {
-						if (valMap[id][0].length === 0) {
+				getWholeScreenMessageMaxLen: function(valMap, id, prop) {
+					var v = prop ? valMap[id][prop] : valMap[id];
+					var maxLen;
+					if (this.isSmall(v)) {
+						maxLen = defMap[id].maxLen2 || 16;
+					} else {
+						maxLen = defMap[id].maxLen || 8;
+					}
+					return maxLen;
+				},
+
+				validateWholeScreenMessage: function(valMap, id, prop) {
+					var v = prop ? valMap[id][prop] : valMap[id];
+					var maxLen = this.getWholeScreenMessageMaxLen(valMap, id, prop);
+					if (this.isSmall(v)) {
+						if (v[0].length === 0) {
 							return "invalid";
-						} else if (Math.max(valMap[id][0].length, valMap[id][1].length) > 16) {
+						} else if (Math.max(v[0].length, v[1].length) > maxLen) {
 							return "invalid";
 						}
 					} else {
-						if (valMap[id].length > 8) {
+						if (v.length > maxLen) {
 							return "invalid";
 						}
 					}
 				},
 
-				constraintWholeScreenMessage: function(v) {
-					if (this.isSmall(v)) {
-						return "len <= 16";
-					} else {
-						return "len <= 8";
-					}
+				constraintWholeScreenMessage: function(valMap, id, prop) {
+					return "len <= " + this.getWholeScreenMessageMaxLen(valMap, id, prop);
 				},
 
 				isSmall: function(v) {
 					return v instanceof Array;
 				},
 
-				convertToLarge: function(valMap, id) {
-					var message = valMap[id][0] + (valMap[id][1] !== "" ? " " + valMap[id][1] : "");
-					valMap[id] = message;
+				convertToLarge: function(valMap, id, prop) {
+					var v = prop ? valMap[id][prop] : valMap[id];
+					var message = v[0] + (v[1] !== "" ? " " + v[1] : "");
+					if (prop) {
+						valMap[id][prop] = message;
+					} else {
+						valMap[id] = message;
+					}
 				},
 
-				convertToSmall: function(valMap, id) {
-					var message = valMap[id]
-					valMap[id] = [ message, "" ];
+				convertToSmall: function(valMap, id, prop) {
+					var v = prop ? valMap[id][prop] : valMap[id];
+					var message = [ v, "" ];
+					if (prop) {
+						valMap[id][prop] = message;
+					} else {
+						valMap[id] = message;
+					}
 				}
 			}
 		});
@@ -316,7 +334,7 @@
 					<tr v-for="message in def.messagesWarn" v-bind:class="validateWholeScreenMessage(current.messagesWarn, message.id)">
 						<td class="label"><div class="stringId">{{message.id}}</div></td>
 						<td class="value">
-							<div class="constraint">{{constraintWholeScreenMessage(current.messagesWarn[message.id])}}</div>
+							<div class="constraint">{{constraintWholeScreenMessage(current.messagesWarn, message.id)}}</div>
 							<div class="ref">{{referent.messagesWarn[message.id]}}</div>
 							<div class="note" v-if="message.note">{{message.note}}</div>
 							<div class="tran" v-if="isSmall(current.messagesWarn[message.id])">
@@ -346,13 +364,21 @@
 
 				<h2>Menu Groups</h2>
 				<table class="data">
-					<tr v-for="menu in def.menuGroups" v-bind:class="validateInput(current.menuGroups, menu.id, 2)">
+					<tr v-for="menu in def.menuGroups" v-bind:class="validateWholeScreenMessage(current.menuGroups, menu.id, 'text2')">
 						<td class="label"><div class="stringId">{{menu.id}}</div></td>
 						<td class="value">
 							<div class="label">Menu Name</div>
-							<div class="constraint">{{constraintString(menu)}}</div>
+							<div class="constraint">{{constraintWholeScreenMessage(current.menuGroups, menu.id, 'text2')}}</div>
 							<div class="ref">{{referent.menuGroups[menu.id].text2}}</div>
-							<div class="tran" v-bind:class="{unchanged : current.menuGroups[menu.id].text2[0] == referent.menuGroups[menu.id].text2[0] && current.menuGroups[menu.id].text2[1] == referent.menuGroups[menu.id].text2[1], empty : current.menuGroups[menu.id].text2[0] == '' || current.menuGroups[menu.id].text2[1] == ''}"><input type="text" v-model="current.menuGroups[menu.id].text2[0]"><input type="text" v-model="current.menuGroups[menu.id].text2[1]"></div>
+							<div class="tran" v-if="isSmall(current.menuGroups[menu.id].text2)">
+								<input type="text" v-model="current.menuGroups[menu.id].text2[0]" v-bind:class="{unchanged : current.menuGroups[menu.id].text2[0] == referent.menuGroups[menu.id].text2[0] && current.menuGroups[menu.id].text2[1] == referent.menuGroups[menu.id].text2[1], empty : current.menuGroups[menu.id].text2[0] == '' && current.menuGroups[menu.id].text2[1] == ''}">
+								<input type="text" v-model="current.menuGroups[menu.id].text2[1]" v-bind:class="{unchanged : current.menuGroups[menu.id].text2[0] == referent.menuGroups[menu.id].text2[0] && current.menuGroups[menu.id].text2[1] == referent.menuGroups[menu.id].text2[1], empty : current.menuGroups[menu.id].text2[0] == '' && current.menuGroups[menu.id].text2[1] == ''}">
+								<button type="button" @click="convertToLarge(current.menuGroups, menu.id, 'text2')">Convert to large text</button>
+							</div>
+							<div class="tran" v-else>
+								<input type="text" v-model="current.menuGroups[menu.id].text2" v-bind:class="{unchanged : current.menuGroups[menu.id].text2 == referent.menuGroups[menu.id].text2, empty : current.menuGroups[menu.id].text2==''}">
+								<button type="button" @click="convertToSmall(current.menuGroups, menu.id, 'text2')">Convert to small text</button>
+							</div>
 							<div class="label">Description</div>
 							<div class="ref">{{referent.menuGroups[menu.id].desc}}</div>
 							<div class="tran"><input type="text" v-model="current.menuGroups[menu.id].desc" v-bind:class="{unchanged : current.menuGroups[menu.id].desc == referent.menuGroups[menu.id].desc, empty : current.menuGroups[menu.id].desc == ''}"></div>
@@ -362,14 +388,22 @@
 
 				<h2>Menu Options</h2>
 				<table class="data">
-					<tr v-for="menu in def.menuOptions" v-bind:class="validateInput(current.menuOptions, menu.id, 2)">
+					<tr v-for="menu in def.menuOptions" v-bind:class="validateWholeScreenMessage(current.menuOptions, menu.id, 'text2')">
 						<td class="label"><div class="stringId">{{menu.id}}</div></td>
 						<td class="value">
 							<div v-bind:class="{hidden : false}">
-								<div class="label">Menu Name (Double-Line)</div>
-								<div class="constraint">{{constraintString(menu)}}</div>
+								<div class="label">Menu Name</div>
+								<div class="constraint">{{constraintWholeScreenMessage(current.menuOptions, menu.id, 'text2')}}</div>
 								<div class="ref">{{referent.menuOptions[menu.id].text2}}</div>
-								<div class="tran" v-bind:class="{unchanged : current.menuOptions[menu.id].text2[0] == referent.menuOptions[menu.id].text2[0] && current.menuOptions[menu.id].text2[1] == referent.menuOptions[menu.id].text2[1], empty : current.menuOptions[menu.id].text2[0] == '' || current.menuOptions[menu.id].text2[1] == ''}"><input type="text" v-model="current.menuOptions[menu.id].text2[0]"><input type="text" v-model="current.menuOptions[menu.id].text2[1]"></div>
+								<div class="tran" v-if="isSmall(current.menuOptions[menu.id].text2)">
+									<input type="text" v-model="current.menuOptions[menu.id].text2[0]" v-bind:class="{unchanged : current.menuOptions[menu.id].text2[0] == referent.menuOptions[menu.id].text2[0] && current.menuOptions[menu.id].text2[1] == referent.menuOptions[menu.id].text2[1], empty : current.menuOptions[menu.id].text2[0] == '' && current.menuOptions[menu.id].text2[1] == ''}">
+									<input type="text" v-model="current.menuOptions[menu.id].text2[1]" v-bind:class="{unchanged : current.menuOptions[menu.id].text2[0] == referent.menuOptions[menu.id].text2[0] && current.menuOptions[menu.id].text2[1] == referent.menuOptions[menu.id].text2[1], empty : current.menuOptions[menu.id].text2[0] == '' && current.menuOptions[menu.id].text2[1] == ''}">
+									<button type="button" @click="convertToLarge(current.menuOptions, menu.id, 'text2')">Convert to large text</button>
+								</div>
+								<div class="tran" v-else>
+									<input type="text" v-model="current.menuOptions[menu.id].text2" v-bind:class="{unchanged : current.menuOptions[menu.id].text2 == referent.menuOptions[menu.id].text2, empty : current.menuOptions[menu.id].text2==''}">
+									<button type="button" @click="convertToSmall(current.menuOptions, menu.id, 'text2')">Convert to small text</button>
+								</div>
 							</div>
 							<div class="label">Description</div>
 							<div class="ref">{{referent.menuOptions[menu.id].desc}}</div>

--- a/Translations/TranslationEditor.html
+++ b/Translations/TranslationEditor.html
@@ -3,7 +3,7 @@
 
 	<head>
 		<meta charset="UTF-8">
-		<title>TS100 Translation Editor</title>
+		<title>IronOS Translation Editor</title>
 
 		<script src="https://cdn.jsdelivr.net/npm/vue/dist/vue.js"></script>
 		<script src="translations_commons.js"></script>
@@ -191,11 +191,49 @@
 						delim = " and ";
 					}
 					return str;
+				},
+
+				validateWholeScreenMessage: function(valMap, id) {
+					var d = defMap[id];
+					if (this.isSmall(valMap[id])) {
+						if (valMap[id][0].length === 0) {
+							return "invalid";
+						} else if (Math.max(valMap[id][0].length, valMap[id][1].length) > 16) {
+							return "invalid";
+						}
+					} else {
+						if (valMap[id].length > 8) {
+							return "invalid";
+						}
+					}
+				},
+
+				constraintWholeScreenMessage: function(v) {
+					if (this.isSmall(v)) {
+						return "len <= 16";
+					} else {
+						return "len <= 8";
+					}
+				},
+
+				isSmall: function(v) {
+					return v instanceof Array;
+				},
+
+				convertToLarge: function(valMap, id) {
+					var message = valMap[id][0] + (valMap[id][1] !== "" ? " " + valMap[id][1] : "");
+					valMap[id] = message;
+				},
+
+				convertToSmall: function(valMap, id) {
+					var message = valMap[id]
+					valMap[id] = [ message, "" ];
 				}
 			}
 		});
 		app.def = def;
 		copyArrayToMap(app.def.messages, defMap);
+		copyArrayToMap(app.def.messagesWarn, defMap);
 		copyArrayToMap(app.def.characters, defMap);
 		copyArrayToMap(app.def.menuGroups, defMap);
 		copyArrayToMap(app.def.menuOptions, defMap);
@@ -208,7 +246,7 @@
 	<body>
 
 		<div id="app">
-			<h1>TS100 Translation Editor<span v-if="meta.currentLoaded"> - {{ current.languageLocalName }} [{{current.languageCode}}]</span></h1>
+			<h1>IronOS Translation Editor<span v-if="meta.currentLoaded"> - {{ current.languageLocalName }} [{{current.languageCode}}]</span></h1>
 			<table class="header data">
 				<tr>
 					<td class="label">Referent Language</td>
@@ -269,6 +307,27 @@
 							<div class="ref">{{referent.messages[message.id]}}</div>
 							<div class="note" v-if="message.note">{{message.note}}</div>
 							<div class="tran"><input :id="'in_'+message.id" type="text" v-model="current.messages[message.id]" v-bind:class="{unchanged : current.messages[message.id] == referent.messages[message.id], empty : current.messages[message.id]==''}"></div>
+						</td>
+					</tr>
+				</table>
+
+				<h2>Warning Messages</h2>
+				<table class="data">
+					<tr v-for="message in def.messagesWarn" v-bind:class="validateWholeScreenMessage(current.messagesWarn, message.id)">
+						<td class="label"><div class="stringId">{{message.id}}</div></td>
+						<td class="value">
+							<div class="constraint">{{constraintWholeScreenMessage(current.messagesWarn[message.id])}}</div>
+							<div class="ref">{{referent.messagesWarn[message.id]}}</div>
+							<div class="note" v-if="message.note">{{message.note}}</div>
+							<div class="tran" v-if="isSmall(current.messagesWarn[message.id])">
+								<input :id="'in_'+message.id+'_0'" type="text" v-model="current.messagesWarn[message.id][0]" v-bind:class="{unchanged : current.messagesWarn[message.id][0] == referent.messagesWarn[message.id][0] && current.messagesWarn[message.id][1] == referent.messagesWarn[message.id][1], empty : current.messagesWarn[message.id][0] == '' && current.messagesWarn[message.id][1] == ''}">
+								<input :id="'in_'+message.id+'_1'" type="text" v-model="current.messagesWarn[message.id][1]" v-bind:class="{unchanged : current.messagesWarn[message.id][0] == referent.messagesWarn[message.id][0] && current.messagesWarn[message.id][1] == referent.messagesWarn[message.id][1], empty : current.messagesWarn[message.id][0] == '' && current.messagesWarn[message.id][1] == ''}">
+								<button type="button" @click="convertToLarge(current.messagesWarn, message.id)">Convert to large text</button>
+							</div>
+							<div class="tran" v-else>
+								<input :id="'in_'+message.id" type="text" v-model="current.messagesWarn[message.id]" v-bind:class="{unchanged : current.messagesWarn[message.id] == referent.messagesWarn[message.id], empty : current.messagesWarn[message.id]==''}">
+								<button type="button" @click="convertToSmall(current.messagesWarn, message.id)">Convert to small text</button>
+							</div>
 						</td>
 					</tr>
 				</table>

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -127,6 +127,15 @@ def get_letter_counts(defs: dict, lang: dict) -> List[str]:
         else:
             text_list.append(obj[eid])
 
+    obj = lang["messagesWarn"]
+    for mod in defs["messagesWarn"]:
+        eid = mod["id"]
+        if isinstance(obj[eid], list):
+            text_list.append(obj[eid][0])
+            text_list.append(obj[eid][1])
+        else:
+            text_list.append(obj[eid])
+
     obj = lang["characters"]
 
     for mod in defs["characters"]:
@@ -397,6 +406,23 @@ def write_language(lang: dict, defs: dict, f: TextIO) -> None:
             source_text = mod["default"]
         if eid in obj:
             source_text = obj[eid]
+        translated_text = convert_string(symbol_conversion_table, source_text)
+        source_text = source_text.replace("\n", "_")
+        f.write(f'const char* {eid} = "{translated_text}";//{source_text} \n')
+
+    f.write("\n")
+
+    obj = lang["messagesWarn"]
+
+    for mod in defs["messagesWarn"]:
+        eid = mod["id"]
+        if isinstance(obj[eid], list):
+            if not obj[eid][1]:
+                source_text = obj[eid][0]
+            else:
+                source_text = obj[eid][0] + "\n" + obj[eid][1]
+        else:
+            source_text = "\n" + obj[eid]
         translated_text = convert_string(symbol_conversion_table, source_text)
         source_text = source_text.replace("\n", "_")
         f.write(f'const char* {eid} = "{translated_text}";//{source_text} \n')

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -145,14 +145,20 @@ def get_letter_counts(defs: dict, lang: dict) -> List[str]:
     obj = lang["menuOptions"]
     for mod in defs["menuOptions"]:
         eid = mod["id"]
-        text_list.append(obj[eid]["text2"][0])
-        text_list.append(obj[eid]["text2"][1])
+        if isinstance(obj[eid]["text2"], list):
+            text_list.append(obj[eid]["text2"][0])
+            text_list.append(obj[eid]["text2"][1])
+        else:
+            text_list.append(obj[eid]["text2"])
 
     obj = lang["menuGroups"]
     for mod in defs["menuGroups"]:
         eid = mod["id"]
-        text_list.append(obj[eid]["text2"][0])
-        text_list.append(obj[eid]["text2"][1])
+        if isinstance(obj[eid]["text2"], list):
+            text_list.append(obj[eid]["text2"][0])
+            text_list.append(obj[eid]["text2"][1])
+        else:
+            text_list.append(obj[eid]["text2"])
 
     obj = lang["menuGroups"]
     for mod in defs["menuGroups"]:
@@ -459,11 +465,17 @@ def write_language(lang: dict, defs: dict, f: TextIO) -> None:
     index = 0
     for mod in defs["menuOptions"]:
         eid = mod["id"]
+        if isinstance(obj[eid]["text2"], list):
+            if not obj[eid]["text2"][1]:
+                source_text = obj[eid]["text2"][0]
+            else:
+                source_text = obj[eid]["text2"][0] + "\n" + obj[eid]["text2"][1]
+        else:
+            source_text = "\n" + obj[eid]["text2"]
         if "feature" in mod:
             f.write(f"#ifdef {mod['feature']}\n")
         f.write(f"  /* [{index:02d}] {eid.ljust(max_len)[:max_len]} */ ")
-        txt = f'{obj[eid]["text2"][0]}\\n{obj[eid]["text2"][1]}'
-        f.write(f'{{ "{convert_string(symbol_conversion_table, txt)}" }},//{obj[eid]["text2"]} \n')
+        f.write(f'{{ "{convert_string(symbol_conversion_table, source_text)}" }},//{obj[eid]["text2"]} \n')
 
         if "feature" in mod:
             f.write("#endif\n")
@@ -478,9 +490,15 @@ def write_language(lang: dict, defs: dict, f: TextIO) -> None:
     max_len = 25
     for mod in defs["menuGroups"]:
         eid = mod["id"]
+        if isinstance(obj[eid]["text2"], list):
+            if not obj[eid]["text2"][1]:
+                source_text = obj[eid]["text2"][0]
+            else:
+                source_text = obj[eid]["text2"][0] + "\n" + obj[eid]["text2"][1]
+        else:
+            source_text = "\n" + obj[eid]["text2"]
         f.write(f"  /* {eid.ljust(max_len)[:max_len]} */ ")
-        txt = f'{obj[eid]["text2"][0]}\\n{obj[eid]["text2"][1]}'
-        f.write(f'"{convert_string(symbol_conversion_table, txt)}",//{obj[eid]["text2"]} \n')
+        f.write(f'"{convert_string(symbol_conversion_table, source_text)}",//{obj[eid]["text2"]} \n')
 
     f.write("};\n\n")
 

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -427,7 +427,7 @@ def write_language(lang: dict, defs: dict, f: TextIO) -> None:
 
     # ----- Writing SettingsDescriptions
     obj = lang["menuOptions"]
-    f.write("const char* SettingsShortNames[][2] = {\n")
+    f.write("const char* SettingsShortNames[] = {\n")
 
     max_len = 25
     index = 0
@@ -436,7 +436,8 @@ def write_language(lang: dict, defs: dict, f: TextIO) -> None:
         if "feature" in mod:
             f.write(f"#ifdef {mod['feature']}\n")
         f.write(f"  /* [{index:02d}] {eid.ljust(max_len)[:max_len]} */ ")
-        f.write(f'{{ "{convert_string(symbol_conversion_table, (obj[eid]["text2"][0]))}", "{convert_string(symbol_conversion_table, (obj[eid]["text2"][1]))}" }},//{obj[eid]["text2"]} \n')
+        txt = f'{obj[eid]["text2"][0]}\\n{obj[eid]["text2"][1]}'
+        f.write(f'{{ "{convert_string(symbol_conversion_table, txt)}" }},//{obj[eid]["text2"]} \n')
 
         if "feature" in mod:
             f.write("#endif\n")

--- a/Translations/translation_BG.json
+++ b/Translations/translation_BG.json
@@ -23,12 +23,17 @@
 		"OffString": "Изкл.",
 		"ResetOKMessage": "Нулиране завършено",
 		"YourGainMessage": "Усилване:",
-		"SettingsResetMessage": "Настройките бяха\nнулирани!",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Настройките бяха",
+			"нулирани!"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "R",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "F",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",

--- a/Translations/translation_BG.json
+++ b/Translations/translation_BG.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Захранване: ",
 		"OffString": "Изкл.",
 		"ResetOKMessage": "Нулиране завършено",
-		"YourGainMessage": "Усилване:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
-		"LockingKeysString": " LOCKED",
-		"UnlockingKeysString": "UNLOCKED",
-		"WarningKeysLockedString": "!LOCKED!"
+		"YourGainMessage": "Усилване:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Настройките бяха",
 			"нулирани!"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "R",

--- a/Translations/translation_BG.json
+++ b/Translations/translation_BG.json
@@ -21,10 +21,13 @@
 		"TipDisconnectedString": "ПРЕКЪСНАТ ВРЪХ",
 		"SolderingAdvancedPowerPrompt": "Захранване: ",
 		"OffString": "Изкл.",
-		"ResetOKMessage": "Нулиране завършено",
 		"YourGainMessage": "Усилване:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": [
+			"Нулиране",
+			"завършено"
+		],
 		"SettingsResetMessage": [
 			"Настройките бяха",
 			"нулирани!"

--- a/Translations/translation_CS.json
+++ b/Translations/translation_CS.json
@@ -23,12 +23,17 @@
 		"OffString": "Vyp",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Zisk:",
-		"SettingsResetMessage": "Tov. nas. obnov.",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Tov. nas. obnov.",
+			""
+		]
 	},
 	"characters": {
 		"SettingRightChar": "P",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "R",
 		"SettingSlowChar": "P",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",

--- a/Translations/translation_CS.json
+++ b/Translations/translation_CS.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Ohřev: ",
 		"OffString": "Vyp",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Zisk:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
-		"LockingKeysString": " LOCKED",
-		"UnlockingKeysString": "UNLOCKED",
-		"WarningKeysLockedString": "!LOCKED!"
+		"YourGainMessage": "Zisk:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Tov. nas. obnov.",
 			""
-		]
+		],
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "P",

--- a/Translations/translation_CS.json
+++ b/Translations/translation_CS.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "HROT NEPŘIPOJEN",
 		"SolderingAdvancedPowerPrompt": "Ohřev: ",
 		"OffString": "Vyp",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Zisk:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Tov. nas. obnov.",
 			""

--- a/Translations/translation_DA.json
+++ b/Translations/translation_DA.json
@@ -23,12 +23,17 @@
 		"OffString": "Off",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
-		"SettingsResetMessage": "Settings were\nreset!",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Settings were",
+			"reset!"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "H",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "F",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "L",
 		"SettingStartSleepChar": "D",
 		"SettingStartSleepOffChar": "O",

--- a/Translations/translation_DA.json
+++ b/Translations/translation_DA.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "TIP DISCONNECTED",
 		"SolderingAdvancedPowerPrompt": "Power: ",
 		"OffString": "Off",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"

--- a/Translations/translation_DA.json
+++ b/Translations/translation_DA.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Power: ",
 		"OffString": "Off",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Your gain:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
-		"LockingKeysString": " LOCKED",
-		"UnlockingKeysString": "UNLOCKED",
-		"WarningKeysLockedString": "!LOCKED!"
+		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "H",

--- a/Translations/translation_DE.json
+++ b/Translations/translation_DE.json
@@ -26,10 +26,15 @@
 		"NoPowerDeliveryMessage": "Kein USB-PD IC\nerkannt!",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Dein Faktor:",
-		"SettingsResetMessage": "Einstellungen\nzurückgesetzt!",
 		"LockingKeysString": "GESPERRT",
 		"UnlockingKeysString": "ENTSPERRT",
 		"WarningKeysLockedString": "!GESPERRT!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Einstellungen",
+			"zurückgesetzt!"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "R",

--- a/Translations/translation_DE.json
+++ b/Translations/translation_DE.json
@@ -22,19 +22,25 @@
 		"TipDisconnectedString": "Spitze fehlt",
 		"SolderingAdvancedPowerPrompt": "Leistung: ",
 		"OffString": "Aus",
-		"NoAccelerometerMessage": "Kein Bewegungssensor\nerkannt!",
-		"NoPowerDeliveryMessage": "Kein USB-PD IC\nerkannt!",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Dein Faktor:",
-		"LockingKeysString": "GESPERRT",
-		"UnlockingKeysString": "ENTSPERRT",
-		"WarningKeysLockedString": "!GESPERRT!"
+		"YourGainMessage": "Dein Faktor:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Einstellungen",
 			"zurückgesetzt!"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"Kein Bewegungssensor",
+			"erkannt!"
+		],
+		"NoPowerDeliveryMessage": [
+			"Kein USB-PD IC",
+			"erkannt!"
+		],
+		"LockingKeysString": "GESPERRT",
+		"UnlockingKeysString": "ENTSPERRT",
+		"WarningKeysLockedString": "!GESPERRT!"
 	},
 	"characters": {
 		"SettingRightChar": "R",

--- a/Translations/translation_DE.json
+++ b/Translations/translation_DE.json
@@ -22,10 +22,10 @@
 		"TipDisconnectedString": "Spitze fehlt",
 		"SolderingAdvancedPowerPrompt": "Leistung: ",
 		"OffString": "Aus",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Dein Faktor:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Einstellungen",
 			"zurückgesetzt!"

--- a/Translations/translation_EN.json
+++ b/Translations/translation_EN.json
@@ -24,12 +24,17 @@
 		"OffString": "Off",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
-		"SettingsResetMessage": "Settings were\nreset!",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": "LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Settings were",
+			"reset!"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "R",
@@ -38,7 +43,7 @@
 		"SettingFastChar": "F",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "S",
 		"SettingStartSleepChar": "Z",
 		"SettingStartSleepOffChar": "R",

--- a/Translations/translation_EN.json
+++ b/Translations/translation_EN.json
@@ -22,10 +22,10 @@
 		"TipDisconnectedString": "NO TIP",
 		"SolderingAdvancedPowerPrompt": "Power: ",
 		"OffString": "Off",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"

--- a/Translations/translation_EN.json
+++ b/Translations/translation_EN.json
@@ -23,18 +23,24 @@
 		"SolderingAdvancedPowerPrompt": "Power: ",
 		"OffString": "Off",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Your gain:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
-		"LockingKeysString": "LOCKED",
-		"UnlockingKeysString": "UNLOCKED",
-		"WarningKeysLockedString": "!LOCKED!"
+		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": "LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "R",

--- a/Translations/translation_ES.json
+++ b/Translations/translation_ES.json
@@ -30,6 +30,12 @@
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"
 	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Settings were",
+			"reset!"
+		]
+	},
 	"characters": {
 		"SettingRightChar": "D",
 		"SettingLeftChar": "I",
@@ -37,7 +43,7 @@
 		"SettingFastChar": "R",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "S",
 		"SettingStartSleepChar": "R",
 		"SettingStartSleepOffChar": "F",

--- a/Translations/translation_ES.json
+++ b/Translations/translation_ES.json
@@ -21,11 +21,11 @@
 		"TipDisconnectedString": "NO HAY PUNTA",
 		"SolderingAdvancedPowerPrompt": "Potencia: ",
 		"OffString": " No",
-		"ResetOKMessage": "Hecho.       ",
 		"YourGainMessage": "Gananc.:",
 		"SettingsResetMessage": "Ajustes borrados"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Hecho.",
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"

--- a/Translations/translation_ES.json
+++ b/Translations/translation_ES.json
@@ -23,18 +23,24 @@
 		"OffString": " No",
 		"ResetOKMessage": "Hecho.       ",
 		"YourGainMessage": "Gananc.:",
-		"SettingsResetMessage": "Ajustes borrados",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
-		"LockingKeysString": " LOCKED",
-		"UnlockingKeysString": "UNLOCKED",
-		"WarningKeysLockedString": "!LOCKED!"
+		"SettingsResetMessage": "Ajustes borrados"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "D",

--- a/Translations/translation_FI.json
+++ b/Translations/translation_FI.json
@@ -23,12 +23,17 @@
 		"OffString": "OFF",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
-		"SettingsResetMessage": "Settings were\nreset!",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Settings were",
+			"reset!"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "O",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "N",
 		"SettingSlowChar": "H",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",

--- a/Translations/translation_FI.json
+++ b/Translations/translation_FI.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Teho: ",
 		"OffString": "OFF",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Your gain:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
-		"LockingKeysString": " LOCKED",
-		"UnlockingKeysString": "UNLOCKED",
-		"WarningKeysLockedString": "!LOCKED!"
+		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "O",

--- a/Translations/translation_FI.json
+++ b/Translations/translation_FI.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "KÄRKI ON IRTI",
 		"SolderingAdvancedPowerPrompt": "Teho: ",
 		"OffString": "OFF",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"

--- a/Translations/translation_FR.json
+++ b/Translations/translation_FR.json
@@ -23,12 +23,17 @@
 		"OffString": "Off",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Gain : ",
-		"SettingsResetMessage": "Réglage réinit. !",
 		"NoAccelerometerMessage": "Accéléromètre\nnon détecté !",
 		"NoPowerDeliveryMessage": "Pas d'USB-PD\ndétecté !",
 		"LockingKeysString": "VERROUIL",
 		"UnlockingKeysString": "DEVERROU",
 		"WarningKeysLockedString": "! VERR. !"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Réglage",
+			"réinit. !"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "D",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "R",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"D",
+		"SettingOffChar": "D",
 		"SettingStartSolderingChar": "A",
 		"SettingStartSleepChar": "V",
 		"SettingStartSleepOffChar": "O",

--- a/Translations/translation_FR.json
+++ b/Translations/translation_FR.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "PANNE DÉBRANCHÉE",
 		"SolderingAdvancedPowerPrompt": "Puissance : ",
 		"OffString": "Off",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Gain : "
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Réglage",
 			"réinit. !"

--- a/Translations/translation_FR.json
+++ b/Translations/translation_FR.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Puissance : ",
 		"OffString": "Off",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Gain : ",
-		"NoAccelerometerMessage": "Accéléromètre\nnon détecté !",
-		"NoPowerDeliveryMessage": "Pas d'USB-PD\ndétecté !",
-		"LockingKeysString": "VERROUIL",
-		"UnlockingKeysString": "DEVERROU",
-		"WarningKeysLockedString": "! VERR. !"
+		"YourGainMessage": "Gain : "
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Réglage",
 			"réinit. !"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"Accéléromètre",
+			"non détecté !"
+		],
+		"NoPowerDeliveryMessage": [
+			"Pas d'USB-PD",
+			"détecté !"
+		],
+		"LockingKeysString": "VERROUIL",
+		"UnlockingKeysString": "DEVERROU",
+		"WarningKeysLockedString": "! VERR. !"
 	},
 	"characters": {
 		"SettingRightChar": "D",

--- a/Translations/translation_HR.json
+++ b/Translations/translation_HR.json
@@ -23,12 +23,17 @@
 		"OffString": "Off",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
-		"SettingsResetMessage": "Settings were\nreset!",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Settings were",
+			"reset!"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "D",

--- a/Translations/translation_HR.json
+++ b/Translations/translation_HR.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Snaga: ",
 		"OffString": "Off",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Your gain:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
-		"LockingKeysString": " LOCKED",
-		"UnlockingKeysString": "UNLOCKED",
-		"WarningKeysLockedString": "!LOCKED!"
+		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "D",
@@ -42,7 +48,7 @@
 		"SettingFastChar": "B",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",

--- a/Translations/translation_HR.json
+++ b/Translations/translation_HR.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "VRH NIJE SPOJEN!",
 		"SolderingAdvancedPowerPrompt": "Snaga: ",
 		"OffString": "Off",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"

--- a/Translations/translation_HU.json
+++ b/Translations/translation_HU.json
@@ -23,12 +23,17 @@
 		"OffString": "Ki",
 		"ResetOKMessage": "Törlés OK",
 		"YourGainMessage": "Erősítés:",
-		"SettingsResetMessage": "Beállítások\ntörölve!",
 		"NoAccelerometerMessage": "Nincs gyorsulásmérő!",
 		"NoPowerDeliveryMessage": "Nincs USB-PD IC!",
 		"LockingKeysString": "LEZÁRVA",
 		"UnlockingKeysString": "FELOLDVA",
 		"WarningKeysLockedString": "!LEZÁRVA!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Beállítások",
+			"törölve!"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "J",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "G",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"0",
+		"SettingOffChar": "0",
 		"SettingStartSolderingChar": "F",
 		"SettingStartSleepChar": "Z",
 		"SettingStartSleepOffChar": "S",

--- a/Translations/translation_HU.json
+++ b/Translations/translation_HU.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Telj: ",
 		"OffString": "Ki",
 		"ResetOKMessage": "Törlés OK",
-		"YourGainMessage": "Erősítés:",
-		"NoAccelerometerMessage": "Nincs gyorsulásmérő!",
-		"NoPowerDeliveryMessage": "Nincs USB-PD IC!",
-		"LockingKeysString": "LEZÁRVA",
-		"UnlockingKeysString": "FELOLDVA",
-		"WarningKeysLockedString": "!LEZÁRVA!"
+		"YourGainMessage": "Erősítés:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Beállítások",
 			"törölve!"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"Nincs",
+			"gyorsulásmérő!"
+		],
+		"NoPowerDeliveryMessage": [
+			"Nincs USB-PD IC!",
+			""
+		],
+		"LockingKeysString": "LEZÁRVA",
+		"UnlockingKeysString": "FELOLDVA",
+		"WarningKeysLockedString": "!LEZÁRVA!"
 	},
 	"characters": {
 		"SettingRightChar": "J",

--- a/Translations/translation_HU.json
+++ b/Translations/translation_HU.json
@@ -21,10 +21,13 @@
 		"TipDisconnectedString": "PÁKA LEVÉVE",
 		"SolderingAdvancedPowerPrompt": "Telj: ",
 		"OffString": "Ki",
-		"ResetOKMessage": "Törlés OK",
 		"YourGainMessage": "Erősítés:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": [
+			"Törlés OK",
+			""
+		],
 		"SettingsResetMessage": [
 			"Beállítások",
 			"törölve!"

--- a/Translations/translation_IT.json
+++ b/Translations/translation_IT.json
@@ -23,12 +23,17 @@
 		"OffString": "OFF",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Guad.: ",
-		"SettingsResetMessage": "Reset effettuato",
 		"NoAccelerometerMessage": "Accelerometro\nnon rilevato",
 		"NoPowerDeliveryMessage": "USB-PD non\ndisponibile",
 		"LockingKeysString": "Blocc.",
 		"UnlockingKeysString": "Sblocc.",
 		"WarningKeysLockedString": "BLOCCATO"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Reset effettuato",
+			""
+		]
 	},
 	"characters": {
 		"SettingRightChar": "D",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "V",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "S",
 		"SettingStartSleepChar": "R",
 		"SettingStartSleepOffChar": "A",

--- a/Translations/translation_IT.json
+++ b/Translations/translation_IT.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "PUNTA ASSENTE",
 		"SolderingAdvancedPowerPrompt": "Potenz:",
 		"OffString": "OFF",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Guad.: "
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Reset effettuato",
 			""

--- a/Translations/translation_IT.json
+++ b/Translations/translation_IT.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Potenz:",
 		"OffString": "OFF",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Guad.: ",
-		"NoAccelerometerMessage": "Accelerometro\nnon rilevato",
-		"NoPowerDeliveryMessage": "USB-PD non\ndisponibile",
-		"LockingKeysString": "Blocc.",
-		"UnlockingKeysString": "Sblocc.",
-		"WarningKeysLockedString": "BLOCCATO"
+		"YourGainMessage": "Guad.: "
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Reset effettuato",
 			""
-		]
+		],
+		"NoAccelerometerMessage": [
+			"Accelerometro",
+			"non rilevato"
+		],
+		"NoPowerDeliveryMessage": [
+			"USB-PD non",
+			"disponibile"
+		],
+		"LockingKeysString": "Blocc.",
+		"UnlockingKeysString": "Sblocc.",
+		"WarningKeysLockedString": "BLOCCATO"
 	},
 	"characters": {
 		"SettingRightChar": "D",

--- a/Translations/translation_LT.json
+++ b/Translations/translation_LT.json
@@ -23,12 +23,17 @@
 		"OffString": "Išj",
 		"ResetOKMessage": "Atstatytas OK",
 		"YourGainMessage": "Greitis:",
-		"SettingsResetMessage": "Nust. atstatyti!",
 		"NoAccelerometerMessage": "Nerastas\nakselerometras!",
 		"NoPowerDeliveryMessage": "Nerastas\nUSB-PD IC !",
 		"LockingKeysString": " UŽRAKIN",
 		"UnlockingKeysString": "ATRAKIN",
 		"WarningKeysLockedString": "!UŽRAK!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Nust. atstatyti!",
+			""
+		]
 	},
 	"characters": {
 		"SettingRightChar": "D",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "G",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"I",
+		"SettingOffChar": "I",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "M",
 		"SettingStartSleepOffChar": "K",

--- a/Translations/translation_LT.json
+++ b/Translations/translation_LT.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Galia: ",
 		"OffString": "Išj",
 		"ResetOKMessage": "Atstatytas OK",
-		"YourGainMessage": "Greitis:",
-		"NoAccelerometerMessage": "Nerastas\nakselerometras!",
-		"NoPowerDeliveryMessage": "Nerastas\nUSB-PD IC !",
-		"LockingKeysString": " UŽRAKIN",
-		"UnlockingKeysString": "ATRAKIN",
-		"WarningKeysLockedString": "!UŽRAK!"
+		"YourGainMessage": "Greitis:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Nust. atstatyti!",
 			""
-		]
+		],
+		"NoAccelerometerMessage": [
+			"Nerastas",
+			"akselerometras!"
+		],
+		"NoPowerDeliveryMessage": [
+			"Nerastas",
+			"USB-PD IC !"
+		],
+		"LockingKeysString": " UŽRAKIN",
+		"UnlockingKeysString": "ATRAKIN",
+		"WarningKeysLockedString": "!UŽRAK!"
 	},
 	"characters": {
 		"SettingRightChar": "D",

--- a/Translations/translation_LT.json
+++ b/Translations/translation_LT.json
@@ -21,10 +21,13 @@
 		"TipDisconnectedString": "NĖRA ANTGALIO",
 		"SolderingAdvancedPowerPrompt": "Galia: ",
 		"OffString": "Išj",
-		"ResetOKMessage": "Atstatytas OK",
 		"YourGainMessage": "Greitis:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": [
+			"Atstatytas OK",
+			""
+		],
 		"SettingsResetMessage": [
 			"Nust. atstatyti!",
 			""

--- a/Translations/translation_NL.json
+++ b/Translations/translation_NL.json
@@ -23,12 +23,17 @@
 		"OffString": "Uit",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Niveau:",
-		"SettingsResetMessage": "Instellingen zijn\ngereset!",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " GEBLOKKEERD",
 		"UnlockingKeysString": "GEDEBLOKKEERD",
 		"WarningKeysLockedString": "!GEBLOKKEERD!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Instellingen",
+			"zijn gereset!"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "R",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "F",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",

--- a/Translations/translation_NL.json
+++ b/Translations/translation_NL.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "PUNT LOSGEKOPPELT",
 		"SolderingAdvancedPowerPrompt": "Vermogen: ",
 		"OffString": "Uit",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Niveau:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Instellingen",
 			"zijn gereset!"

--- a/Translations/translation_NL.json
+++ b/Translations/translation_NL.json
@@ -22,17 +22,32 @@
 		"SolderingAdvancedPowerPrompt": "Vermogen: ",
 		"OffString": "Uit",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Niveau:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
-		"LockingKeysString": " GEBLOKKEERD",
-		"UnlockingKeysString": "GEDEBLOKKEERD",
-		"WarningKeysLockedString": "!GEBLOKKEERD!"
+		"YourGainMessage": "Niveau:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Instellingen",
 			"zijn gereset!"
+		],
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": [
+			" GEBLOKKEERD",
+			""
+		],
+		"UnlockingKeysString": [
+			"GEDEBLOKKEERD",
+			""
+		],
+		"WarningKeysLockedString": [
+			"!GEBLOKKEERD!",
+			""
 		]
 	},
 	"characters": {

--- a/Translations/translation_NL_BE.json
+++ b/Translations/translation_NL_BE.json
@@ -23,12 +23,17 @@
 		"OffString": "Uit",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
-		"SettingsResetMessage": "Settings were\nreset!",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Settings were",
+			"reset!"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "R",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "S",
 		"SettingSlowChar": "T",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",

--- a/Translations/translation_NL_BE.json
+++ b/Translations/translation_NL_BE.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "Punt ONTKOPPELD",
 		"SolderingAdvancedPowerPrompt": "Vermogen: ",
 		"OffString": "Uit",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"

--- a/Translations/translation_NL_BE.json
+++ b/Translations/translation_NL_BE.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Vermogen: ",
 		"OffString": "Uit",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Your gain:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
-		"LockingKeysString": " LOCKED",
-		"UnlockingKeysString": "UNLOCKED",
-		"WarningKeysLockedString": "!LOCKED!"
+		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "R",

--- a/Translations/translation_NO.json
+++ b/Translations/translation_NO.json
@@ -23,12 +23,17 @@
 		"OffString": "Av",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
-		"SettingsResetMessage": "Settings were\nreset!",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Settings were",
+			"reset!"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "H",

--- a/Translations/translation_NO.json
+++ b/Translations/translation_NO.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Effekt: ",
 		"OffString": "Av",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Your gain:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
-		"LockingKeysString": " LOCKED",
-		"UnlockingKeysString": "UNLOCKED",
-		"WarningKeysLockedString": "!LOCKED!"
+		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "H",
@@ -42,7 +48,7 @@
 		"SettingFastChar": "H",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "L",
 		"SettingStartSleepChar": "D",
 		"SettingStartSleepOffChar": "O",

--- a/Translations/translation_NO.json
+++ b/Translations/translation_NO.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "SPISS FRAKOBLET",
 		"SolderingAdvancedPowerPrompt": "Effekt: ",
 		"OffString": "Av",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"

--- a/Translations/translation_NO.json
+++ b/Translations/translation_NO.json
@@ -116,7 +116,7 @@
 		},
 		"SleepTimeout": {
 			"text2": [
-				"",
+				"DTid",
 				""
 			],
 			"desc": "Tid før dvale <Minutter/Sekunder"

--- a/Translations/translation_PL.json
+++ b/Translations/translation_PL.json
@@ -24,12 +24,17 @@
 		"OffString": "Wył",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Us.zysk:",
-		"SettingsResetMessage": "Ust. zresetowane",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " ZABLOK.",
 		"UnlockingKeysString": "ODBLOK.",
 		"WarningKeysLockedString": "!ZABLOK!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Ust. zresetowane",
+			""
+		]
 	},
 	"characters": {
 		"SettingRightChar": "P",
@@ -38,7 +43,7 @@
 		"SettingFastChar": "S",
 		"SettingSlowChar": "W",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "Z",
 		"SettingStartSleepOffChar": "O",

--- a/Translations/translation_PL.json
+++ b/Translations/translation_PL.json
@@ -22,10 +22,10 @@
 		"TipDisconnectedString": "GROT ODŁĄCZONY",
 		"SolderingAdvancedPowerPrompt": "Moc: ",
 		"OffString": "Wył",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Us.zysk:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Ust. zresetowane",
 			""

--- a/Translations/translation_PL.json
+++ b/Translations/translation_PL.json
@@ -23,18 +23,24 @@
 		"SolderingAdvancedPowerPrompt": "Moc: ",
 		"OffString": "Wył",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Us.zysk:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
-		"LockingKeysString": " ZABLOK.",
-		"UnlockingKeysString": "ODBLOK.",
-		"WarningKeysLockedString": "!ZABLOK!"
+		"YourGainMessage": "Us.zysk:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Ust. zresetowane",
 			""
-		]
+		],
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": " ZABLOK.",
+		"UnlockingKeysString": "ODBLOK.",
+		"WarningKeysLockedString": "!ZABLOK!"
 	},
 	"characters": {
 		"SettingRightChar": "P",

--- a/Translations/translation_PT.json
+++ b/Translations/translation_PT.json
@@ -23,12 +23,17 @@
 		"OffString": "Off",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
-		"SettingsResetMessage": "Settings were\nreset!",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Settings were",
+			"reset!"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "D",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "R",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",

--- a/Translations/translation_PT.json
+++ b/Translations/translation_PT.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Power: ",
 		"OffString": "Off",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Your gain:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
-		"LockingKeysString": " LOCKED",
-		"UnlockingKeysString": "UNLOCKED",
-		"WarningKeysLockedString": "!LOCKED!"
+		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "D",

--- a/Translations/translation_PT.json
+++ b/Translations/translation_PT.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "SEM PONTA",
 		"SolderingAdvancedPowerPrompt": "Power: ",
 		"OffString": "Off",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"

--- a/Translations/translation_RU.json
+++ b/Translations/translation_RU.json
@@ -23,12 +23,17 @@
 		"OffString": "Выкл.",
 		"ResetOKMessage": "Сброс OK",
 		"YourGainMessage": "Прирост:",
-		"SettingsResetMessage": "Настройки\nсброшены!",
 		"NoAccelerometerMessage": "Не определен\nакселерометр!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Настройки",
+			"сброшены!"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "П",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "Б",
 		"SettingSlowChar": "М",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "П",
 		"SettingStartSleepChar": "О",
 		"SettingStartSleepOffChar": "К",

--- a/Translations/translation_RU.json
+++ b/Translations/translation_RU.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "ЖАЛО ОТСОЕДИНЕНО",
 		"SolderingAdvancedPowerPrompt": "Питание: ",
 		"OffString": "Выкл.",
-		"ResetOKMessage": "Сброс OK",
 		"YourGainMessage": "Прирост:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Сброс OK",
 		"SettingsResetMessage": [
 			"Настройки",
 			"сброшены!"

--- a/Translations/translation_RU.json
+++ b/Translations/translation_RU.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Питание: ",
 		"OffString": "Выкл.",
 		"ResetOKMessage": "Сброс OK",
-		"YourGainMessage": "Прирост:",
-		"NoAccelerometerMessage": "Не определен\nакселерометр!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
-		"LockingKeysString": " LOCKED",
-		"UnlockingKeysString": "UNLOCKED",
-		"WarningKeysLockedString": "!LOCKED!"
+		"YourGainMessage": "Прирост:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Настройки",
 			"сброшены!"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"Не определен",
+			"акселерометр!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "П",

--- a/Translations/translation_SK.json
+++ b/Translations/translation_SK.json
@@ -23,12 +23,17 @@
 		"OffString": "Vyp",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Zisk:",
-		"SettingsResetMessage": "Tov. nas. obnov.",
 		"NoAccelerometerMessage": "Bez pohyb. senz.",
 		"NoPowerDeliveryMessage": "Chýba čip USB-PD",
 		"LockingKeysString": " ZABLOK.",
 		"UnlockingKeysString": "ODBLOK.",
 		"WarningKeysLockedString": "!ZABLOK!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Tov. nas. obnov.",
+			""
+		]
 	},
 	"characters": {
 		"SettingRightChar": "P",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "R",
 		"SettingSlowChar": "P",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"Z",
+		"SettingOffChar": "Z",
 		"SettingStartSolderingChar": "S",
 		"SettingStartSleepChar": "K",
 		"SettingStartSleepOffChar": "O",

--- a/Translations/translation_SK.json
+++ b/Translations/translation_SK.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Výkon: ",
 		"OffString": "Vyp",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Zisk:",
-		"NoAccelerometerMessage": "Bez pohyb. senz.",
-		"NoPowerDeliveryMessage": "Chýba čip USB-PD",
-		"LockingKeysString": " ZABLOK.",
-		"UnlockingKeysString": "ODBLOK.",
-		"WarningKeysLockedString": "!ZABLOK!"
+		"YourGainMessage": "Zisk:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Tov. nas. obnov.",
 			""
-		]
+		],
+		"NoAccelerometerMessage": [
+			"Bez pohyb. senz.",
+			""
+		],
+		"NoPowerDeliveryMessage": [
+			"Chýba čip USB-PD",
+			""
+		],
+		"LockingKeysString": " ZABLOK.",
+		"UnlockingKeysString": "ODBLOK.",
+		"WarningKeysLockedString": "!ZABLOK!"
 	},
 	"characters": {
 		"SettingRightChar": "P",

--- a/Translations/translation_SK.json
+++ b/Translations/translation_SK.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "HROT ODPOJENÝ",
 		"SolderingAdvancedPowerPrompt": "Výkon: ",
 		"OffString": "Vyp",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Zisk:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Tov. nas. obnov.",
 			""

--- a/Translations/translation_SL.json
+++ b/Translations/translation_SL.json
@@ -23,12 +23,17 @@
 		"OffString": "Off",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Ojačenje",
-		"SettingsResetMessage": "Nastavitve OK!",
 		"NoAccelerometerMessage": "Ni pospeševalnik",
 		"NoPowerDeliveryMessage": "Ni USB-PD čipa!",
 		"LockingKeysString": "ZAKLENJ.",
 		"UnlockingKeysString": "ODKLENJ.",
 		"WarningKeysLockedString": "ZAKLENJ."
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Nastavitve OK!",
+			""
+		]
 	},
 	"characters": {
 		"SettingRightChar": "D",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "H",
 		"SettingSlowChar": "P",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"U",
+		"SettingOffChar": "U",
 		"SettingStartSolderingChar": "S",
 		"SettingStartSleepChar": "Z",
 		"SettingStartSleepOffChar": "V",

--- a/Translations/translation_SL.json
+++ b/Translations/translation_SL.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "NI KONICE",
 		"SolderingAdvancedPowerPrompt": "Moč: ",
 		"OffString": "Off",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Ojačenje"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Nastavitve OK!",
 			""

--- a/Translations/translation_SL.json
+++ b/Translations/translation_SL.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Moč: ",
 		"OffString": "Off",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Ojačenje",
-		"NoAccelerometerMessage": "Ni pospeševalnik",
-		"NoPowerDeliveryMessage": "Ni USB-PD čipa!",
-		"LockingKeysString": "ZAKLENJ.",
-		"UnlockingKeysString": "ODKLENJ.",
-		"WarningKeysLockedString": "ZAKLENJ."
+		"YourGainMessage": "Ojačenje"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Nastavitve OK!",
 			""
-		]
+		],
+		"NoAccelerometerMessage": [
+			"Ni pospeševalnik",
+			""
+		],
+		"NoPowerDeliveryMessage": [
+			"Ni USB-PD čipa!",
+			""
+		],
+		"LockingKeysString": "ZAKLENJ.",
+		"UnlockingKeysString": "ODKLENJ.",
+		"WarningKeysLockedString": "ZAKLENJ."
 	},
 	"characters": {
 		"SettingRightChar": "D",

--- a/Translations/translation_SR_CYRL.json
+++ b/Translations/translation_SR_CYRL.json
@@ -23,12 +23,17 @@
 		"OffString": "Иск",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
-		"SettingsResetMessage": "Settings were\nreset!",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Settings were",
+			"reset!"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "Д",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "Б",
 		"SettingSlowChar": "С",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",

--- a/Translations/translation_SR_CYRL.json
+++ b/Translations/translation_SR_CYRL.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "ВРХ НИЈЕ СПОЈЕН",
 		"SolderingAdvancedPowerPrompt": "Снага: ",
 		"OffString": "Иск",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"

--- a/Translations/translation_SR_CYRL.json
+++ b/Translations/translation_SR_CYRL.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Снага: ",
 		"OffString": "Иск",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Your gain:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
-		"LockingKeysString": " LOCKED",
-		"UnlockingKeysString": "UNLOCKED",
-		"WarningKeysLockedString": "!LOCKED!"
+		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "Д",

--- a/Translations/translation_SR_LATN.json
+++ b/Translations/translation_SR_LATN.json
@@ -23,12 +23,17 @@
 		"OffString": "Isk",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
-		"SettingsResetMessage": "Settings were\nreset!",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Settings were",
+			"reset!"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "D",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "B",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",

--- a/Translations/translation_SR_LATN.json
+++ b/Translations/translation_SR_LATN.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Snaga: ",
 		"OffString": "Isk",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Your gain:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
-		"LockingKeysString": " LOCKED",
-		"UnlockingKeysString": "UNLOCKED",
-		"WarningKeysLockedString": "!LOCKED!"
+		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "D",

--- a/Translations/translation_SR_LATN.json
+++ b/Translations/translation_SR_LATN.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "VRH NIJE SPOJEN",
 		"SolderingAdvancedPowerPrompt": "Snaga: ",
 		"OffString": "Isk",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"

--- a/Translations/translation_SV.json
+++ b/Translations/translation_SV.json
@@ -23,12 +23,17 @@
 		"OffString": "Av",
 		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:",
-		"SettingsResetMessage": "Settings were\nreset!",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": " LOCKED",
 		"UnlockingKeysString": "UNLOCKED",
 		"WarningKeysLockedString": "!LOCKED!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Settings were",
+			"reset!"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "H",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "S",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",

--- a/Translations/translation_SV.json
+++ b/Translations/translation_SV.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Ström: ",
 		"OffString": "Av",
 		"ResetOKMessage": "Reset OK",
-		"YourGainMessage": "Your gain:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
-		"LockingKeysString": " LOCKED",
-		"UnlockingKeysString": "UNLOCKED",
-		"WarningKeysLockedString": "!LOCKED!"
+		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": " LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "H",

--- a/Translations/translation_SV.json
+++ b/Translations/translation_SV.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "SPETS URTAGEN",
 		"SolderingAdvancedPowerPrompt": "Ström: ",
 		"OffString": "Av",
-		"ResetOKMessage": "Reset OK",
 		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Reset OK",
 		"SettingsResetMessage": [
 			"Settings were",
 			"reset!"

--- a/Translations/translation_TR.json
+++ b/Translations/translation_TR.json
@@ -23,9 +23,14 @@
 		"OffString": "Kapalı",
 		"ResetOKMessage": "Sıfırlama Tamam",
 		"YourGainMessage": "Kazancınız:",
-		"SettingsResetMessage": "Ayarlar Sıfırlandı",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Ayarlar",
+			"Sıfırlandı"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "R",
@@ -34,7 +39,7 @@
 		"SettingFastChar": "F",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"O",
+		"SettingOffChar": "O",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",
 		"SettingStartSleepOffChar": "O",

--- a/Translations/translation_TR.json
+++ b/Translations/translation_TR.json
@@ -21,10 +21,13 @@
 		"TipDisconnectedString": "UÇ ÇIKARILDI",
 		"SolderingAdvancedPowerPrompt": "Güç: ",
 		"OffString": "Kapalı",
-		"ResetOKMessage": "Sıfırlama Tamam",
 		"YourGainMessage": "Kazancınız:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": [
+			"Sıfırlama Tamam",
+			""
+		],
 		"SettingsResetMessage": [
 			"Ayarlar",
 			"Sıfırlandı"

--- a/Translations/translation_TR.json
+++ b/Translations/translation_TR.json
@@ -22,15 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Güç: ",
 		"OffString": "Kapalı",
 		"ResetOKMessage": "Sıfırlama Tamam",
-		"YourGainMessage": "Kazancınız:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!"
+		"YourGainMessage": "Kazancınız:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Ayarlar",
 			"Sıfırlandı"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
+		"LockingKeysString": "LOCKED",
+		"UnlockingKeysString": "UNLOCKED",
+		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
 		"SettingRightChar": "R",

--- a/Translations/translation_UK.json
+++ b/Translations/translation_UK.json
@@ -23,12 +23,17 @@
 		"OffString": "Вимк",
 		"ResetOKMessage": "Скид. OK",
 		"YourGainMessage": "Приріст:",
-		"SettingsResetMessage": "Налаштування\nскинуті!",
 		"NoAccelerometerMessage": "Акселерометр\nне виявлено!",
 		"NoPowerDeliveryMessage": "USB-PD IC\nне виявлено!",
 		"LockingKeysString": " ЗАБЛОК.",
 		"UnlockingKeysString": "РОЗБЛОК.",
 		"WarningKeysLockedString": "!ЗАБЛОК!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": [
+			"Налаштування",
+			"скинуті!"
+		]
 	},
 	"characters": {
 		"SettingRightChar": "П",
@@ -37,7 +42,7 @@
 		"SettingFastChar": "Ш",
 		"SettingSlowChar": "П",
 		"SettingMediumChar": "M",
-		"SettingOffChar":"B",
+		"SettingOffChar": "B",
 		"SettingStartSolderingChar": "П",
 		"SettingStartSleepChar": "О",
 		"SettingStartSleepOffChar": "К",

--- a/Translations/translation_UK.json
+++ b/Translations/translation_UK.json
@@ -22,18 +22,24 @@
 		"SolderingAdvancedPowerPrompt": "Живлення: ",
 		"OffString": "Вимк",
 		"ResetOKMessage": "Скид. OK",
-		"YourGainMessage": "Приріст:",
-		"NoAccelerometerMessage": "Акселерометр\nне виявлено!",
-		"NoPowerDeliveryMessage": "USB-PD IC\nне виявлено!",
-		"LockingKeysString": " ЗАБЛОК.",
-		"UnlockingKeysString": "РОЗБЛОК.",
-		"WarningKeysLockedString": "!ЗАБЛОК!"
+		"YourGainMessage": "Приріст:"
 	},
 	"messagesWarn": {
 		"SettingsResetMessage": [
 			"Налаштування",
 			"скинуті!"
-		]
+		],
+		"NoAccelerometerMessage": [
+			"Акселерометр",
+			"не виявлено!"
+		],
+		"NoPowerDeliveryMessage": [
+			"USB-PD IC",
+			"не виявлено!"
+		],
+		"LockingKeysString": " ЗАБЛОК.",
+		"UnlockingKeysString": "РОЗБЛОК.",
+		"WarningKeysLockedString": "!ЗАБЛОК!"
 	},
 	"characters": {
 		"SettingRightChar": "П",

--- a/Translations/translation_UK.json
+++ b/Translations/translation_UK.json
@@ -21,10 +21,10 @@
 		"TipDisconnectedString": "Жало вимкнено!",
 		"SolderingAdvancedPowerPrompt": "Живлення: ",
 		"OffString": "Вимк",
-		"ResetOKMessage": "Скид. OK",
 		"YourGainMessage": "Приріст:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "Скид. OK",
 		"SettingsResetMessage": [
 			"Налаштування",
 			"скинуті!"

--- a/Translations/translation_YUE_HK.json
+++ b/Translations/translation_YUE_HK.json
@@ -24,12 +24,14 @@
 		"OffString": "關",
 		"ResetOKMessage": "已重設！",
 		"YourGainMessage": "Your gain:",
-		"SettingsResetMessage": "\n設定已被重設！",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": "已鎖定",
 		"UnlockingKeysString": "已解除鎖定",
 		"WarningKeysLockedString": "!撳掣鎖定!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": "設定已被重設！"
 	},
 	"characters": {
 		"SettingRightChar": "右",
@@ -38,7 +40,7 @@
 		"SettingFastChar": "快",
 		"SettingSlowChar": "慢",
 		"SettingMediumChar": "中",
-		"SettingOffChar":"關",
+		"SettingOffChar": "關",
 		"SettingStartSolderingChar": "焊",
 		"SettingStartSleepChar": "待",
 		"SettingStartSleepOffChar": "室",

--- a/Translations/translation_YUE_HK.json
+++ b/Translations/translation_YUE_HK.json
@@ -62,243 +62,141 @@
 	},
 	"menuGroups": {
 		"PowerMenu": {
-			"text2": [
-				"",
-				"電源設定"
-			],
+			"text2": "電源設定",
 			"desc": "電源設定"
 		},
 		"SolderingMenu": {
-			"text2": [
-				"",
-				"焊接設定"
-			],
+			"text2": "焊接設定",
 			"desc": "焊接設定"
 		},
 		"PowerSavingMenu": {
-			"text2": [
-				"",
-				"待機設定"
-			],
+			"text2": "待機設定",
 			"desc": "自動待機慳電設定"
 		},
 		"UIMenu": {
-			"text2": [
-				"",
-				"使用者介面"
-			],
+			"text2": "使用者介面",
 			"desc": "使用者介面設定"
 		},
 		"AdvancedMenu": {
-			"text2": [
-				"",
-				"進階設定"
-			],
+			"text2": "進階設定",
 			"desc": "進階設定"
 		}
 	},
 	"menuOptions": {
 		"DCInCutoff": {
-			"text2": [
-				"",
-				"電源"
-			],
+			"text2": "電源",
 			"desc": "輸入電源；設定自動停機電壓 <DC 10V> <S 鋰電池，以每粒3.3V計算；依個設定會停用功率限制>"
 		},
 		"SleepTemperature": {
-			"text2": [
-				"",
-				"待機温度"
-			],
+			"text2": "待機温度",
 			"desc": "喺待機模式時嘅辣雞咀温度"
 		},
 		"SleepTimeout": {
-			"text2": [
-				"",
-				"待機延時"
-			],
+			"text2": "待機延時",
 			"desc": "自動進入待機模式前嘅閒置等候時間 <S=秒 | M=分鐘>"
 		},
 		"ShutdownTimeout": {
-			"text2": [
-				"",
-				"自動熄機"
-			],
+			"text2": "自動熄機",
 			"desc": "自動熄機前嘅閒置等候時間 <M=分鐘>"
 		},
 		"MotionSensitivity": {
-			"text2": [
-				"",
-				"動作敏感度"
-			],
+			"text2": "動作敏感度",
 			"desc": "0=停用 | 1=最低敏感度 | ... | 9=最高敏感度"
 		},
 		"TemperatureUnit": {
-			"text2": [
-				"",
-				"温度單位"
-			],
+			"text2": "温度單位",
 			"desc": "C=攝氏 | F=華氏"
 		},
 		"AdvancedIdle": {
-			"text2": [
-				"",
-				"詳細閒置畫面"
-			],
+			"text2": "詳細閒置畫面",
 			"desc": "喺閒置畫面以英文細字顯示詳細嘅資料"
 		},
 		"DisplayRotation": {
-			"text2": [
-				"",
-				"畫面方向"
-			],
+			"text2": "畫面方向",
 			"desc": "A=自動 | L=使用左手 | R=使用右手"
 		},
 		"BoostTemperature": {
-			"text2": [
-				"",
-				"增熱温度"
-			],
+			"text2": "增熱温度",
 			"desc": "喺增熱模式時使用嘅温度"
 		},
 		"AutoStart": {
-			"text2": [
-				"",
-				"自動啓用"
-			],
+			"text2": "自動啓用",
 			"desc": "開機時自動啓用 <無=停用 | 焊=焊接模式 | 待=待機模式 | 室=室温待機>"
 		},
 		"CooldownBlink": {
-			"text2": [
-				"",
-				"降温時閃爍"
-			],
+			"text2": "降温時閃爍",
 			"desc": "停止加熱之後，當辣雞咀仲係熱嗰陣閃爍畫面"
 		},
 		"TemperatureCalibration": {
-			"text2": [
-				"",
-				"温度校正？"
-			],
+			"text2": "温度校正？",
 			"desc": "開始校正辣雞咀温度位移"
 		},
 		"SettingsReset": {
-			"text2": [
-				"",
-				"全部重設？"
-			],
+			"text2": "全部重設？",
 			"desc": "將所有設定重設到預設值"
 		},
 		"VoltageCalibration": {
-			"text2": [
-				"",
-				"輸入電壓校正？"
-			],
+			"text2": "輸入電壓校正？",
 			"desc": "開始校正VIN輸入電壓 <長撳以退出>"
 		},
 		"AdvancedSoldering": {
-			"text2": [
-				"",
-				"詳細焊接畫面"
-			],
+			"text2": "詳細焊接畫面",
 			"desc": "喺焊接模式畫面以英文細字顯示詳細嘅資料"
 		},
 		"ScrollingSpeed": {
-			"text2": [
-				"",
-				"捲動速度"
-			],
+			"text2": "捲動速度",
 			"desc": "解說文字嘅捲動速度"
 		},
 		"QCMaxVoltage": {
-			"text2": [
-				"",
-				"QC電壓"
-			],
+			"text2": "QC電壓",
 			"desc": "使用QC電源時請求嘅最高目標電壓"
 		},
 		"PowerLimit": {
-			"text2": [
-				"",
-				"功率限制"
-			],
+			"text2": "功率限制",
 			"desc": "限制辣雞可用嘅最大功率 <W=watt（火）>"
 		},
 		"ReverseButtonTempChange": {
-			"text2": [
-				"",
-				"反轉加減掣"
-			],
+			"text2": "反轉加減掣",
 			"desc": "反轉調校温度時加減掣嘅方向"
 		},
 		"TempChangeShortStep": {
-			"text2": [
-				"",
-				"温度調整 短"
-			],
+			"text2": "温度調整 短",
 			"desc": "調校温度時短撳一下嘅温度變幅"
 		},
 		"TempChangeLongStep": {
-			"text2": [
-				"",
-				"温度調整 長"
-			],
+			"text2": "温度調整 長",
 			"desc": "調校温度時長撳嘅温度變幅"
 		},
 		"PowerPulsePower": {
-			"text2": [
-				"",
-				"電源脈衝"
-			],
+			"text2": "電源脈衝",
 			"desc": "為保持電源喚醒而通電所用嘅功率 <watt（火）>"
 		},
 		"HallEffSensitivity": {
-			"text2": [
-				"",
-				"磁場敏感度"
-			],
+			"text2": "磁場敏感度",
 			"desc": "磁場感應器用嚟啓動待機模式嘅敏感度 <關=停用 | 低=最低敏感度 | 中=中等敏感度 | 高=最高敏感度>"
 		},
 		"LockingMode": {
-			"text2": [
-				"",
-				"撳掣鎖定"
-			],
+			"text2": "撳掣鎖定",
 			"desc": "喺焊接模式時，同時長撳兩粒掣啓用撳掣鎖定 <無=停用 | 增=鎖定增熱模式 | 全=鎖定全部>"
 		},
 		"MinVolCell": {
-			"text2": [
-				"",
-				"最低電壓"
-			],
+			"text2": "最低電壓",
 			"desc": "每粒電池嘅最低可用電壓 <伏特> <3S: 3.0V - 3.7V, 4/5/6S: 2.4V - 3.7V>"
 		},
 		"AnimLoop": {
-			"text2": [
-				"",
-				"動畫循環"
-			],
+			"text2": "動畫循環",
 			"desc": "循環顯示功能表圖示動畫"
 		},
 		"AnimSpeed": {
-			"text2": [
-				"",
-				"動畫速度"
-			],
+			"text2": "動畫速度",
 			"desc": "功能表圖示動畫嘅速度 <關=不顯示動畫 | 慢=慢速 | 中=中速 | 快=快速>"
 		},
 		"PowerPulseWait": {
-			"text2": [
-				"",
-				"電源脈衝間隔"
-			],
+			"text2": "電源脈衝間隔",
 			"desc": "為保持電源喚醒，每次通電之間嘅間隔時間 <x2.5s（秒）>"
 		},
 		"PowerPulseDuration": {
-			"text2": [
-				"",
-				"電源脈衝時長"
-			],
+			"text2": "電源脈衝時長",
 			"desc": "為保持電源喚醒，每次通電脈衝嘅時間長度 <x250ms（亳秒）>"
 		}
 	}

--- a/Translations/translation_YUE_HK.json
+++ b/Translations/translation_YUE_HK.json
@@ -22,10 +22,10 @@
 		"TipDisconnectedString": "NO TIP",
 		"SolderingAdvancedPowerPrompt": "Power: ",
 		"OffString": "關",
-		"ResetOKMessage": "已重設！",
 		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "已重設！",
 		"SettingsResetMessage": "設定已被重設！",
 		"NoAccelerometerMessage": [
 			"No accelerometer",

--- a/Translations/translation_YUE_HK.json
+++ b/Translations/translation_YUE_HK.json
@@ -23,15 +23,21 @@
 		"SolderingAdvancedPowerPrompt": "Power: ",
 		"OffString": "關",
 		"ResetOKMessage": "已重設！",
-		"YourGainMessage": "Your gain:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
+		"YourGainMessage": "Your gain:"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": "設定已被重設！",
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
 		"LockingKeysString": "已鎖定",
 		"UnlockingKeysString": "已解除鎖定",
 		"WarningKeysLockedString": "!撳掣鎖定!"
-	},
-	"messagesWarn": {
-		"SettingsResetMessage": "設定已被重設！"
 	},
 	"characters": {
 		"SettingRightChar": "右",

--- a/Translations/translation_ZH_TW.json
+++ b/Translations/translation_ZH_TW.json
@@ -24,12 +24,14 @@
 		"OffString": "關",
 		"ResetOKMessage": "已重設！",
 		"YourGainMessage": "Your gain:",
-		"SettingsResetMessage": "\n設定已被重設！",
 		"NoAccelerometerMessage": "No accelerometer\ndetected!",
 		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
 		"LockingKeysString": "已鎖定",
 		"UnlockingKeysString": "已解除鎖定",
 		"WarningKeysLockedString": "!按鍵鎖定!"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": "設定已被重設！"
 	},
 	"characters": {
 		"SettingRightChar": "右",
@@ -38,7 +40,7 @@
 		"SettingFastChar": "快",
 		"SettingSlowChar": "慢",
 		"SettingMediumChar": "中",
-		"SettingOffChar":"關",
+		"SettingOffChar": "關",
 		"SettingStartSolderingChar": "焊",
 		"SettingStartSleepChar": "待",
 		"SettingStartSleepOffChar": "室",

--- a/Translations/translation_ZH_TW.json
+++ b/Translations/translation_ZH_TW.json
@@ -23,15 +23,21 @@
 		"SolderingAdvancedPowerPrompt": "Power: ",
 		"OffString": "關",
 		"ResetOKMessage": "已重設！",
-		"YourGainMessage": "Your gain:",
-		"NoAccelerometerMessage": "No accelerometer\ndetected!",
-		"NoPowerDeliveryMessage": "No USB-PD IC\ndetected!",
+		"YourGainMessage": "Your gain:"
+	},
+	"messagesWarn": {
+		"SettingsResetMessage": "設定已被重設！",
+		"NoAccelerometerMessage": [
+			"No accelerometer",
+			"detected!"
+		],
+		"NoPowerDeliveryMessage": [
+			"No USB-PD IC",
+			"detected!"
+		],
 		"LockingKeysString": "已鎖定",
 		"UnlockingKeysString": "已解除鎖定",
 		"WarningKeysLockedString": "!按鍵鎖定!"
-	},
-	"messagesWarn": {
-		"SettingsResetMessage": "設定已被重設！"
 	},
 	"characters": {
 		"SettingRightChar": "右",

--- a/Translations/translation_ZH_TW.json
+++ b/Translations/translation_ZH_TW.json
@@ -22,10 +22,10 @@
 		"TipDisconnectedString": "NO TIP",
 		"SolderingAdvancedPowerPrompt": "Power: ",
 		"OffString": "關",
-		"ResetOKMessage": "已重設！",
 		"YourGainMessage": "Your gain:"
 	},
 	"messagesWarn": {
+		"ResetOKMessage": "已重設！",
 		"SettingsResetMessage": "設定已被重設！",
 		"NoAccelerometerMessage": [
 			"No accelerometer",

--- a/Translations/translation_ZH_TW.json
+++ b/Translations/translation_ZH_TW.json
@@ -62,243 +62,141 @@
 	},
 	"menuGroups": {
 		"PowerMenu": {
-			"text2": [
-				"",
-				"電源設定"
-			],
+			"text2": "電源設定",
 			"desc": "電源設定"
 		},
 		"SolderingMenu": {
-			"text2": [
-				"",
-				"焊接設定"
-			],
+			"text2": "焊接設定",
 			"desc": "焊接設定"
 		},
 		"PowerSavingMenu": {
-			"text2": [
-				"",
-				"待機設定"
-			],
+			"text2": "待機設定",
 			"desc": "自動待機省電設定"
 		},
 		"UIMenu": {
-			"text2": [
-				"",
-				"使用者介面"
-			],
+			"text2": "使用者介面",
 			"desc": "使用者介面設定"
 		},
 		"AdvancedMenu": {
-			"text2": [
-				"",
-				"進階設定"
-			],
+			"text2": "進階設定",
 			"desc": "進階設定"
 		}
 	},
 	"menuOptions": {
 		"DCInCutoff": {
-			"text2": [
-				"",
-				"電源"
-			],
+			"text2": "電源",
 			"desc": "輸入電源；設定自動停機電壓 <DC 10V> <S 鋰電池，以每顆3.3V計算；此設定會停用功率限制>"
 		},
 		"SleepTemperature": {
-			"text2": [
-				"",
-				"待機溫度"
-			],
+			"text2": "待機溫度",
 			"desc": "於待機模式時的鉻鐵頭溫度"
 		},
 		"SleepTimeout": {
-			"text2": [
-				"",
-				"待機延時"
-			],
+			"text2": "待機延時",
 			"desc": "自動進入待機模式前的閒置等候時間 <S=秒 | M=分鐘>"
 		},
 		"ShutdownTimeout": {
-			"text2": [
-				"",
-				"自動關機"
-			],
+			"text2": "自動關機",
 			"desc": "自動關機前的閒置等候時間 <M=分鐘>"
 		},
 		"MotionSensitivity": {
-			"text2": [
-				"",
-				"動作敏感度"
-			],
+			"text2": "動作敏感度",
 			"desc": "0=停用 | 1=最低敏感度 | ... | 9=最高敏感度"
 		},
 		"TemperatureUnit": {
-			"text2": [
-				"",
-				"溫標"
-			],
+			"text2": "溫標",
 			"desc": "C=攝氏 | F=華氏"
 		},
 		"AdvancedIdle": {
-			"text2": [
-				"",
-				"詳細閒置畫面"
-			],
+			"text2": "詳細閒置畫面",
 			"desc": "於閒置畫面以英文小字型顯示詳細資料"
 		},
 		"DisplayRotation": {
-			"text2": [
-				"",
-				"畫面方向"
-			],
+			"text2": "畫面方向",
 			"desc": "A=自動 | L=使用左手 | R=使用右手"
 		},
 		"BoostTemperature": {
-			"text2": [
-				"",
-				"增熱溫度"
-			],
+			"text2": "增熱溫度",
 			"desc": "於增熱模式時使用的溫度"
 		},
 		"AutoStart": {
-			"text2": [
-				"",
-				"自動啟用"
-			],
+			"text2": "自動啟用",
 			"desc": "開機時自動啟用 <無=停用 | 焊=焊接模式 | 待=待機模式 | 室=室溫待機>"
 		},
 		"CooldownBlink": {
-			"text2": [
-				"",
-				"降溫時閃爍"
-			],
+			"text2": "降溫時閃爍",
 			"desc": "停止加熱之後，當鉻鐵頭仍處於高溫時閃爍畫面"
 		},
 		"TemperatureCalibration": {
-			"text2": [
-				"",
-				"溫度校正？"
-			],
+			"text2": "溫度校正？",
 			"desc": "開始校正鉻鐵頭溫度位移"
 		},
 		"SettingsReset": {
-			"text2": [
-				"",
-				"全部重設？"
-			],
+			"text2": "全部重設？",
 			"desc": "將所有設定重設到預設值"
 		},
 		"VoltageCalibration": {
-			"text2": [
-				"",
-				"輸入電壓校正？"
-			],
+			"text2": "輸入電壓校正？",
 			"desc": "開始校正VIN輸入電壓 <長按以退出>"
 		},
 		"AdvancedSoldering": {
-			"text2": [
-				"",
-				"詳細焊接畫面"
-			],
+			"text2": "詳細焊接畫面",
 			"desc": "於焊接模式畫面以英文小字型顯示詳細資料"
 		},
 		"ScrollingSpeed": {
-			"text2": [
-				"",
-				"捲動速度"
-			],
+			"text2": "捲動速度",
 			"desc": "解說文字的捲動速度"
 		},
 		"QCMaxVoltage": {
-			"text2": [
-				"",
-				"QC電壓"
-			],
+			"text2": "QC電壓",
 			"desc": "使用QC電源時請求的最高目標電壓"
 		},
 		"PowerLimit": {
-			"text2": [
-				"",
-				"功率限制"
-			],
+			"text2": "功率限制",
 			"desc": "限制鉻鐵可用的最大功率 <W=watt（瓦特）>"
 		},
 		"ReverseButtonTempChange": {
-			"text2": [
-				"",
-				"調換加減鍵"
-			],
+			"text2": "調換加減鍵",
 			"desc": "調校溫度時調換加減鍵的方向"
 		},
 		"TempChangeShortStep": {
-			"text2": [
-				"",
-				"溫度調整 短"
-			],
+			"text2": "溫度調整 短",
 			"desc": "調校溫度時短按一下的溫度變幅"
 		},
 		"TempChangeLongStep": {
-			"text2": [
-				"",
-				"溫度調整 長"
-			],
+			"text2": "溫度調整 長",
 			"desc": "調校溫度時長按按鍵的溫度變幅"
 		},
 		"PowerPulsePower": {
-			"text2": [
-				"",
-				"電源脈衝"
-			],
+			"text2": "電源脈衝",
 			"desc": "為保持電源喚醒而通電所用的功率 <watt（瓦特）>"
 		},
 		"HallEffSensitivity": {
-			"text2": [
-				"",
-				"磁場敏感度"
-			],
+			"text2": "磁場敏感度",
 			"desc": "磁場感應器用作啟動待機模式的敏感度 <關=停用 | 低=最低敏感度 | 中=中等敏感度 | 高=最高敏感度>"
 		},
 		"LockingMode": {
-			"text2": [
-				"",
-				"按鍵鎖定"
-			],
+			"text2": "按鍵鎖定",
 			"desc": "於焊接模式時，同時長按兩個按鍵啟用按鍵鎖定 <無=停用 | 增=鎖定增熱模式 | 全=鎖定全部>"
 		},
 		"MinVolCell": {
-			"text2": [
-				"",
-				"最低電壓"
-			],
+			"text2": "最低電壓",
 			"desc": "每顆電池的最低可用電壓 <伏特> <3S: 3.0V - 3.7V, 4/5/6S: 2.4V - 3.7V>"
 		},
 		"AnimLoop": {
-			"text2": [
-				"",
-				"動畫循環"
-			],
+			"text2": "動畫循環",
 			"desc": "循環顯示功能表圖示動畫"
 		},
 		"AnimSpeed": {
-			"text2": [
-				"",
-				"動畫速度"
-			],
+			"text2": "動畫速度",
 			"desc": "功能表圖示動畫的速度 <關=不顯示動畫 | 慢=慢速 | 中=中速 | 快=快速>"
 		},
 		"PowerPulseWait": {
-			"text2": [
-				"",
-				"電源脈衝間隔"
-			],
+			"text2": "電源脈衝間隔",
 			"desc": "為保持電源喚醒，每次通電之間的間隔時間 <x2.5s（秒）>"
 		},
 		"PowerPulseDuration": {
-			"text2": [
-				"",
-				"電源脈衝時長"
-			],
+			"text2": "電源脈衝時長",
 			"desc": "為保持電源喚醒，每次通電脈衝的時間長度 <x250ms（亳秒）>"
 		}
 	}

--- a/Translations/translations_def.js
+++ b/Translations/translations_def.js
@@ -91,11 +91,6 @@ var def =
 			"default": "Your Gain"
 		},
 		{
-			"id": "SettingsResetMessage",
-			"maxLen": 16,
-			"default": "Settings were\nreset!"
-		},
-		{
 			"id": "NoAccelerometerMessage",
 			"maxLen": 16,
 			"default": "No accelerometer\ndetected!"
@@ -119,6 +114,11 @@ var def =
 			"id": "WarningKeysLockedString",
 			"maxLen": 8,
 			"default": "LOCKED!"
+		}
+	],
+	"messagesWarn": [
+		{
+			"id": "SettingsResetMessage"
 		}
 	],
 	"characters": [

--- a/Translations/translations_def.js
+++ b/Translations/translations_def.js
@@ -82,16 +82,15 @@ var def =
 			"maxLen": 3
 		},
 		{
-			"id": "ResetOKMessage",
-			"maxLen": 8
-		},
-		{
 			"id": "YourGainMessage",
 			"maxLen": 8,
 			"default": "Your Gain"
 		}
 	],
 	"messagesWarn": [
+		{
+			"id": "ResetOKMessage"
+		},
 		{
 			"id": "SettingsResetMessage"
 		},

--- a/Translations/translations_def.js
+++ b/Translations/translations_def.js
@@ -195,23 +195,28 @@ var def =
 	"menuGroups": [
 		{
 			"id": "PowerMenu",
-			"maxLen": 11
+			"maxLen": 5,
+			"maxLen2": 11
 		},
 		{
 			"id": "SolderingMenu",
-			"maxLen": 11
+			"maxLen": 5,
+			"maxLen2": 11
 		},
 		{
 			"id": "PowerSavingMenu",
-			"maxLen": 11
+			"maxLen": 5,
+			"maxLen2": 11
 		},
 		{
 			"id": "UIMenu",
-			"maxLen": 11
+			"maxLen": 5,
+			"maxLen2": 11
 		},
 		{
 			"id": "AdvancedMenu",
-			"maxLen": 11
+			"maxLen": 5,
+			"maxLen2": 11
 		}
 	],
 	"menuOptions": [

--- a/Translations/translations_def.js
+++ b/Translations/translations_def.js
@@ -89,36 +89,26 @@ var def =
 			"id": "YourGainMessage",
 			"maxLen": 8,
 			"default": "Your Gain"
-		},
-		{
-			"id": "NoAccelerometerMessage",
-			"maxLen": 16,
-			"default": "No accelerometer\ndetected!"
-		},
-		{
-			"id": "NoPowerDeliveryMessage",
-			"maxLen": 16,
-			"default": "No USB-PD IC\ndetected!"
-		},
-		{
-			"id": "LockingKeysString",
-			"maxLen": 8,
-			"default": "LOCKING"
-		},
-		{
-			"id": "UnlockingKeysString",
-			"maxLen": 8,
-			"default": "UNLOCK"
-		},
-		{
-			"id": "WarningKeysLockedString",
-			"maxLen": 8,
-			"default": "LOCKED!"
 		}
 	],
 	"messagesWarn": [
 		{
 			"id": "SettingsResetMessage"
+		},
+		{
+			"id": "NoAccelerometerMessage"
+		},
+		{
+			"id": "NoPowerDeliveryMessage"
+		},
+		{
+			"id": "LockingKeysString"
+		},
+		{
+			"id": "UnlockingKeysString"
+		},
+		{
+			"id": "WarningKeysLockedString"
 		}
 	],
 	"characters": [

--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -267,6 +267,26 @@ void OLED::print(const char *const str, FontStyle fontStyle) {
   }
 }
 
+/**
+ * Prints a static string message designed to use the whole screen, starting
+ * from the top-left corner.
+ *
+ * If the message starts with a newline (`\\x01`), the string starting from
+ * after the newline is printed in the large font. Otherwise, the message
+ * is printed in the small font.
+ *
+ * @param string The string message to be printed
+ */
+void OLED::printWholeScreen(const char *string) {
+  setCursor(0, 0);
+  if (string[0] == '\x01') {
+    // Empty first line means that this uses large font (for CJK).
+    OLED::print(string + 1, FontStyle::LARGE);
+  } else {
+    OLED::print(string, FontStyle::SMALL);
+  }
+}
+
 inline void stripLeaderZeros(char *buffer, uint8_t places) {
   // Removing the leading zero's by swapping them to SymbolSpace
   // Stop 1 short so that we dont blank entire number if its zero

--- a/source/Core/Drivers/OLED.hpp
+++ b/source/Core/Drivers/OLED.hpp
@@ -55,6 +55,7 @@ public:
   static bool    getRotation() { return inLeftHandedMode; }
   static int16_t getCursorX() { return cursor_x; }
   static void    print(const char *string, FontStyle fontStyle); // Draw a string to the current location, with selected font
+  static void    printWholeScreen(const char *string);
   // Set the cursor location by pixels
   static void setCursor(int16_t x, int16_t y) {
     cursor_x = x;

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -12,7 +12,7 @@ extern const uint8_t USER_FONT_12[];
 extern const uint8_t USER_FONT_6x8[];
 extern const bool    HasFahrenheit;
 
-extern const char *SettingsShortNames[][2];
+extern const char *SettingsShortNames[];
 extern const char *SettingsDescriptions[];
 extern const char *SettingsMenuEntries[];
 

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -12,9 +12,9 @@ extern const uint8_t USER_FONT_12[];
 extern const uint8_t USER_FONT_6x8[];
 extern const bool    HasFahrenheit;
 
-extern const char *SettingsShortNames[33][2];
-extern const char *SettingsDescriptions[33];
-extern const char *SettingsMenuEntries[5];
+extern const char *SettingsShortNames[][2];
+extern const char *SettingsDescriptions[];
+extern const char *SettingsMenuEntries[];
 
 extern const char *SettingsCalibrationDone;
 extern const char *SettingsCalibrationWarning;

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -35,9 +35,9 @@ extern const char *IdleSetString;
 extern const char *TipDisconnectedString;
 extern const char *SolderingAdvancedPowerPrompt;
 extern const char *OffString;
-extern const char *ResetOKMessage;
 extern const char *YourGainMessage;
 
+extern const char *ResetOKMessage;
 extern const char *SettingsResetMessage;
 extern const char *NoAccelerometerMessage;
 extern const char *NoPowerDeliveryMessage;

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -37,13 +37,13 @@ extern const char *SolderingAdvancedPowerPrompt;
 extern const char *OffString;
 extern const char *ResetOKMessage;
 extern const char *YourGainMessage;
+
+extern const char *SettingsResetMessage;
 extern const char *NoAccelerometerMessage;
 extern const char *NoPowerDeliveryMessage;
 extern const char *LockingKeysString;
 extern const char *UnlockingKeysString;
 extern const char *WarningKeysLockedString;
-
-extern const char *SettingsResetMessage;
 
 extern const char *SettingRightChar;
 extern const char *SettingLeftChar;

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -37,12 +37,13 @@ extern const char *SolderingAdvancedPowerPrompt;
 extern const char *OffString;
 extern const char *ResetOKMessage;
 extern const char *YourGainMessage;
-extern const char *SettingsResetMessage;
 extern const char *NoAccelerometerMessage;
 extern const char *NoPowerDeliveryMessage;
 extern const char *LockingKeysString;
 extern const char *UnlockingKeysString;
 extern const char *WarningKeysLockedString;
+
+extern const char *SettingsResetMessage;
 
 extern const char *SettingRightChar;
 extern const char *SettingLeftChar;

--- a/source/Core/Inc/gui.hpp
+++ b/source/Core/Inc/gui.hpp
@@ -29,6 +29,7 @@ typedef struct {
 
 void                  enterSettingsMenu();
 void                  GUIDelay();
+void                  warnUser(const char *warning, const int timeout);
 extern const menuitem rootSettingsMenu[];
 
 #endif /* GUI_HPP_ */

--- a/source/Core/Src/gui.cpp
+++ b/source/Core/Src/gui.cpp
@@ -237,17 +237,6 @@ const menuitem advancedMenu[] = {
     {nullptr, nullptr, nullptr}                                                                                                            // end of menu marker. DO NOT REMOVE
 };
 
-static void printShortDescriptionDoubleLine(SettingsItemIndex settingsItemIndex) {
-  uint8_t shortDescIndex = static_cast<uint8_t>(settingsItemIndex);
-  OLED::setCursor(0, 0);
-  if (SettingsShortNames[shortDescIndex][0] == '\x01') {
-    // Empty first line means that this uses large font (for CJK).
-    OLED::print(SettingsShortNames[shortDescIndex] + 1, FontStyle::LARGE);
-  } else {
-    OLED::print(SettingsShortNames[shortDescIndex], FontStyle::SMALL);
-  }
-}
-
 /**
  * Prints two small lines (or one line for CJK) of short description for
  * setting items and prepares cursor after it.
@@ -257,7 +246,8 @@ static void printShortDescriptionDoubleLine(SettingsItemIndex settingsItemIndex)
  */
 static void printShortDescription(SettingsItemIndex settingsItemIndex, uint16_t cursorCharPosition) {
   // print short description (default single line, explicit double line)
-  printShortDescriptionDoubleLine(settingsItemIndex);
+  uint8_t shortDescIndex = static_cast<uint8_t>(settingsItemIndex);
+  OLED::printWholeScreen(SettingsShortNames[shortDescIndex]);
 
   // prepare cursor for value
   // make room for scroll indicator
@@ -1011,18 +1001,8 @@ static bool animOpenState = false;
 
 static void displayMenu(size_t index) {
   // Call into the menu
-  const char *textPtr = SettingsMenuEntries[index];
-  FontStyle   font;
-  if (textPtr[0] == '\x01') { // `\x01` is used as newline.
-    // Empty first line means that this uses large font (for CJK).
-    font = FontStyle::LARGE;
-    textPtr++;
-  } else {
-    font = FontStyle::SMALL;
-  }
-  OLED::setCursor(0, 0);
   // Draw title
-  OLED::print(textPtr, font);
+  OLED::printWholeScreen(SettingsMenuEntries[index]);
   // Draw symbol
   // 16 pixel wide image
   // 2 pixel wide scrolling indicator

--- a/source/Core/Src/gui.cpp
+++ b/source/Core/Src/gui.cpp
@@ -239,15 +239,12 @@ const menuitem advancedMenu[] = {
 
 static void printShortDescriptionDoubleLine(SettingsItemIndex settingsItemIndex) {
   uint8_t shortDescIndex = static_cast<uint8_t>(settingsItemIndex);
-  if (SettingsShortNames[shortDescIndex][0][0] == '\x00') {
+  OLED::setCursor(0, 0);
+  if (SettingsShortNames[shortDescIndex][0] == '\x01') {
     // Empty first line means that this uses large font (for CJK).
-    OLED::setCursor(0, 0);
-    OLED::print(SettingsShortNames[shortDescIndex][1], FontStyle::LARGE);
+    OLED::print(SettingsShortNames[shortDescIndex] + 1, FontStyle::LARGE);
   } else {
-    OLED::setCursor(0, 0);
-    OLED::print(SettingsShortNames[shortDescIndex][0], FontStyle::SMALL);
-    OLED::setCursor(0, 8);
-    OLED::print(SettingsShortNames[shortDescIndex][1], FontStyle::SMALL);
+    OLED::print(SettingsShortNames[shortDescIndex], FontStyle::SMALL);
   }
 }
 

--- a/source/Core/Src/gui.cpp
+++ b/source/Core/Src/gui.cpp
@@ -711,13 +711,7 @@ static bool settings_displayCoolingBlinkEnabled(void) {
 static bool settings_setResetSettings(void) {
   if (userConfirmation(SettingsResetWarning)) {
     resetSettings();
-
-    OLED::clearScreen();
-    OLED::setCursor(0, 0);
-    OLED::print(ResetOKMessage, FontStyle::LARGE);
-    OLED::refresh();
-
-    waitForButtonPressOrTimeout(2000); // 2 second timeout
+    warnUser(ResetOKMessage, 2 * TICKS_SECOND);
   }
   return false;
 }
@@ -801,7 +795,7 @@ static bool settings_setCalibrateVIN(void) {
       OLED::setCursor(0, 0);
       OLED::printNumber(systemSettings.voltageDiv, 3, FontStyle::LARGE);
       OLED::refresh();
-      waitForButtonPressOrTimeout(1000);
+      waitForButtonPressOrTimeout(1 * TICKS_SECOND);
       return false;
     case BUTTON_NONE:
     default:

--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -43,10 +43,10 @@ static uint16_t   min(uint16_t a, uint16_t b) {
   else
     return a;
 }
-void warnUser(const char *warning, const FontStyle font, const int timeout) {
+
+void warnUser(const char *warning, const int timeout) {
   OLED::clearScreen();
-  OLED::setCursor(0, 0);
-  OLED::print(warning, font);
+  OLED::printWholeScreen(warning);
   OLED::refresh();
   waitForButtonPressOrTimeout(timeout);
 }
@@ -462,7 +462,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
       case BUTTON_BOTH_LONG:
         // Unlock buttons
         buttonsLocked = false;
-        warnUser(UnlockingKeysString, FontStyle::LARGE, TICKS_SECOND);
+        warnUser(UnlockingKeysString, TICKS_SECOND);
         break;
       case BUTTON_F_LONG:
         // if boost mode is enabled turn it on
@@ -476,7 +476,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
       case BUTTON_F_SHORT:
       case BUTTON_B_SHORT:
         // Do nothing and display a lock warming
-        warnUser(WarningKeysLockedString, FontStyle::LARGE, TICKS_SECOND / 2);
+        warnUser(WarningKeysLockedString, TICKS_SECOND / 2);
         break;
       default:
         break;
@@ -511,7 +511,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
         if (systemSettings.lockingMode != 0) {
           // Lock buttons
           buttonsLocked = true;
-          warnUser(LockingKeysString, FontStyle::LARGE, TICKS_SECOND);
+          warnUser(LockingKeysString, TICKS_SECOND);
         }
         break;
       default:
@@ -713,12 +713,7 @@ void showDebugMenu(void) {
 void showWarnings() {
   // Display alert if settings were reset
   if (settingsWereReset) {
-    if (SettingsResetMessage[0] == '\x01') { // `\x01` is used as newline.
-      // Empty first line means that this uses large font (for CJK).
-      warnUser(SettingsResetMessage + 1, FontStyle::LARGE, 10 * TICKS_SECOND);
-    } else {
-      warnUser(SettingsResetMessage, FontStyle::SMALL, 10 * TICKS_SECOND);
-    }
+    warnUser(SettingsResetMessage, 10 * TICKS_SECOND);
   }
 #ifndef NO_WARN_MISSING
   // We also want to alert if accel or pd is not detected / not responding
@@ -732,7 +727,7 @@ void showWarnings() {
     if (systemSettings.accelMissingWarningCounter < 2) {
       systemSettings.accelMissingWarningCounter++;
       saveSettings();
-      warnUser(NoAccelerometerMessage, FontStyle::SMALL, 10 * TICKS_SECOND);
+      warnUser(NoAccelerometerMessage, 10 * TICKS_SECOND);
     }
   }
 #ifdef POW_PD
@@ -741,7 +736,7 @@ void showWarnings() {
     if (systemSettings.pdMissingWarningCounter < 2) {
       systemSettings.pdMissingWarningCounter++;
       saveSettings();
-      warnUser(NoPowerDeliveryMessage, FontStyle::SMALL, 10 * TICKS_SECOND);
+      warnUser(NoPowerDeliveryMessage, 10 * TICKS_SECOND);
     }
   }
 #endif

--- a/source/Makefile
+++ b/source/Makefile
@@ -316,7 +316,7 @@ $(OUT_OBJS_S): $(OUTPUT_DIR)/%.o: %.S Makefile
 	@echo 'Building file: $<'
 	@$(AS) -c $(AFLAGS) $< -o $@
 
-Core/Gen/Translation.%.cpp: ../Translations/translation_%.json Makefile ../Translations/make_translation.py ../Translations/translations_commons.js ../Translations/font_tables.py ../Translations/wqy-bitmapsong/wenquanyi_9pt.bdf
+Core/Gen/Translation.%.cpp: ../Translations/translation_%.json Makefile ../Translations/make_translation.py ../Translations/translations_def.js ../Translations/font_tables.py ../Translations/wqy-bitmapsong/wenquanyi_9pt.bdf
 	@test -d $(@D) || mkdir -p $(@D)
 	@echo 'Generating translations for language $*'
 	@python3 ../Translations/make_translation.py -o $(PWD)/$@ $*


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- The changes have been tested locally
    - Only tested some translations
- There are no breaking changes

* **What kind of change does this PR introduce?**

Refactoring:

- Change `SettingsShortNames` to use one combined string like `SettingsMenuEntries` instead of one string per line
- Combine "starting with \n" checks into `OLED::printWholeScreen` and change some code to use it instead
- Change translations to work with the changes

* **Other information**:

- I am actually not quite sure about this. It cleans up some of the code, but the way a `\n` is prepended to the translation strings would seem to be making a bit of a mess.
- I did not prepend `\n` to some translation strings because they exceed the screen space with the large font, and using the small font seems more appropriate.