### PR TITLE
Change internal representation of translation strings

### DIFF
--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -528,7 +528,7 @@ def write_language(lang: dict, defs: dict, f: TextIO) -> None:
     str_offsets = []
     offset = 0
     write_null = False
-    f.write("const char TranslationStrings[] = {\n")
+    f.write("const char TranslationStringsData[] = {\n")
     for i, source_str in enumerate(str_table):
         if write_null:
             f.write(' "\\0"\n')
@@ -567,7 +567,7 @@ def write_language(lang: dict, defs: dict, f: TextIO) -> None:
         assert str_offsets[idx] >= 0
         return str_offsets[idx]
 
-    f.write("static const TranslationIndexTable TranslationIndices = {\n")
+    f.write("const TranslationIndexTable TranslationIndices = {\n")
 
     # ----- Write the messages string indices:
     for group in [str_group_messages, str_group_messageswarn, str_group_characters]:
@@ -593,7 +593,8 @@ def write_language(lang: dict, defs: dict, f: TextIO) -> None:
         f.write(f"  }}, // {name}\n\n")
 
     f.write("}; // TranslationIndices\n\n")
-    f.write("const TranslationIndexTable *const Tr = &TranslationIndices;\n\n")
+    f.write("const TranslationIndexTable *const Tr = &TranslationIndices;\n")
+    f.write("const char *const TranslationStrings = TranslationStringsData;\n\n")
 
     f.write(
         f"const bool HasFahrenheit = {('true' if lang.get('tempUnitFahrenheit', True) else 'false')};\n"

--- a/Translations/make_translation_test.py
+++ b/Translations/make_translation_test.py
@@ -3,20 +3,26 @@ import unittest
 
 
 class TestMakeTranslation(unittest.TestCase):
-    def test_get_chars_from_font_index(self):
-        from make_translation import get_chars_from_font_index
+    def test_get_bytes_from_font_index(self):
+        from make_translation import get_bytes_from_font_index
 
-        self.assertEqual(get_chars_from_font_index(2), "\\x02")
-        self.assertEqual(get_chars_from_font_index(239), "\\xEF")
-        self.assertEqual(get_chars_from_font_index(240), "\\xF0")
-        self.assertEqual(get_chars_from_font_index(241), "\\xF1\\x01")
-        self.assertEqual(get_chars_from_font_index(495), "\\xF1\\xFF")
-        self.assertEqual(get_chars_from_font_index(496), "\\xF2\\x01")
-        self.assertEqual(get_chars_from_font_index(750), "\\xF2\\xFF")
-        self.assertEqual(get_chars_from_font_index(751), "\\xF3\\x01")
-        self.assertEqual(get_chars_from_font_index(0x10 * 0xFF - 15), "\\xFF\\xFF")
+        self.assertEqual(get_bytes_from_font_index(2), b"\x02")
+        self.assertEqual(get_bytes_from_font_index(239), b"\xEF")
+        self.assertEqual(get_bytes_from_font_index(240), b"\xF0")
+        self.assertEqual(get_bytes_from_font_index(241), b"\xF1\x01")
+        self.assertEqual(get_bytes_from_font_index(495), b"\xF1\xFF")
+        self.assertEqual(get_bytes_from_font_index(496), b"\xF2\x01")
+        self.assertEqual(get_bytes_from_font_index(750), b"\xF2\xFF")
+        self.assertEqual(get_bytes_from_font_index(751), b"\xF3\x01")
+        self.assertEqual(get_bytes_from_font_index(0x10 * 0xFF - 15), b"\xFF\xFF")
         with self.assertRaises(ValueError):
-            get_chars_from_font_index(0x10 * 0xFF - 14)
+            get_bytes_from_font_index(0x10 * 0xFF - 14)
+
+    def test_bytes_to_escaped(self):
+        from make_translation import bytes_to_escaped
+
+        self.assertEqual(bytes_to_escaped(b"\x00"), "\\x00")
+        self.assertEqual(bytes_to_escaped(b"\xF1\xAB"), "\\xF1\\xAB")
 
 
 if __name__ == "__main__":

--- a/Translations/translations_def.js
+++ b/Translations/translations_def.js
@@ -2,9 +2,6 @@ var def =
 {
 	"messages": [
 		{
-			"id": "SettingsCalibrationDone"
-		},
-		{
 			"id": "SettingsCalibrationWarning"
 		},
 		{
@@ -24,28 +21,11 @@ var def =
 			"note": "Preferably end with a space"
 		},
 		{
-			"id": "WarningTipTempString",
-			"maxLen": 12,
-			"note": "Preferably end with a space"
-		},
-		{
-			"id": "BadTipString",
-			"maxLen": 8
-		},
-		{
 			"id": "SleepingSimpleString",
 			"maxLen": 4
 		},
 		{
 			"id": "SleepingAdvancedString",
-			"maxLen": 16
-		},
-		{
-			"id": "WarningSimpleString",
-			"maxLen": 4
-		},
-		{
-			"id": "WarningAdvancedString",
 			"maxLen": 16
 		},
 		{
@@ -80,11 +60,6 @@ var def =
 		{
 			"id": "OffString",
 			"maxLen": 3
-		},
-		{
-			"id": "YourGainMessage",
-			"maxLen": 8,
-			"default": "Your Gain"
 		}
 	],
 	"messagesWarn": [

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -61,8 +61,6 @@ enum class SettingsItemIndex : uint8_t {
   NUM_ITEMS,
 };
 
-extern const char TranslationStrings[];
-
 struct TranslationIndexTable {
   uint16_t SettingsCalibrationWarning;
   uint16_t SettingsResetWarning;
@@ -114,6 +112,7 @@ struct TranslationIndexTable {
 };
 
 extern const TranslationIndexTable *const Tr;
+extern const char *const                  TranslationStrings;
 
 constexpr uint8_t settings_item_index(const SettingsItemIndex i) { return static_cast<uint8_t>(i); }
 // Use a constexpr function for type-checking.

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -12,56 +12,6 @@ extern const uint8_t USER_FONT_12[];
 extern const uint8_t USER_FONT_6x8[];
 extern const bool    HasFahrenheit;
 
-extern const char TranslationStrings[];
-
-extern const uint16_t SettingsShortNames[];
-extern const uint16_t SettingsDescriptions[];
-extern const uint16_t SettingsMenuEntries[];
-
-extern const uint16_t SettingsCalibrationWarning;
-extern const uint16_t SettingsResetWarning;
-extern const uint16_t UVLOWarningString;
-extern const uint16_t UndervoltageString;
-extern const uint16_t InputVoltageString;
-
-extern const uint16_t SleepingSimpleString;
-extern const uint16_t SleepingAdvancedString;
-extern const uint16_t SleepingTipAdvancedString;
-extern const uint16_t IdleTipString;
-extern const uint16_t IdleSetString;
-extern const uint16_t TipDisconnectedString;
-extern const uint16_t SolderingAdvancedPowerPrompt;
-extern const uint16_t OffString;
-
-extern const uint16_t ResetOKMessage;
-extern const uint16_t SettingsResetMessage;
-extern const uint16_t NoAccelerometerMessage;
-extern const uint16_t NoPowerDeliveryMessage;
-extern const uint16_t LockingKeysString;
-extern const uint16_t UnlockingKeysString;
-extern const uint16_t WarningKeysLockedString;
-
-extern const uint16_t SettingRightChar;
-extern const uint16_t SettingLeftChar;
-extern const uint16_t SettingAutoChar;
-extern const uint16_t SettingStartSolderingChar;
-extern const uint16_t SettingStartSleepChar;
-extern const uint16_t SettingStartSleepOffChar;
-extern const uint16_t SettingStartNoneChar;
-extern const uint16_t SettingSensitivityOff;
-extern const uint16_t SettingSensitivityLow;
-extern const uint16_t SettingSensitivityMedium;
-extern const uint16_t SettingSensitivityHigh;
-extern const uint16_t SettingLockDisableChar;
-extern const uint16_t SettingLockBoostChar;
-extern const uint16_t SettingLockFullChar;
-extern const uint16_t SettingNAChar;
-
-extern const uint16_t SettingOffChar;
-extern const uint16_t SettingFastChar;
-extern const uint16_t SettingMediumChar;
-extern const uint16_t SettingSlowChar;
-
 extern const char *SymbolPlus;
 extern const char *SymbolMinus;
 extern const char *SymbolSpace;
@@ -108,7 +58,62 @@ enum class SettingsItemIndex : uint8_t {
   AnimSpeed,
   PowerPulseWait,
   PowerPulseDuration,
+  NUM_ITEMS,
 };
+
+extern const char TranslationStrings[];
+
+struct TranslationIndexTable {
+  uint16_t SettingsCalibrationWarning;
+  uint16_t SettingsResetWarning;
+  uint16_t UVLOWarningString;
+  uint16_t UndervoltageString;
+  uint16_t InputVoltageString;
+
+  uint16_t SleepingSimpleString;
+  uint16_t SleepingAdvancedString;
+  uint16_t SleepingTipAdvancedString;
+  uint16_t IdleTipString;
+  uint16_t IdleSetString;
+  uint16_t TipDisconnectedString;
+  uint16_t SolderingAdvancedPowerPrompt;
+  uint16_t OffString;
+
+  uint16_t ResetOKMessage;
+  uint16_t SettingsResetMessage;
+  uint16_t NoAccelerometerMessage;
+  uint16_t NoPowerDeliveryMessage;
+  uint16_t LockingKeysString;
+  uint16_t UnlockingKeysString;
+  uint16_t WarningKeysLockedString;
+
+  uint16_t SettingRightChar;
+  uint16_t SettingLeftChar;
+  uint16_t SettingAutoChar;
+  uint16_t SettingFastChar;
+  uint16_t SettingSlowChar;
+  uint16_t SettingMediumChar;
+  uint16_t SettingOffChar;
+  uint16_t SettingStartSolderingChar;
+  uint16_t SettingStartSleepChar;
+  uint16_t SettingStartSleepOffChar;
+  uint16_t SettingStartNoneChar;
+  uint16_t SettingSensitivityOff;
+  uint16_t SettingSensitivityLow;
+  uint16_t SettingSensitivityMedium;
+  uint16_t SettingSensitivityHigh;
+  uint16_t SettingLockDisableChar;
+  uint16_t SettingLockBoostChar;
+  uint16_t SettingLockFullChar;
+  uint16_t SettingNAChar;
+
+  uint16_t SettingsDescriptions[static_cast<uint32_t>(SettingsItemIndex::NUM_ITEMS)];
+  uint16_t SettingsShortNames[static_cast<uint32_t>(SettingsItemIndex::NUM_ITEMS)];
+  uint16_t SettingsMenuEntries[5];
+  uint16_t SettingsMenuEntriesDescriptions[5]; // unused
+};
+
+extern const TranslationIndexTable *const Tr;
 
 constexpr uint8_t settings_item_index(const SettingsItemIndex i) { return static_cast<uint8_t>(i); }
 // Use a constexpr function for type-checking.

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -12,53 +12,55 @@ extern const uint8_t USER_FONT_12[];
 extern const uint8_t USER_FONT_6x8[];
 extern const bool    HasFahrenheit;
 
-extern const char *SettingsShortNames[];
-extern const char *SettingsDescriptions[];
-extern const char *SettingsMenuEntries[];
+extern const char TranslationStrings[];
 
-extern const char *SettingsCalibrationWarning;
-extern const char *SettingsResetWarning;
-extern const char *UVLOWarningString;
-extern const char *UndervoltageString;
-extern const char *InputVoltageString;
+extern const uint16_t SettingsShortNames[];
+extern const uint16_t SettingsDescriptions[];
+extern const uint16_t SettingsMenuEntries[];
 
-extern const char *SleepingSimpleString;
-extern const char *SleepingAdvancedString;
-extern const char *SleepingTipAdvancedString;
-extern const char *IdleTipString;
-extern const char *IdleSetString;
-extern const char *TipDisconnectedString;
-extern const char *SolderingAdvancedPowerPrompt;
-extern const char *OffString;
+extern const uint16_t SettingsCalibrationWarning;
+extern const uint16_t SettingsResetWarning;
+extern const uint16_t UVLOWarningString;
+extern const uint16_t UndervoltageString;
+extern const uint16_t InputVoltageString;
 
-extern const char *ResetOKMessage;
-extern const char *SettingsResetMessage;
-extern const char *NoAccelerometerMessage;
-extern const char *NoPowerDeliveryMessage;
-extern const char *LockingKeysString;
-extern const char *UnlockingKeysString;
-extern const char *WarningKeysLockedString;
+extern const uint16_t SleepingSimpleString;
+extern const uint16_t SleepingAdvancedString;
+extern const uint16_t SleepingTipAdvancedString;
+extern const uint16_t IdleTipString;
+extern const uint16_t IdleSetString;
+extern const uint16_t TipDisconnectedString;
+extern const uint16_t SolderingAdvancedPowerPrompt;
+extern const uint16_t OffString;
 
-extern const char *SettingRightChar;
-extern const char *SettingLeftChar;
-extern const char *SettingAutoChar;
-extern const char *SettingStartSolderingChar;
-extern const char *SettingStartSleepChar;
-extern const char *SettingStartSleepOffChar;
-extern const char *SettingStartNoneChar;
-extern const char *SettingSensitivityOff;
-extern const char *SettingSensitivityLow;
-extern const char *SettingSensitivityMedium;
-extern const char *SettingSensitivityHigh;
-extern const char *SettingLockDisableChar;
-extern const char *SettingLockBoostChar;
-extern const char *SettingLockFullChar;
-extern const char *SettingNAChar;
+extern const uint16_t ResetOKMessage;
+extern const uint16_t SettingsResetMessage;
+extern const uint16_t NoAccelerometerMessage;
+extern const uint16_t NoPowerDeliveryMessage;
+extern const uint16_t LockingKeysString;
+extern const uint16_t UnlockingKeysString;
+extern const uint16_t WarningKeysLockedString;
 
-extern const char *SettingOffChar;
-extern const char *SettingFastChar;
-extern const char *SettingMediumChar;
-extern const char *SettingSlowChar;
+extern const uint16_t SettingRightChar;
+extern const uint16_t SettingLeftChar;
+extern const uint16_t SettingAutoChar;
+extern const uint16_t SettingStartSolderingChar;
+extern const uint16_t SettingStartSleepChar;
+extern const uint16_t SettingStartSleepOffChar;
+extern const uint16_t SettingStartNoneChar;
+extern const uint16_t SettingSensitivityOff;
+extern const uint16_t SettingSensitivityLow;
+extern const uint16_t SettingSensitivityMedium;
+extern const uint16_t SettingSensitivityHigh;
+extern const uint16_t SettingLockDisableChar;
+extern const uint16_t SettingLockBoostChar;
+extern const uint16_t SettingLockFullChar;
+extern const uint16_t SettingNAChar;
+
+extern const uint16_t SettingOffChar;
+extern const uint16_t SettingFastChar;
+extern const uint16_t SettingMediumChar;
+extern const uint16_t SettingSlowChar;
 
 extern const char *SymbolPlus;
 extern const char *SymbolMinus;
@@ -111,5 +113,7 @@ enum class SettingsItemIndex : uint8_t {
 constexpr uint8_t settings_item_index(const SettingsItemIndex i) { return static_cast<uint8_t>(i); }
 // Use a constexpr function for type-checking.
 #define SETTINGS_DESC(i) (settings_item_index(i) + 1)
+
+const char *translatedString(uint16_t index);
 
 #endif /* TRANSLATION_H_ */

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -110,6 +110,6 @@ enum class SettingsItemIndex : uint8_t {
 
 constexpr uint8_t settings_item_index(const SettingsItemIndex i) { return static_cast<uint8_t>(i); }
 // Use a constexpr function for type-checking.
-#define SETTINGS_DESC(i) (SettingsDescriptions[settings_item_index(i)])
+#define SETTINGS_DESC(i) (settings_item_index(i) + 1)
 
 #endif /* TRANSLATION_H_ */

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -16,26 +16,20 @@ extern const char *SettingsShortNames[];
 extern const char *SettingsDescriptions[];
 extern const char *SettingsMenuEntries[];
 
-extern const char *SettingsCalibrationDone;
 extern const char *SettingsCalibrationWarning;
 extern const char *SettingsResetWarning;
 extern const char *UVLOWarningString;
 extern const char *UndervoltageString;
 extern const char *InputVoltageString;
-extern const char *WarningTipTempString;
-extern const char *BadTipString;
 
 extern const char *SleepingSimpleString;
 extern const char *SleepingAdvancedString;
-extern const char *WarningSimpleString;
-extern const char *WarningAdvancedString;
 extern const char *SleepingTipAdvancedString;
 extern const char *IdleTipString;
 extern const char *IdleSetString;
 extern const char *TipDisconnectedString;
 extern const char *SolderingAdvancedPowerPrompt;
 extern const char *OffString;
-extern const char *YourGainMessage;
 
 extern const char *ResetOKMessage;
 extern const char *SettingsResetMessage;
@@ -65,8 +59,7 @@ extern const char *SettingOffChar;
 extern const char *SettingFastChar;
 extern const char *SettingMediumChar;
 extern const char *SettingSlowChar;
-extern const char *TipModelStrings[];
-extern const char *DebugMenu[];
+
 extern const char *SymbolPlus;
 extern const char *SymbolMinus;
 extern const char *SymbolSpace;

--- a/source/Core/Inc/gui.hpp
+++ b/source/Core/Inc/gui.hpp
@@ -21,7 +21,9 @@
 
 // Struct for holding the function pointers and descriptions
 typedef struct {
-  const char *description;
+  // The settings description index, please use the `SETTINGS_DESC` macro with
+  // the `SettingsItemIndex` enum. Use 0 for no description.
+  uint8_t description;
   // return true if increment reached the maximum value
   bool (*const incrementHandler)(void);
   bool (*const draw)(void);

--- a/source/Core/Src/Translation.cpp
+++ b/source/Core/Src/Translation.cpp
@@ -1,0 +1,3 @@
+#include "Translation.h"
+
+const char *translatedString(uint16_t offset) { return TranslationStrings + offset; }

--- a/source/Core/Src/gui.cpp
+++ b/source/Core/Src/gui.cpp
@@ -247,7 +247,7 @@ const menuitem advancedMenu[] = {
 static void printShortDescription(SettingsItemIndex settingsItemIndex, uint16_t cursorCharPosition) {
   // print short description (default single line, explicit double line)
   uint8_t shortDescIndex = static_cast<uint8_t>(settingsItemIndex);
-  OLED::printWholeScreen(translatedString(SettingsShortNames[shortDescIndex]));
+  OLED::printWholeScreen(translatedString(Tr->SettingsShortNames[shortDescIndex]));
 
   // prepare cursor for value
   // make room for scroll indicator
@@ -362,7 +362,7 @@ static bool settings_displayInputMinVRange(void) {
     OLED::printNumber(systemSettings.minVoltageCells % 10, 1, FontStyle::LARGE);
   } else {
     printShortDescription(SettingsItemIndex::MinVolCell, 5);
-    OLED::print(translatedString(SettingNAChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingNAChar), FontStyle::LARGE);
   }
   return false;
 }
@@ -437,7 +437,7 @@ static bool settings_setSleepTime(void) {
 static bool settings_displaySleepTime(void) {
   printShortDescription(SettingsItemIndex::SleepTimeout, 5);
   if (systemSettings.SleepTime == 0) {
-    OLED::print(translatedString(OffString), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->OffString), FontStyle::LARGE);
   } else if (systemSettings.SleepTime < 6) {
     OLED::printNumber(systemSettings.SleepTime * 10, 2, FontStyle::LARGE);
     OLED::print(SymbolSeconds, FontStyle::LARGE);
@@ -461,7 +461,7 @@ static bool settings_setShutdownTime(void) {
 static bool settings_displayShutdownTime(void) {
   printShortDescription(SettingsItemIndex::ShutdownTimeout, 5);
   if (systemSettings.ShutdownTime == 0) {
-    OLED::print(translatedString(OffString), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->OffString), FontStyle::LARGE);
   } else {
     OLED::printNumber(systemSettings.ShutdownTime, 2, FontStyle::LARGE);
     OLED::print(SymbolMinutes, FontStyle::LARGE);
@@ -546,7 +546,7 @@ static bool settings_setPowerLimit(void) {
 static bool settings_displayPowerLimit(void) {
   printShortDescription(SettingsItemIndex::PowerLimit, 5);
   if (systemSettings.powerLimit == 0) {
-    OLED::print(translatedString(OffString), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->OffString), FontStyle::LARGE);
   } else {
     OLED::printNumber(systemSettings.powerLimit, 2, FontStyle::LARGE);
     OLED::print(SymbolWatts, FontStyle::LARGE);
@@ -564,7 +564,7 @@ static bool settings_setScrollSpeed(void) {
 
 static bool settings_displayScrollSpeed(void) {
   printShortDescription(SettingsItemIndex::ScrollingSpeed, 7);
-  OLED::print(translatedString((systemSettings.descriptionScrollSpeed) ? SettingFastChar : SettingSlowChar), FontStyle::LARGE);
+  OLED::print(translatedString((systemSettings.descriptionScrollSpeed) ? Tr->SettingFastChar : Tr->SettingSlowChar), FontStyle::LARGE);
   return false;
 }
 
@@ -592,16 +592,16 @@ static bool settings_displayDisplayRotation(void) {
 
   switch (systemSettings.OrientationMode) {
   case 0:
-    OLED::print(translatedString(SettingRightChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingRightChar), FontStyle::LARGE);
     break;
   case 1:
-    OLED::print(translatedString(SettingLeftChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingLeftChar), FontStyle::LARGE);
     break;
   case 2:
-    OLED::print(translatedString(SettingAutoChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingAutoChar), FontStyle::LARGE);
     break;
   default:
-    OLED::print(translatedString(SettingRightChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingRightChar), FontStyle::LARGE);
     break;
   }
   return false;
@@ -637,7 +637,7 @@ static bool settings_displayBoostTemp(void) {
   if (systemSettings.BoostTemp) {
     OLED::printNumber(systemSettings.BoostTemp, 3, FontStyle::LARGE);
   } else {
-    OLED::print(translatedString(OffString), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->OffString), FontStyle::LARGE);
   }
   return false;
 }
@@ -653,19 +653,19 @@ static bool settings_displayAutomaticStartMode(void) {
 
   switch (systemSettings.autoStartMode) {
   case 0:
-    OLED::print(translatedString(SettingStartNoneChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingStartNoneChar), FontStyle::LARGE);
     break;
   case 1:
-    OLED::print(translatedString(SettingStartSolderingChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingStartSolderingChar), FontStyle::LARGE);
     break;
   case 2:
-    OLED::print(translatedString(SettingStartSleepChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingStartSleepChar), FontStyle::LARGE);
     break;
   case 3:
-    OLED::print(translatedString(SettingStartSleepOffChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingStartSleepOffChar), FontStyle::LARGE);
     break;
   default:
-    OLED::print(translatedString(SettingStartNoneChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingStartNoneChar), FontStyle::LARGE);
     break;
   }
   return false;
@@ -682,16 +682,16 @@ static bool settings_displayLockingMode(void) {
 
   switch (systemSettings.lockingMode) {
   case 0:
-    OLED::print(translatedString(SettingLockDisableChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingLockDisableChar), FontStyle::LARGE);
     break;
   case 1:
-    OLED::print(translatedString(SettingLockBoostChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingLockBoostChar), FontStyle::LARGE);
     break;
   case 2:
-    OLED::print(translatedString(SettingLockFullChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingLockFullChar), FontStyle::LARGE);
     break;
   default:
-    OLED::print(translatedString(SettingLockDisableChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingLockDisableChar), FontStyle::LARGE);
     break;
   }
   return false;
@@ -709,9 +709,9 @@ static bool settings_displayCoolingBlinkEnabled(void) {
 }
 
 static bool settings_setResetSettings(void) {
-  if (userConfirmation(translatedString(SettingsResetWarning))) {
+  if (userConfirmation(translatedString(Tr->SettingsResetWarning))) {
     resetSettings();
-    warnUser(translatedString(ResetOKMessage), 2 * TICKS_SECOND);
+    warnUser(translatedString(Tr->ResetOKMessage), 2 * TICKS_SECOND);
   }
   return false;
 }
@@ -754,7 +754,7 @@ static void setTipOffset() {
 // If not only do single point tuning as per usual
 static bool settings_setCalibrate(void) {
 
-  if (userConfirmation(translatedString(SettingsCalibrationWarning))) {
+  if (userConfirmation(translatedString(Tr->SettingsCalibrationWarning))) {
     // User confirmed
     // So we now perform the actual calculation
     setTipOffset();
@@ -881,7 +881,7 @@ static bool settings_displayPowerPulse(void) {
     OLED::print(SymbolDot, FontStyle::LARGE);
     OLED::printNumber(systemSettings.KeepAwakePulse % 10, 1, FontStyle::LARGE);
   } else {
-    OLED::print(translatedString(OffString), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->OffString), FontStyle::LARGE);
   }
   return false;
 }
@@ -907,16 +907,16 @@ static bool settings_displayAnimationSpeed(void) {
   printShortDescription(SettingsItemIndex::AnimSpeed, 7);
   switch (systemSettings.animationSpeed) {
   case settingOffSpeed_t::SLOW:
-    OLED::print(translatedString(SettingSlowChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingSlowChar), FontStyle::LARGE);
     break;
   case settingOffSpeed_t::MEDIUM:
-    OLED::print(translatedString(SettingMediumChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingMediumChar), FontStyle::LARGE);
     break;
   case settingOffSpeed_t::FAST:
-    OLED::print(translatedString(SettingFastChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingFastChar), FontStyle::LARGE);
     break;
   default:
-    OLED::print(translatedString(SettingOffChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingOffChar), FontStyle::LARGE);
     break;
   }
   return false;
@@ -967,17 +967,17 @@ static bool settings_displayHallEffect(void) {
   printShortDescription(SettingsItemIndex::HallEffSensitivity, 7);
   switch (systemSettings.hallEffectSensitivity) {
   case 1:
-    OLED::print(translatedString(SettingSensitivityLow), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingSensitivityLow), FontStyle::LARGE);
     break;
   case 2:
-    OLED::print(translatedString(SettingSensitivityMedium), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingSensitivityMedium), FontStyle::LARGE);
     break;
   case 3:
-    OLED::print(translatedString(SettingSensitivityHigh), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingSensitivityHigh), FontStyle::LARGE);
     break;
   case 0:
   default:
-    OLED::print(translatedString(SettingSensitivityOff), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->SettingSensitivityOff), FontStyle::LARGE);
     break;
   }
   return false;
@@ -996,7 +996,7 @@ static bool animOpenState = false;
 static void displayMenu(size_t index) {
   // Call into the menu
   // Draw title
-  OLED::printWholeScreen(translatedString(SettingsMenuEntries[index]));
+  OLED::printWholeScreen(translatedString(Tr->SettingsMenuEntries[index]));
   // Draw symbol
   // 16 pixel wide image
   // 2 pixel wide scrolling indicator
@@ -1128,7 +1128,7 @@ void gui_Menu(const menuitem *menu) {
       // Draw description
       if (descriptionStart == 0)
         descriptionStart = xTaskGetTickCount();
-      const char *description = translatedString(SettingsDescriptions[menu[currentScreen].description - 1]);
+      const char *description = translatedString(Tr->SettingsDescriptions[menu[currentScreen].description - 1]);
       // lower the value - higher the speed
       int16_t descriptionWidth  = FONT_12_WIDTH * (str_display_len(description) + 7);
       int16_t descriptionOffset = ((xTaskGetTickCount() - descriptionStart) / (systemSettings.descriptionScrollSpeed == 1 ? (TICKS_100MS / 10) : (TICKS_100MS / 5)));

--- a/source/Core/Src/gui.cpp
+++ b/source/Core/Src/gui.cpp
@@ -139,12 +139,12 @@ const menuitem rootSettingsMenu[]{
      * Advanced Menu
      * Exit
      */
-    {nullptr, settings_enterPowerMenu, settings_displayPowerMenu},             /*Power*/
-    {nullptr, settings_enterSolderingMenu, settings_displaySolderingMenu},     /*Soldering*/
-    {nullptr, settings_enterPowerSavingMenu, settings_displayPowerSavingMenu}, /*Sleep Options Menu*/
-    {nullptr, settings_enterUIMenu, settings_displayUIMenu},                   /*UI Menu*/
-    {nullptr, settings_enterAdvancedMenu, settings_displayAdvancedMenu},       /*Advanced Menu*/
-    {nullptr, nullptr, nullptr}                                                // end of menu marker. DO NOT REMOVE
+    {0, settings_enterPowerMenu, settings_displayPowerMenu},             /*Power*/
+    {0, settings_enterSolderingMenu, settings_displaySolderingMenu},     /*Soldering*/
+    {0, settings_enterPowerSavingMenu, settings_displayPowerSavingMenu}, /*Sleep Options Menu*/
+    {0, settings_enterUIMenu, settings_displayUIMenu},                   /*UI Menu*/
+    {0, settings_enterAdvancedMenu, settings_displayAdvancedMenu},       /*Advanced Menu*/
+    {0, nullptr, nullptr}                                                // end of menu marker. DO NOT REMOVE
 };
 
 const menuitem powerMenu[] = {
@@ -158,7 +158,7 @@ const menuitem powerMenu[] = {
 #ifdef POW_QC
     {SETTINGS_DESC(SettingsItemIndex::QCMaxVoltage), settings_setQCInputV, settings_displayQCInputV}, /*Voltage input*/
 #endif
-    {nullptr, nullptr, nullptr} // end of menu marker. DO NOT REMOVE
+    {0, nullptr, nullptr} // end of menu marker. DO NOT REMOVE
 };
 const menuitem solderingMenu[] = {
     /*
@@ -173,7 +173,7 @@ const menuitem solderingMenu[] = {
     {SETTINGS_DESC(SettingsItemIndex::TempChangeShortStep), settings_setTempChangeShortStep, settings_displayTempChangeShortStep}, /*Temp change short step*/
     {SETTINGS_DESC(SettingsItemIndex::TempChangeLongStep), settings_setTempChangeLongStep, settings_displayTempChangeLongStep},    /*Temp change long step*/
     {SETTINGS_DESC(SettingsItemIndex::LockingMode), settings_setLockingMode, settings_displayLockingMode},                         /*Locking Mode*/
-    {nullptr, nullptr, nullptr}                                                                                                    // end of menu marker. DO NOT REMOVE
+    {0, nullptr, nullptr}                                                                                                          // end of menu marker. DO NOT REMOVE
 };
 const menuitem UIMenu[] = {
     /*
@@ -192,7 +192,7 @@ const menuitem UIMenu[] = {
     {SETTINGS_DESC(SettingsItemIndex::ReverseButtonTempChange), settings_setReverseButtonTempChangeEnabled, settings_displayReverseButtonTempChangeEnabled}, /* Reverse Temp change buttons + - */
     {SETTINGS_DESC(SettingsItemIndex::AnimSpeed), settings_setAnimationSpeed, settings_displayAnimationSpeed},                                               /*Animation Speed adjustment */
     {SETTINGS_DESC(SettingsItemIndex::AnimLoop), settings_setAnimationLoop, settings_displayAnimationLoop},                                                  /*Animation Loop switch */
-    {nullptr, nullptr, nullptr}                                                                                                                              // end of menu marker. DO NOT REMOVE
+    {0, nullptr, nullptr}                                                                                                                                    // end of menu marker. DO NOT REMOVE
 };
 const menuitem PowerSavingMenu[] = {
     /*
@@ -208,7 +208,7 @@ const menuitem PowerSavingMenu[] = {
 #ifdef HALL_SENSOR
     {SETTINGS_DESC(SettingsItemIndex::HallEffSensitivity), settings_setHallEffect, settings_displayHallEffect}, /* HallEffect Sensitivity*/
 #endif
-    {nullptr, nullptr, nullptr} // end of menu marker. DO NOT REMOVE
+    {0, nullptr, nullptr} // end of menu marker. DO NOT REMOVE
 };
 const menuitem advancedMenu[] = {
 
@@ -234,7 +234,7 @@ const menuitem advancedMenu[] = {
     {SETTINGS_DESC(SettingsItemIndex::PowerPulsePower), settings_setPowerPulse, settings_displayPowerPulse},                               /*Power Pulse adjustment */
     {SETTINGS_DESC(SettingsItemIndex::PowerPulseWait), settings_setPowerPulseWait, settings_displayPowerPulseWait},                        /*Power Pulse Wait adjustment*/
     {SETTINGS_DESC(SettingsItemIndex::PowerPulseDuration), settings_setPowerPulseDuration, settings_displayPowerPulseDuration},            /*Power Pulse Duration adjustment*/
-    {nullptr, nullptr, nullptr}                                                                                                            // end of menu marker. DO NOT REMOVE
+    {0, nullptr, nullptr}                                                                                                                  // end of menu marker. DO NOT REMOVE
 };
 
 /**
@@ -1110,7 +1110,7 @@ void gui_Menu(const menuitem *menu) {
     OLED::setCursor(0, 0);
     // If the user has hesitated for >=3 seconds, show the long text
     // Otherwise "draw" the option
-    if ((xTaskGetTickCount() - lastButtonTime < (TICKS_SECOND * 3)) || menu[currentScreen].description == nullptr) {
+    if ((xTaskGetTickCount() - lastButtonTime < (TICKS_SECOND * 3)) || menu[currentScreen].description == 0) {
       lcdRefresh = true;
       OLED::clearScreen();
       if (menu[currentScreen].draw()) {
@@ -1128,7 +1128,7 @@ void gui_Menu(const menuitem *menu) {
       // Draw description
       if (descriptionStart == 0)
         descriptionStart = xTaskGetTickCount();
-      const char *description = menu[currentScreen].description;
+      const char *description = SettingsDescriptions[menu[currentScreen].description - 1];
       // lower the value - higher the speed
       int16_t descriptionWidth  = FONT_12_WIDTH * (str_display_len(description) + 7);
       int16_t descriptionOffset = ((xTaskGetTickCount() - descriptionStart) / (systemSettings.descriptionScrollSpeed == 1 ? (TICKS_100MS / 10) : (TICKS_100MS / 5)));

--- a/source/Core/Src/gui.cpp
+++ b/source/Core/Src/gui.cpp
@@ -247,7 +247,7 @@ const menuitem advancedMenu[] = {
 static void printShortDescription(SettingsItemIndex settingsItemIndex, uint16_t cursorCharPosition) {
   // print short description (default single line, explicit double line)
   uint8_t shortDescIndex = static_cast<uint8_t>(settingsItemIndex);
-  OLED::printWholeScreen(SettingsShortNames[shortDescIndex]);
+  OLED::printWholeScreen(translatedString(SettingsShortNames[shortDescIndex]));
 
   // prepare cursor for value
   // make room for scroll indicator
@@ -362,7 +362,7 @@ static bool settings_displayInputMinVRange(void) {
     OLED::printNumber(systemSettings.minVoltageCells % 10, 1, FontStyle::LARGE);
   } else {
     printShortDescription(SettingsItemIndex::MinVolCell, 5);
-    OLED::print(SettingNAChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingNAChar), FontStyle::LARGE);
   }
   return false;
 }
@@ -437,7 +437,7 @@ static bool settings_setSleepTime(void) {
 static bool settings_displaySleepTime(void) {
   printShortDescription(SettingsItemIndex::SleepTimeout, 5);
   if (systemSettings.SleepTime == 0) {
-    OLED::print(OffString, FontStyle::LARGE);
+    OLED::print(translatedString(OffString), FontStyle::LARGE);
   } else if (systemSettings.SleepTime < 6) {
     OLED::printNumber(systemSettings.SleepTime * 10, 2, FontStyle::LARGE);
     OLED::print(SymbolSeconds, FontStyle::LARGE);
@@ -461,7 +461,7 @@ static bool settings_setShutdownTime(void) {
 static bool settings_displayShutdownTime(void) {
   printShortDescription(SettingsItemIndex::ShutdownTimeout, 5);
   if (systemSettings.ShutdownTime == 0) {
-    OLED::print(OffString, FontStyle::LARGE);
+    OLED::print(translatedString(OffString), FontStyle::LARGE);
   } else {
     OLED::printNumber(systemSettings.ShutdownTime, 2, FontStyle::LARGE);
     OLED::print(SymbolMinutes, FontStyle::LARGE);
@@ -546,7 +546,7 @@ static bool settings_setPowerLimit(void) {
 static bool settings_displayPowerLimit(void) {
   printShortDescription(SettingsItemIndex::PowerLimit, 5);
   if (systemSettings.powerLimit == 0) {
-    OLED::print(OffString, FontStyle::LARGE);
+    OLED::print(translatedString(OffString), FontStyle::LARGE);
   } else {
     OLED::printNumber(systemSettings.powerLimit, 2, FontStyle::LARGE);
     OLED::print(SymbolWatts, FontStyle::LARGE);
@@ -564,7 +564,7 @@ static bool settings_setScrollSpeed(void) {
 
 static bool settings_displayScrollSpeed(void) {
   printShortDescription(SettingsItemIndex::ScrollingSpeed, 7);
-  OLED::print((systemSettings.descriptionScrollSpeed) ? SettingFastChar : SettingSlowChar, FontStyle::LARGE);
+  OLED::print(translatedString((systemSettings.descriptionScrollSpeed) ? SettingFastChar : SettingSlowChar), FontStyle::LARGE);
   return false;
 }
 
@@ -592,16 +592,16 @@ static bool settings_displayDisplayRotation(void) {
 
   switch (systemSettings.OrientationMode) {
   case 0:
-    OLED::print(SettingRightChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingRightChar), FontStyle::LARGE);
     break;
   case 1:
-    OLED::print(SettingLeftChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingLeftChar), FontStyle::LARGE);
     break;
   case 2:
-    OLED::print(SettingAutoChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingAutoChar), FontStyle::LARGE);
     break;
   default:
-    OLED::print(SettingRightChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingRightChar), FontStyle::LARGE);
     break;
   }
   return false;
@@ -637,7 +637,7 @@ static bool settings_displayBoostTemp(void) {
   if (systemSettings.BoostTemp) {
     OLED::printNumber(systemSettings.BoostTemp, 3, FontStyle::LARGE);
   } else {
-    OLED::print(OffString, FontStyle::LARGE);
+    OLED::print(translatedString(OffString), FontStyle::LARGE);
   }
   return false;
 }
@@ -653,19 +653,19 @@ static bool settings_displayAutomaticStartMode(void) {
 
   switch (systemSettings.autoStartMode) {
   case 0:
-    OLED::print(SettingStartNoneChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingStartNoneChar), FontStyle::LARGE);
     break;
   case 1:
-    OLED::print(SettingStartSolderingChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingStartSolderingChar), FontStyle::LARGE);
     break;
   case 2:
-    OLED::print(SettingStartSleepChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingStartSleepChar), FontStyle::LARGE);
     break;
   case 3:
-    OLED::print(SettingStartSleepOffChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingStartSleepOffChar), FontStyle::LARGE);
     break;
   default:
-    OLED::print(SettingStartNoneChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingStartNoneChar), FontStyle::LARGE);
     break;
   }
   return false;
@@ -682,16 +682,16 @@ static bool settings_displayLockingMode(void) {
 
   switch (systemSettings.lockingMode) {
   case 0:
-    OLED::print(SettingLockDisableChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingLockDisableChar), FontStyle::LARGE);
     break;
   case 1:
-    OLED::print(SettingLockBoostChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingLockBoostChar), FontStyle::LARGE);
     break;
   case 2:
-    OLED::print(SettingLockFullChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingLockFullChar), FontStyle::LARGE);
     break;
   default:
-    OLED::print(SettingLockDisableChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingLockDisableChar), FontStyle::LARGE);
     break;
   }
   return false;
@@ -709,9 +709,9 @@ static bool settings_displayCoolingBlinkEnabled(void) {
 }
 
 static bool settings_setResetSettings(void) {
-  if (userConfirmation(SettingsResetWarning)) {
+  if (userConfirmation(translatedString(SettingsResetWarning))) {
     resetSettings();
-    warnUser(ResetOKMessage, 2 * TICKS_SECOND);
+    warnUser(translatedString(ResetOKMessage), 2 * TICKS_SECOND);
   }
   return false;
 }
@@ -754,7 +754,7 @@ static void setTipOffset() {
 // If not only do single point tuning as per usual
 static bool settings_setCalibrate(void) {
 
-  if (userConfirmation(SettingsCalibrationWarning)) {
+  if (userConfirmation(translatedString(SettingsCalibrationWarning))) {
     // User confirmed
     // So we now perform the actual calculation
     setTipOffset();
@@ -881,7 +881,7 @@ static bool settings_displayPowerPulse(void) {
     OLED::print(SymbolDot, FontStyle::LARGE);
     OLED::printNumber(systemSettings.KeepAwakePulse % 10, 1, FontStyle::LARGE);
   } else {
-    OLED::print(OffString, FontStyle::LARGE);
+    OLED::print(translatedString(OffString), FontStyle::LARGE);
   }
   return false;
 }
@@ -907,16 +907,16 @@ static bool settings_displayAnimationSpeed(void) {
   printShortDescription(SettingsItemIndex::AnimSpeed, 7);
   switch (systemSettings.animationSpeed) {
   case settingOffSpeed_t::SLOW:
-    OLED::print(SettingSlowChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingSlowChar), FontStyle::LARGE);
     break;
   case settingOffSpeed_t::MEDIUM:
-    OLED::print(SettingMediumChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingMediumChar), FontStyle::LARGE);
     break;
   case settingOffSpeed_t::FAST:
-    OLED::print(SettingFastChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingFastChar), FontStyle::LARGE);
     break;
   default:
-    OLED::print(SettingOffChar, FontStyle::LARGE);
+    OLED::print(translatedString(SettingOffChar), FontStyle::LARGE);
     break;
   }
   return false;
@@ -967,17 +967,17 @@ static bool settings_displayHallEffect(void) {
   printShortDescription(SettingsItemIndex::HallEffSensitivity, 7);
   switch (systemSettings.hallEffectSensitivity) {
   case 1:
-    OLED::print(SettingSensitivityLow, FontStyle::LARGE);
+    OLED::print(translatedString(SettingSensitivityLow), FontStyle::LARGE);
     break;
   case 2:
-    OLED::print(SettingSensitivityMedium, FontStyle::LARGE);
+    OLED::print(translatedString(SettingSensitivityMedium), FontStyle::LARGE);
     break;
   case 3:
-    OLED::print(SettingSensitivityHigh, FontStyle::LARGE);
+    OLED::print(translatedString(SettingSensitivityHigh), FontStyle::LARGE);
     break;
   case 0:
   default:
-    OLED::print(SettingSensitivityOff, FontStyle::LARGE);
+    OLED::print(translatedString(SettingSensitivityOff), FontStyle::LARGE);
     break;
   }
   return false;
@@ -996,7 +996,7 @@ static bool animOpenState = false;
 static void displayMenu(size_t index) {
   // Call into the menu
   // Draw title
-  OLED::printWholeScreen(SettingsMenuEntries[index]);
+  OLED::printWholeScreen(translatedString(SettingsMenuEntries[index]));
   // Draw symbol
   // 16 pixel wide image
   // 2 pixel wide scrolling indicator
@@ -1128,7 +1128,7 @@ void gui_Menu(const menuitem *menu) {
       // Draw description
       if (descriptionStart == 0)
         descriptionStart = xTaskGetTickCount();
-      const char *description = SettingsDescriptions[menu[currentScreen].description - 1];
+      const char *description = translatedString(SettingsDescriptions[menu[currentScreen].description - 1]);
       // lower the value - higher the speed
       int16_t descriptionWidth  = FONT_12_WIDTH * (str_display_len(description) + 7);
       int16_t descriptionOffset = ((xTaskGetTickCount() - descriptionStart) / (systemSettings.descriptionScrollSpeed == 1 ? (TICKS_100MS / 10) : (TICKS_100MS / 5)));

--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -107,13 +107,13 @@ static bool checkVoltageForExit() {
       OLED::clearScreen();
       OLED::setCursor(0, 0);
       if (systemSettings.detailedSoldering) {
-        OLED::print(UndervoltageString, FontStyle::SMALL);
+        OLED::print(translatedString(UndervoltageString), FontStyle::SMALL);
         OLED::setCursor(0, 8);
-        OLED::print(InputVoltageString, FontStyle::SMALL);
+        OLED::print(translatedString(InputVoltageString), FontStyle::SMALL);
         printVoltage();
         OLED::print(SymbolVolts, FontStyle::SMALL);
       } else {
-        OLED::print(UVLOWarningString, FontStyle::LARGE);
+        OLED::print(translatedString(UVLOWarningString), FontStyle::LARGE);
       }
 
       OLED::refresh();
@@ -326,9 +326,9 @@ static int gui_SolderingSleepingMode(bool stayOff, bool autoStarted) {
     OLED::clearScreen();
     OLED::setCursor(0, 0);
     if (systemSettings.detailedSoldering) {
-      OLED::print(SleepingAdvancedString, FontStyle::SMALL);
+      OLED::print(translatedString(SleepingAdvancedString), FontStyle::SMALL);
       OLED::setCursor(0, 8);
-      OLED::print(SleepingTipAdvancedString, FontStyle::SMALL);
+      OLED::print(translatedString(SleepingTipAdvancedString), FontStyle::SMALL);
       OLED::printNumber(tipTemp, 3, FontStyle::SMALL);
       if (systemSettings.temperatureInF)
         OLED::print(SymbolDegF, FontStyle::SMALL);
@@ -340,7 +340,7 @@ static int gui_SolderingSleepingMode(bool stayOff, bool autoStarted) {
       printVoltage();
       OLED::print(SymbolVolts, FontStyle::SMALL);
     } else {
-      OLED::print(SleepingSimpleString, FontStyle::LARGE);
+      OLED::print(translatedString(SleepingSimpleString), FontStyle::LARGE);
       OLED::printNumber(tipTemp, 3, FontStyle::LARGE);
       if (systemSettings.temperatureInF)
         OLED::drawSymbol(0);
@@ -462,7 +462,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
       case BUTTON_BOTH_LONG:
         // Unlock buttons
         buttonsLocked = false;
-        warnUser(UnlockingKeysString, TICKS_SECOND);
+        warnUser(translatedString(UnlockingKeysString), TICKS_SECOND);
         break;
       case BUTTON_F_LONG:
         // if boost mode is enabled turn it on
@@ -476,7 +476,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
       case BUTTON_F_SHORT:
       case BUTTON_B_SHORT:
         // Do nothing and display a lock warming
-        warnUser(WarningKeysLockedString, TICKS_SECOND / 2);
+        warnUser(translatedString(WarningKeysLockedString), TICKS_SECOND / 2);
         break;
       default:
         break;
@@ -511,7 +511,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
         if (systemSettings.lockingMode != 0) {
           // Lock buttons
           buttonsLocked = true;
-          warnUser(LockingKeysString, TICKS_SECOND);
+          warnUser(translatedString(LockingKeysString), TICKS_SECOND);
         }
         break;
       default:
@@ -523,7 +523,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
     OLED::clearScreen();
     // Draw in the screen details
     if (systemSettings.detailedSoldering) {
-      OLED::print(SolderingAdvancedPowerPrompt, FontStyle::SMALL); // Power:
+      OLED::print(translatedString(SolderingAdvancedPowerPrompt), FontStyle::SMALL); // Power:
       OLED::printNumber(x10WattHistory.average() / 10, 2, FontStyle::SMALL);
       OLED::print(SymbolDot, FontStyle::SMALL);
       OLED::printNumber(x10WattHistory.average() % 10, 1, FontStyle::SMALL);
@@ -535,7 +535,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
       }
 
       OLED::setCursor(0, 8);
-      OLED::print(SleepingTipAdvancedString, FontStyle::SMALL);
+      OLED::print(translatedString(SleepingTipAdvancedString), FontStyle::SMALL);
       gui_drawTipTemp(true, FontStyle::SMALL);
 
       if (boostModeOn) {
@@ -713,7 +713,7 @@ void showDebugMenu(void) {
 void showWarnings() {
   // Display alert if settings were reset
   if (settingsWereReset) {
-    warnUser(SettingsResetMessage, 10 * TICKS_SECOND);
+    warnUser(translatedString(SettingsResetMessage), 10 * TICKS_SECOND);
   }
 #ifndef NO_WARN_MISSING
   // We also want to alert if accel or pd is not detected / not responding
@@ -727,7 +727,7 @@ void showWarnings() {
     if (systemSettings.accelMissingWarningCounter < 2) {
       systemSettings.accelMissingWarningCounter++;
       saveSettings();
-      warnUser(NoAccelerometerMessage, 10 * TICKS_SECOND);
+      warnUser(translatedString(NoAccelerometerMessage), 10 * TICKS_SECOND);
     }
   }
 #ifdef POW_PD
@@ -736,7 +736,7 @@ void showWarnings() {
     if (systemSettings.pdMissingWarningCounter < 2) {
       systemSettings.pdMissingWarningCounter++;
       saveSettings();
-      warnUser(NoPowerDeliveryMessage, 10 * TICKS_SECOND);
+      warnUser(translatedString(NoPowerDeliveryMessage), 10 * TICKS_SECOND);
     }
   }
 #endif
@@ -844,16 +844,16 @@ void startGUITask(void const *argument __unused) {
     OLED::setCursor(0, 0);
     if (systemSettings.detailedIDLE) {
       if (tipTemp > tipDisconnectedThres) {
-        OLED::print(TipDisconnectedString, FontStyle::SMALL);
+        OLED::print(translatedString(TipDisconnectedString), FontStyle::SMALL);
       } else {
-        OLED::print(IdleTipString, FontStyle::SMALL);
+        OLED::print(translatedString(IdleTipString), FontStyle::SMALL);
         gui_drawTipTemp(false, FontStyle::SMALL);
-        OLED::print(IdleSetString, FontStyle::SMALL);
+        OLED::print(translatedString(IdleSetString), FontStyle::SMALL);
         OLED::printNumber(systemSettings.SolderingTemp, 3, FontStyle::SMALL);
       }
       OLED::setCursor(0, 8);
 
-      OLED::print(InputVoltageString, FontStyle::SMALL);
+      OLED::print(translatedString(InputVoltageString), FontStyle::SMALL);
       printVoltage();
 
     } else {

--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -107,13 +107,13 @@ static bool checkVoltageForExit() {
       OLED::clearScreen();
       OLED::setCursor(0, 0);
       if (systemSettings.detailedSoldering) {
-        OLED::print(translatedString(UndervoltageString), FontStyle::SMALL);
+        OLED::print(translatedString(Tr->UndervoltageString), FontStyle::SMALL);
         OLED::setCursor(0, 8);
-        OLED::print(translatedString(InputVoltageString), FontStyle::SMALL);
+        OLED::print(translatedString(Tr->InputVoltageString), FontStyle::SMALL);
         printVoltage();
         OLED::print(SymbolVolts, FontStyle::SMALL);
       } else {
-        OLED::print(translatedString(UVLOWarningString), FontStyle::LARGE);
+        OLED::print(translatedString(Tr->UVLOWarningString), FontStyle::LARGE);
       }
 
       OLED::refresh();
@@ -326,9 +326,9 @@ static int gui_SolderingSleepingMode(bool stayOff, bool autoStarted) {
     OLED::clearScreen();
     OLED::setCursor(0, 0);
     if (systemSettings.detailedSoldering) {
-      OLED::print(translatedString(SleepingAdvancedString), FontStyle::SMALL);
+      OLED::print(translatedString(Tr->SleepingAdvancedString), FontStyle::SMALL);
       OLED::setCursor(0, 8);
-      OLED::print(translatedString(SleepingTipAdvancedString), FontStyle::SMALL);
+      OLED::print(translatedString(Tr->SleepingTipAdvancedString), FontStyle::SMALL);
       OLED::printNumber(tipTemp, 3, FontStyle::SMALL);
       if (systemSettings.temperatureInF)
         OLED::print(SymbolDegF, FontStyle::SMALL);
@@ -340,7 +340,7 @@ static int gui_SolderingSleepingMode(bool stayOff, bool autoStarted) {
       printVoltage();
       OLED::print(SymbolVolts, FontStyle::SMALL);
     } else {
-      OLED::print(translatedString(SleepingSimpleString), FontStyle::LARGE);
+      OLED::print(translatedString(Tr->SleepingSimpleString), FontStyle::LARGE);
       OLED::printNumber(tipTemp, 3, FontStyle::LARGE);
       if (systemSettings.temperatureInF)
         OLED::drawSymbol(0);
@@ -462,7 +462,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
       case BUTTON_BOTH_LONG:
         // Unlock buttons
         buttonsLocked = false;
-        warnUser(translatedString(UnlockingKeysString), TICKS_SECOND);
+        warnUser(translatedString(Tr->UnlockingKeysString), TICKS_SECOND);
         break;
       case BUTTON_F_LONG:
         // if boost mode is enabled turn it on
@@ -476,7 +476,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
       case BUTTON_F_SHORT:
       case BUTTON_B_SHORT:
         // Do nothing and display a lock warming
-        warnUser(translatedString(WarningKeysLockedString), TICKS_SECOND / 2);
+        warnUser(translatedString(Tr->WarningKeysLockedString), TICKS_SECOND / 2);
         break;
       default:
         break;
@@ -511,7 +511,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
         if (systemSettings.lockingMode != 0) {
           // Lock buttons
           buttonsLocked = true;
-          warnUser(translatedString(LockingKeysString), TICKS_SECOND);
+          warnUser(translatedString(Tr->LockingKeysString), TICKS_SECOND);
         }
         break;
       default:
@@ -523,7 +523,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
     OLED::clearScreen();
     // Draw in the screen details
     if (systemSettings.detailedSoldering) {
-      OLED::print(translatedString(SolderingAdvancedPowerPrompt), FontStyle::SMALL); // Power:
+      OLED::print(translatedString(Tr->SolderingAdvancedPowerPrompt), FontStyle::SMALL); // Power:
       OLED::printNumber(x10WattHistory.average() / 10, 2, FontStyle::SMALL);
       OLED::print(SymbolDot, FontStyle::SMALL);
       OLED::printNumber(x10WattHistory.average() % 10, 1, FontStyle::SMALL);
@@ -535,7 +535,7 @@ static void gui_solderingMode(uint8_t jumpToSleep) {
       }
 
       OLED::setCursor(0, 8);
-      OLED::print(translatedString(SleepingTipAdvancedString), FontStyle::SMALL);
+      OLED::print(translatedString(Tr->SleepingTipAdvancedString), FontStyle::SMALL);
       gui_drawTipTemp(true, FontStyle::SMALL);
 
       if (boostModeOn) {
@@ -713,7 +713,7 @@ void showDebugMenu(void) {
 void showWarnings() {
   // Display alert if settings were reset
   if (settingsWereReset) {
-    warnUser(translatedString(SettingsResetMessage), 10 * TICKS_SECOND);
+    warnUser(translatedString(Tr->SettingsResetMessage), 10 * TICKS_SECOND);
   }
 #ifndef NO_WARN_MISSING
   // We also want to alert if accel or pd is not detected / not responding
@@ -727,7 +727,7 @@ void showWarnings() {
     if (systemSettings.accelMissingWarningCounter < 2) {
       systemSettings.accelMissingWarningCounter++;
       saveSettings();
-      warnUser(translatedString(NoAccelerometerMessage), 10 * TICKS_SECOND);
+      warnUser(translatedString(Tr->NoAccelerometerMessage), 10 * TICKS_SECOND);
     }
   }
 #ifdef POW_PD
@@ -736,7 +736,7 @@ void showWarnings() {
     if (systemSettings.pdMissingWarningCounter < 2) {
       systemSettings.pdMissingWarningCounter++;
       saveSettings();
-      warnUser(translatedString(NoPowerDeliveryMessage), 10 * TICKS_SECOND);
+      warnUser(translatedString(Tr->NoPowerDeliveryMessage), 10 * TICKS_SECOND);
     }
   }
 #endif
@@ -844,16 +844,16 @@ void startGUITask(void const *argument __unused) {
     OLED::setCursor(0, 0);
     if (systemSettings.detailedIDLE) {
       if (tipTemp > tipDisconnectedThres) {
-        OLED::print(translatedString(TipDisconnectedString), FontStyle::SMALL);
+        OLED::print(translatedString(Tr->TipDisconnectedString), FontStyle::SMALL);
       } else {
-        OLED::print(translatedString(IdleTipString), FontStyle::SMALL);
+        OLED::print(translatedString(Tr->IdleTipString), FontStyle::SMALL);
         gui_drawTipTemp(false, FontStyle::SMALL);
-        OLED::print(translatedString(IdleSetString), FontStyle::SMALL);
+        OLED::print(translatedString(Tr->IdleSetString), FontStyle::SMALL);
         OLED::printNumber(systemSettings.SolderingTemp, 3, FontStyle::SMALL);
       }
       OLED::setCursor(0, 8);
 
-      OLED::print(translatedString(InputVoltageString), FontStyle::SMALL);
+      OLED::print(translatedString(Tr->InputVoltageString), FontStyle::SMALL);
       printVoltage();
 
     } else {

--- a/source/Makefile
+++ b/source/Makefile
@@ -322,7 +322,7 @@ Core/Gen/Translation.%.cpp: ../Translations/translation_%.json Makefile ../Trans
 	@python3 ../Translations/make_translation.py -o $(PWD)/$@ $*
 
 clean :
-	rm -Rf $(SOURCE_CORE_DIR)/Translation.cpp Core/Gen
+	rm -Rf Core/Gen
 	rm -Rf $(OUTPUT_DIR_BASE)
 	rm -Rf $(HEXFILE_DIR)
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- ✔️  The changes have been tested locally
- ✔️  There are no breaking changes

* **What kind of change does this PR introduce?**

- Make translation strings into one contiguous block
- Index individual strings using 16-bit integer offsets
- Group translation string indices into a single struct


* **Other information**:

I want to make it so that the translation data (excluding font table) can be compressed in ROM and decompressed to RAM on boot, which should help reduce ROM size for multi-language builds. For multi-language use, only the active language needs to be extracted to RAM. I already had a prototype with compression working, using https://github.com/janding/lzfx (would like to try other compression algorithms, but when I tried FastLZ it didn't work for unknown reasons).

Italian (IT) currently has the largest translation data at 3797 bytes. The smallest is ZH_CN and ZH_TW at 1431 bytes. All translations (excluding the un-merged Japanese translation) combined takes 78846 bytes. (These values do not include the font tables.) Assuming an average compression ratio of 0.8, it could save about 15.4KB (actual saving per build will be less since they won't include all languages).

I think I might skip the compression for the Miniware devices since the STM32 only has 20KB of RAM. I also need to try to exclude the unused strings in the Miniware builds, but this requires further refactoring of the Python script.

This conflicts with PR #919 but I will probably redo that on top of this PR, or after implementing compression.

