### PR TITLE
Impl. menu item scroll down animation

### DIFF
--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -59,7 +59,38 @@ FRToSI2C::I2C_REG OLED_Setup_Array[] = {
 };
 // Setup based on the SSD1307 and modified for the SSD1306
 
-const uint8_t REFRESH_COMMANDS[17] = {0x80, 0xAF, 0x80, 0x21, 0x80, 0x20, 0x80, 0x7F, 0x80, 0xC0, 0x80, 0x22, 0x80, 0x00, 0x80, 0x01, 0x40};
+const uint8_t REFRESH_COMMANDS[17] = {
+    // Set display ON:
+    0x80,
+    0xAF, // cmd
+
+    // Set column address:
+    //  A[6:0] - Column start address = 0x20
+    //  B[6:0] - Column end address = 0x7F
+    0x80,
+    0x21, // cmd
+    0x80,
+    0x20, // A
+    0x80,
+    0x7F, // B
+
+    // Set COM output scan direction (normal mode, COM0 to COM[N-1])
+    0x80,
+    0xC0,
+
+    // Set page address:
+    //  A[2:0] - Page start address = 0
+    //  B[2:0] - Page end address = 1
+    0x80,
+    0x22, // cmd
+    0x80,
+    0x00, // A
+    0x80,
+    0x01, // B
+
+    // Start of data
+    0x40,
+};
 
 /*
  * Animation timing function that follows a bezier curve.
@@ -233,6 +264,45 @@ void OLED::useSecondaryFramebuffer(bool useSecondary) {
     setFramebuffer(secondFrameBuffer);
   } else {
     setFramebuffer(NULL);
+  }
+}
+/**
+ * Plays a transition animation of scrolling downward. Note this does *not*
+ * use the secondary framebuffer.
+ *
+ * This transition relies on the previous screen data already in the OLED
+ * RAM. The caller shall not call `OLED::refresh()` before calling this
+ * method, as doing so will overwrite the previous screen data. The caller
+ * does not need to call `OLED::refresh()` after this function returns.
+ *
+ * **This function blocks until the transition has completed.**
+ */
+void OLED::transitionScrollDown() {
+  // We want to draw the updated framebuffer to the next page downward.
+  uint8_t const pageStart = screenBuffer[13];
+  uint8_t const nextPage  = (pageStart + 2) % 8;
+  // Change page start address:
+  screenBuffer[13] = nextPage;
+  // Change page end address:
+  screenBuffer[15] = nextPage + 1;
+
+  refresh();
+  osDelay(TICKS_100MS / 5);
+
+  uint8_t const startLine = pageStart * 8 + 1;
+  uint8_t const scrollTo  = (pageStart + 2) * 8;
+
+  // Scroll the screen by changing display start line.
+  for (uint8_t current = startLine; current <= scrollTo; current++) {
+    // Set display start line (0x40~0x7F):
+    //  X[5:0] - display start line value
+    uint8_t scrollCommandByte = 0b01000000 | (current & 0b00111111);
+
+    // Also update setup command for "set display start line":
+    OLED_Setup_Array[8].val = scrollCommandByte;
+
+    FRToSI2C::I2C_RegisterWrite(DEVICEADDR_OLED, 0x80, scrollCommandByte);
+    osDelay(TICKS_100MS / 5);
   }
 }
 

--- a/source/Core/Drivers/OLED.hpp
+++ b/source/Core/Drivers/OLED.hpp
@@ -81,6 +81,7 @@ public:
   static void drawScrollIndicator(uint8_t p, uint8_t h); // Draws a scrolling position indicator
   static void transitionSecondaryFramebuffer(bool forwardNavigation);
   static void useSecondaryFramebuffer(bool useSecondary);
+  static void transitionScrollDown();
 
 private:
   static void         drawChar(uint16_t charCode, FontStyle fontStyle); // Draw a character to the current cursor location

--- a/source/Core/Drivers/OLED.hpp
+++ b/source/Core/Drivers/OLED.hpp
@@ -79,6 +79,7 @@ public:
   static void drawFilledRect(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1, bool clear);
   static void drawHeatSymbol(uint8_t state);
   static void drawScrollIndicator(uint8_t p, uint8_t h); // Draws a scrolling position indicator
+  static void maskScrollIndicatorOnOLED();
   static void transitionSecondaryFramebuffer(bool forwardNavigation);
   static void useSecondaryFramebuffer(bool useSecondary);
   static void transitionScrollDown();

--- a/source/Core/Src/gui.cpp
+++ b/source/Core/Src/gui.cpp
@@ -1043,6 +1043,7 @@ void gui_Menu(const menuitem *menu) {
   uint8_t     scrollContentSize      = 0;
   bool        scrollBlink            = false;
   bool        lastValue              = false;
+  bool        scrollingDown          = false;
 
   ScrollMessage scrollMessage;
 
@@ -1068,6 +1069,10 @@ void gui_Menu(const menuitem *menu) {
 
   while ((menu[currentScreen].draw != nullptr) && earlyExit == false) {
     OLED::setCursor(0, 0);
+    if (scrollingDown) {
+      animOpenState = true;
+    }
+
     // If the user has hesitated for >=3 seconds, show the long text
     // Otherwise "draw" the option
     if ((xTaskGetTickCount() - lastButtonTime < (TICKS_SECOND * 3)) || menu[currentScreen].description == 0) {
@@ -1087,6 +1092,18 @@ void gui_Menu(const menuitem *menu) {
       // Draw description
       const char *description = translatedString(Tr->SettingsDescriptions[menu[currentScreen].description - 1]);
       lcdRefresh |= scrollMessage.drawUpdate(description, xTaskGetTickCount());
+    }
+
+    if (lcdRefresh) {
+      if (scrollingDown) {
+        OLED::transitionScrollDown();
+        scrollingDown = false;
+        animOpenState = false;
+      } else {
+        OLED::refresh(); // update the LCD
+        osDelay(40);
+      }
+      lcdRefresh = false;
     }
 
     ButtonState buttons = getButtonState();
@@ -1115,7 +1132,8 @@ void gui_Menu(const menuitem *menu) {
     case BUTTON_B_SHORT:
       if (scrollMessage.isReset()) {
         currentScreen++;
-        lastValue = false;
+        scrollingDown = true;
+        lastValue     = false;
       } else
         scrollMessage.reset();
       break;
@@ -1136,6 +1154,7 @@ void gui_Menu(const menuitem *menu) {
     case BUTTON_B_LONG:
       if (xTaskGetTickCount() - autoRepeatTimer + autoRepeatAcceleration > PRESS_ACCEL_INTERVAL_MAX) {
         currentScreen++;
+        scrollingDown   = true;
         autoRepeatTimer = xTaskGetTickCount();
         scrollMessage.reset();
 
@@ -1151,11 +1170,6 @@ void gui_Menu(const menuitem *menu) {
       autoRepeatAcceleration = PRESS_ACCEL_INTERVAL_MAX - PRESS_ACCEL_INTERVAL_MIN;
     }
 
-    if (lcdRefresh) {
-      OLED::refresh(); // update the LCD
-      osDelay(40);
-      lcdRefresh = false;
-    }
     if ((xTaskGetTickCount() - lastButtonTime) > (TICKS_SECOND * 30)) {
       // If user has not pressed any buttons in 30 seconds, exit back a menu layer
       // This will trickle the user back to the main screen eventually
@@ -1163,6 +1177,8 @@ void gui_Menu(const menuitem *menu) {
       scrollMessage.reset();
     }
   }
+
+  animOpenState = false;
 }
 
 void enterSettingsMenu() {

--- a/source/Core/Src/gui.cpp
+++ b/source/Core/Src/gui.cpp
@@ -1086,7 +1086,7 @@ void gui_Menu(const menuitem *menu) {
       uint8_t position        = OLED_HEIGHT * currentScreen / scrollContentSize;
       if (lastValue)
         scrollBlink = !scrollBlink;
-      if (!lastValue || !scrollBlink)
+      if ((!lastValue || !scrollBlink) && !scrollingDown)
         OLED::drawScrollIndicator(position, indicatorHeight);
     } else {
       // Draw description
@@ -1096,6 +1096,7 @@ void gui_Menu(const menuitem *menu) {
 
     if (lcdRefresh) {
       if (scrollingDown) {
+        OLED::maskScrollIndicatorOnOLED();
         OLED::transitionScrollDown();
         scrollingDown = false;
         animOpenState = false;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**

Feature: Added a scroll-down animation when changing menu items.

Part of what's mentioned in #892.


* **What is the current behavior?**

When changing to the next menu item, the screen changes directly with no transition animation.

* **What is the new behavior (if this is a feature change)?**

When changing to the next menu item, the screen changes via a scroll-down animation.

* **Other information**:

This change involves changing some of the OLED command parameters, so this may require some careful review.

If the screen gets rotated when the scroll-down transition is playing, the transition becomes weird. The screen gets refreshed after the transition has finished playing, so I don't think this is a critical issue.