### PR TITLE
Enable shutdown from sleep mode

### DIFF
--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -297,6 +297,9 @@ static bool shouldShutdown() {
       }
     }
   }
+  if (getButtonState() == BUTTON_B_LONG) { // allow also if back button is pressed long
+    return true;
+  }
   return false;
 }
 static int gui_SolderingSleepingMode(bool stayOff, bool autoStarted) {


### PR DESCRIPTION
If the iron is in sleep mode it is now possible to shutdown with
a long press on the back button without reheating in-between.

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Feature

* **What is the current behavior?**
If the iron is in sleep mode (in my case via the hall sensor) it is not possible to exit soldering mode without leaving the sleep mode. This causes an unnecessary heating of the tip before you can exit soldering mode via a long back button press.

* **What is the new behavior (if this is a feature change)?**
It is now possible to shutdown directly from sleeping mode with a long back button press.
