### PR TITLE
Fix typo in line 9 of Flashing.md

### DIFF
--- a/Documentation/Flashing.md
+++ b/Documentation/Flashing.md
@@ -6,7 +6,7 @@
 
 Main releases are made to the [releases page](https://github.com/Ralim/IronOS/releases).
 Download the zip file that matches your model of soldering iron, and extract it.
-You then need to use the appropriate file type for your unit, in general Miniware irons are `.hex` and Pinecil is `.bin.`
+You then need to use the appropriate file type for your unit, in general Miniware irons are `.hex` and Pinecil is `.bin`.
 Flash according to details below
 
 ### Bleeding edge / latest


### PR DESCRIPTION
there was a dot included as code block after .bin in line 9


Please try and fill out this template where possible, not all fields are required and can be removed.

* **Please check if the PR fulfills these requirements**

* **What kind of change does this PR introduce?**
(Bug fix, feature, docs update, ...)
docs

* **What is the current behavior?**
typo in the Flashing Guide