### PR TITLE
languages (certain unifying)

### DIFF
--- a/Translations/translation_BG.json
+++ b/Translations/translation_BG.json
@@ -298,14 +298,14 @@
 				"Power pulse",
 				"wait time"
 			],
-			"desc": "Time to wait before triggering every keep-awake pulse (x 2,5s)"
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2,5с)"
 		},
 		"PowerPulseDuration": {
 			"text2": [
 				"Power pulse",
 				"duration"
 			],
-			"desc": "Keep-awake-pulse duration (x 250ms)"
+			"desc": "Keep-awake-pulse duration (x 250мс)"
 		},
 		"LanguageSwitch": {
 			"text2": [

--- a/Translations/translation_BG.json
+++ b/Translations/translation_BG.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "R",
 		"SettingLeftChar": "L",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "F",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "F",
 		"SettingStartNoneChar": "И",
 		"SettingStartSolderingChar": "Р",
 		"SettingStartSleepChar": "С",

--- a/Translations/translation_BG.json
+++ b/Translations/translation_BG.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "R",
 		"SettingLeftChar": "L",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
@@ -158,7 +158,7 @@
 				"Ориентация",
 				"на дисплея"
 			],
-			"desc": "Ориентация на дисплея (A=Автоматично | L=Лява Ръка | R=Дясна Ръка)"
+			"desc": "Ориентация на дисплея (R=Дясна Ръка | L=Лява Ръка | A=Автоматично)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_CS.json
+++ b/Translations/translation_CS.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "P",
 		"SettingLeftChar": "L",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "R",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "P",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "R",
 		"SettingStartNoneChar": "O",
 		"SettingStartSolderingChar": "P",
 		"SettingStartSleepChar": "S",

--- a/Translations/translation_CS.json
+++ b/Translations/translation_CS.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "P",
 		"SettingLeftChar": "L",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "P",
 		"SettingMediumChar": "M",
@@ -157,7 +157,7 @@
 				"Orientace",
 				"obrazovky"
 			],
-			"desc": "Orientace obrazovky (A=Auto | L=Levák | P=Pravák)."
+			"desc": "Orientace obrazovky (P=Pravák | L=Levák | A=Auto)."
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_DA.json
+++ b/Translations/translation_DA.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "H",
 		"SettingLeftChar": "V",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "F",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "F",
 		"SettingStartNoneChar": "S",
 		"SettingStartSolderingChar": "L",
 		"SettingStartSleepChar": "D",

--- a/Translations/translation_DA.json
+++ b/Translations/translation_DA.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "H",
 		"SettingLeftChar": "V",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
@@ -157,7 +157,7 @@
 				"Display",
 				"orientation"
 			],
-			"desc": "Skærm Orientering (A=Automatisk | V=Venstre Håndet | H=Højre Håndet)"
+			"desc": "Skærm Orientering (H=Højre Håndet | V=Venstre Håndet | A=Automatisk)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_DE.json
+++ b/Translations/translation_DE.json
@@ -46,13 +46,13 @@
 		"WarningKeysLockedString": "!GESPERRT!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "R",
 		"SettingLeftChar": "L",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "S",
+		"SettingOffChar": "A",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "A",
+		"SettingFastChar": "S",
 		"SettingStartNoneChar": "A",
 		"SettingStartSolderingChar": "L",
 		"SettingStartSleepChar": "R",

--- a/Translations/translation_DE.json
+++ b/Translations/translation_DE.json
@@ -46,9 +46,9 @@
 		"WarningKeysLockedString": "!GESPERRT!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "R",
 		"SettingLeftChar": "L",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "A",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
@@ -158,7 +158,7 @@
 				"Anzeige-",
 				"ausrichtung"
 			],
-			"desc": "A=automatisch | L=linkshändig | R=rechtshändig"
+			"desc": "R=rechtshändig | L=linkshändig | A=automatisch"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_EN.json
+++ b/Translations/translation_EN.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "R",
 		"SettingLeftChar": "L",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "F",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "F",
 		"SettingStartNoneChar": "O",
 		"SettingStartSolderingChar": "S",
 		"SettingStartSleepChar": "Z",
@@ -108,7 +108,7 @@
 				"Power",
 				"source"
 			],
-			"desc": "Power source. Sets cutoff voltage. (DC 10V) (S 3.3V per cell, disable power limit)"
+			"desc": "Power source. Sets cutoff voltage. [DC 10V] [S 3.3V per cell, disable power limit]"
 		},
 		"SleepTemperature": {
 			"text2": [
@@ -122,14 +122,14 @@
 				"Sleep",
 				"timeout"
 			],
-			"desc": "Interval before \"sleep mode\" kicks in (S=seconds | M=minutes)"
+			"desc": "Interval before \"sleep mode\" kicks in [S=seconds | M=minutes]"
 		},
 		"ShutdownTimeout": {
 			"text2": [
 				"Shutdown",
 				"timeout"
 			],
-			"desc": "Interval before the iron shuts down (M=minutes)"
+			"desc": "Interval before the iron shuts down [M=minutes]"
 		},
 		"MotionSensitivity": {
 			"text2": [
@@ -199,7 +199,7 @@
 				"Calibrate",
 				"input voltage?"
 			],
-			"desc": "Start VIN calibration (long press to exit)"
+			"desc": "Start VIN calibration [long press to exit]"
 		},
 		"AdvancedSoldering": {
 			"text2": [
@@ -213,7 +213,7 @@
 				"Scrolling",
 				"speed"
 			],
-			"desc": "Speed info text scrolls past at (S=slow | F=fast)"
+			"desc": "Speed info text scrolls past at [S=slow | F=fast]"
 		},
 		"QCMaxVoltage": {
 			"text2": [
@@ -227,7 +227,7 @@
 				"Power",
 				"limit"
 			],
-			"desc": "Maximum power the iron can use (W=watt)"
+			"desc": "Maximum power the iron can use [W=watt]"
 		},
 		"ReverseButtonTempChange": {
 			"text2": [
@@ -255,28 +255,28 @@
 				"Power",
 				"pulse"
 			],
-			"desc": "Intensity of power of keep-awake-pulse (watt)"
+			"desc": "Intensity of power of keep-awake-pulse [watt]"
 		},
 		"HallEffSensitivity": {
 			"text2": [
 				"Hall sensor",
 				"sensitivity"
 			],
-			"desc": "Sensitivity of the Hall effect sensor to detect sleep (O=off | L=low | M=medium | H=high)"
+			"desc": "Sensitivity of the Hall effect sensor to detect sleep [O=off | L=low | M=medium | H=high]"
 		},
 		"LockingMode": {
 			"text2": [
 				"Allow locking",
 				"buttons"
 			],
-			"desc": "While soldering, hold down both buttons to toggle locking them (D=disable | B=boost mode only | F=full locking)"
+			"desc": "While soldering, hold down both buttons to toggle locking them [D=disable | B=boost mode only | F=full locking]"
 		},
 		"MinVolCell": {
 			"text2": [
 				"Minimum",
 				"voltage"
 			],
-			"desc": "Minimum allowed voltage per cell (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+			"desc": "Minimum allowed voltage per cell [3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V]"
 		},
 		"AnimLoop": {
 			"text2": [
@@ -290,21 +290,21 @@
 				"Anim.",
 				"speed"
 			],
-			"desc": "Pace of icon animations in menu (O=off | S=slow | M=medium | F=fast)"
+			"desc": "Pace of icon animations in menu [O=off | S=slow | M=medium | F=fast]"
 		},
 		"PowerPulseWait": {
 			"text2": [
 				"Power pulse",
 				"delay"
 			],
-			"desc": "Delay before keep-awake pulse is triggered (x 2.5s)"
+			"desc": "Delay before keep-awake pulse is triggered [x 2.5s]"
 		},
 		"PowerPulseDuration": {
 			"text2": [
 				"Power pulse",
 				"duration"
 			],
-			"desc": "Keep-awake-pulse duration (x 250ms)"
+			"desc": "Keep-awake-pulse duration [x 250ms]"
 		},
 		"LanguageSwitch": {
 			"text2": [

--- a/Translations/translation_EN.json
+++ b/Translations/translation_EN.json
@@ -108,7 +108,7 @@
 				"Power",
 				"source"
 			],
-			"desc": "Power source. Sets cutoff voltage. [DC 10V] [S 3.3V per cell, disable power limit]"
+			"desc": "Power source. Sets cutoff voltage. (DC 10V) (S 3.3V per cell, disable power limit)"
 		},
 		"SleepTemperature": {
 			"text2": [
@@ -122,14 +122,14 @@
 				"Sleep",
 				"timeout"
 			],
-			"desc": "Interval before \"sleep mode\" kicks in [S=seconds | M=minutes]"
+			"desc": "Interval before \"sleep mode\" kicks in (S=seconds | M=minutes)"
 		},
 		"ShutdownTimeout": {
 			"text2": [
 				"Shutdown",
 				"timeout"
 			],
-			"desc": "Interval before the iron shuts down [M=minutes]"
+			"desc": "Interval before the iron shuts down (M=minutes)"
 		},
 		"MotionSensitivity": {
 			"text2": [
@@ -199,7 +199,7 @@
 				"Calibrate",
 				"input voltage?"
 			],
-			"desc": "Start VIN calibration [long press to exit]"
+			"desc": "Start VIN calibration (long press to exit)"
 		},
 		"AdvancedSoldering": {
 			"text2": [
@@ -213,7 +213,7 @@
 				"Scrolling",
 				"speed"
 			],
-			"desc": "Speed info text scrolls past at [S=slow | F=fast]"
+			"desc": "Speed info text scrolls past at (S=slow | F=fast)"
 		},
 		"QCMaxVoltage": {
 			"text2": [
@@ -227,7 +227,7 @@
 				"Power",
 				"limit"
 			],
-			"desc": "Maximum power the iron can use [W=watt]"
+			"desc": "Maximum power the iron can use (W=watt)"
 		},
 		"ReverseButtonTempChange": {
 			"text2": [
@@ -255,28 +255,28 @@
 				"Power",
 				"pulse"
 			],
-			"desc": "Intensity of power of keep-awake-pulse [watt]"
+			"desc": "Intensity of power of keep-awake-pulse (watt)"
 		},
 		"HallEffSensitivity": {
 			"text2": [
 				"Hall sensor",
 				"sensitivity"
 			],
-			"desc": "Sensitivity of the Hall effect sensor to detect sleep [O=off | L=low | M=medium | H=high]"
+			"desc": "Sensitivity of the Hall effect sensor to detect sleep (O=off | L=low | M=medium | H=high)"
 		},
 		"LockingMode": {
 			"text2": [
 				"Allow locking",
 				"buttons"
 			],
-			"desc": "While soldering, hold down both buttons to toggle locking them [D=disable | B=boost mode only | F=full locking]"
+			"desc": "While soldering, hold down both buttons to toggle locking them (D=disable | B=boost mode only | F=full locking)"
 		},
 		"MinVolCell": {
 			"text2": [
 				"Minimum",
 				"voltage"
 			],
-			"desc": "Minimum allowed voltage per cell [3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V]"
+			"desc": "Minimum allowed voltage per cell (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
 		},
 		"AnimLoop": {
 			"text2": [
@@ -290,21 +290,21 @@
 				"Anim.",
 				"speed"
 			],
-			"desc": "Pace of icon animations in menu [O=off | S=slow | M=medium | F=fast]"
+			"desc": "Pace of icon animations in menu (O=off | S=slow | M=medium | F=fast)"
 		},
 		"PowerPulseWait": {
 			"text2": [
 				"Power pulse",
 				"delay"
 			],
-			"desc": "Delay before keep-awake pulse is triggered [x 2.5s]"
+			"desc": "Delay before keep-awake pulse is triggered (x 2.5s)"
 		},
 		"PowerPulseDuration": {
 			"text2": [
 				"Power pulse",
 				"duration"
 			],
-			"desc": "Keep-awake-pulse duration [x 250ms]"
+			"desc": "Keep-awake-pulse duration (x 250ms)"
 		},
 		"LanguageSwitch": {
 			"text2": [

--- a/Translations/translation_EN.json
+++ b/Translations/translation_EN.json
@@ -46,8 +46,8 @@
 	},
 	"characters": {
 		"SettingAutoChar": "A",
-		"SettingRightChar": "R",
-		"SettingLeftChar": "L",
+		"SettingRightChar": ">",
+		"SettingLeftChar": "<",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
@@ -157,7 +157,7 @@
 				"Display",
 				"orientation"
 			],
-			"desc": "A=automatic | L=left-handed | R=right-handed"
+			"desc": "A=automatic | <=left-handed | >=right-handed"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_EN.json
+++ b/Translations/translation_EN.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
+		"SettingRightChar": "R",
+		"SettingLeftChar": "L",
 		"SettingAutoChar": "A",
-		"SettingRightChar": ">",
-		"SettingLeftChar": "<",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
@@ -157,7 +157,7 @@
 				"Display",
 				"orientation"
 			],
-			"desc": "A=automatic | <=left-handed | >=right-handed"
+			"desc": "R=right-handed | L=left-handed | A=automatic"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_ES.json
+++ b/Translations/translation_ES.json
@@ -46,13 +46,13 @@
 		"WarningKeysLockedString": "¡BLOQUEADO!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "D",
 		"SettingLeftChar": "I",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "R",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "R",
 		"SettingStartNoneChar": "N",
 		"SettingStartSolderingChar": "S",
 		"SettingStartSleepChar": "R",
@@ -109,7 +109,7 @@
 				"Fuente",
 				"de energía"
 			],
-			"desc": "Elige el tipo de fuente para limitar el voltaje (DC 10V) (S 3,3V por pila, ilimitado)"
+			"desc": "Elige el tipo de fuente para limitar el voltaje [DC 10V] [S 3,3V por pila, ilimitado]"
 		},
 		"SleepTemperature": {
 			"text2": [
@@ -123,28 +123,28 @@
 				"Entrar",
 				"en reposo"
 			],
-			"desc": "Tiempo de inactividad para entrar en reposo (min | seg)"
+			"desc": "Tiempo de inactividad para entrar en reposo [min | seg]"
 		},
 		"ShutdownTimeout": {
 			"text2": [
 				"Tiempo de",
 				"apagado"
 			],
-			"desc": "Tiempo de inactividad para apagarse (en minutos)"
+			"desc": "Tiempo de inactividad para apagarse [en minutos]"
 		},
 		"MotionSensitivity": {
 			"text2": [
 				"Detección de",
 				"movimiento"
 			],
-			"desc": "Tiempo de reacción al agarrar (0=no | 1=menos sensible | ... | 9=más sensible)"
+			"desc": "Tiempo de reacción al agarrar [0=no | 1=menos sensible | ... | 9=más sensible]"
 		},
 		"TemperatureUnit": {
 			"text2": [
 				"Unidad de",
 				"temperatura"
 			],
-			"desc": "Unidad de temperatura (C=centígrados | F=Fahrenheit)"
+			"desc": "Unidad de temperatura [C=centígrados | F=Fahrenheit]"
 		},
 		"AdvancedIdle": {
 			"text2": [
@@ -158,7 +158,7 @@
 				"Orientación",
 				"de pantalla"
 			],
-			"desc": "Orientación de la pantalla (A=automático | I=zurdo | D=diestro)"
+			"desc": "Orientación de la pantalla [A=automático | I=zurdo | D=diestro]"
 		},
 		"BoostTemperature": {
 			"text2": [
@@ -172,7 +172,7 @@
 				"Calentar",
 				"al enchufar"
 			],
-			"desc": "Se calienta él solo al arrancar (N=no | S=entrar en modo soldar | R=solo entrar en reposo | F=en reposo pero mantiene la punta fría)"
+			"desc": "Se calienta él solo al arrancar [N=no | S=entrar en modo soldar | R=solo entrar en reposo | F=en reposo pero mantiene la punta fría]"
 		},
 		"CooldownBlink": {
 			"text2": [
@@ -214,7 +214,7 @@
 				"Velocidad",
 				"del texto"
 			],
-			"desc": "Velocidad de desplazamiento del texto (R=rápida | L=lenta)"
+			"desc": "Velocidad de desplazamiento del texto [R=rápida | L=lenta]"
 		},
 		"QCMaxVoltage": {
 			"text2": [
@@ -228,7 +228,7 @@
 				"Ajustar la",
 				"potenc. máx."
 			],
-			"desc": "Elige el límite de potencia máxima del soldador (en vatios)"
+			"desc": "Elige el límite de potencia máxima del soldador [en vatios]"
 		},
 		"ReverseButtonTempChange": {
 			"text2": [
@@ -263,21 +263,21 @@
 				"Hall Eff",
 				"Sensibilidad"
 			],
-			"desc": "Sensibilidad del sensor de efecto Hall en la detección de reposo (O=Off | L=Low | M=Medium | H=High)"
+			"desc": "Sensibilidad del sensor de efecto Hall en la detección de reposo [O=Off | L=Low | M=Medium | H=High]"
 		},
 		"LockingMode": {
 			"text2": [
 				"Permitir botones",
 				"bloqueo"
 			],
-			"desc": "Al soldar, una pulsación larga en ambos botones los bloquea (D=desactivar | B=sólo potenciar | F=bloqueo total)."
+			"desc": "Al soldar, una pulsación larga en ambos botones los bloquea [D=desactivar | B=sólo potenciar | F=bloqueo total]."
 		},
 		"MinVolCell": {
 			"text2": [
 				"Mínimo",
 				"voltaje"
 			],
-			"desc": "voltaje mínimo permitido por célula (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
+			"desc": "voltaje mínimo permitido por célula [3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V]"
 		},
 		"AnimLoop": {
 			"text2": [
@@ -291,21 +291,21 @@
 				"Anim.",
 				"velocidad"
 			],
-			"desc": "Velocidad de las animaciones de los iconos en el menú (O=off | L=low | M=medium | H=high)"
+			"desc": "Velocidad de las animaciones de los iconos en el menú [O=off | L=low | M=medium | H=high]"
 		},
 		"PowerPulseWait": {
 			"text2": [
 				"Impulso de potencia",
 				"tiempo de espera"
 			],
-			"desc": "Tiempo de espera antes de disparar cada pulso de mantenimiento de la vigilia (x 2,5s)"
+			"desc": "Tiempo de espera antes de disparar cada pulso de mantenimiento de la vigilia [x 2,5s]"
 		},
 		"PowerPulseDuration": {
 			"text2": [
 				"Impulso de potencia",
 				"duración"
 			],
-			"desc": "Duración del impulso de mantenimiento de la vigilia (x 250ms)"
+			"desc": "Duración del impulso de mantenimiento de la vigilia [x 250ms]"
 		},
 		"LanguageSwitch": {
 			"text2": [

--- a/Translations/translation_ES.json
+++ b/Translations/translation_ES.json
@@ -46,9 +46,9 @@
 		"WarningKeysLockedString": "¡BLOQUEADO!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "D",
 		"SettingLeftChar": "I",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
@@ -158,7 +158,7 @@
 				"Orientación",
 				"de pantalla"
 			],
-			"desc": "Orientación de la pantalla (A=automático | I=zurdo | D=diestro)"
+			"desc": "Orientación de la pantalla (D=diestro | I=zurdo | A=automático)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_ES.json
+++ b/Translations/translation_ES.json
@@ -109,7 +109,7 @@
 				"Fuente",
 				"de energía"
 			],
-			"desc": "Elige el tipo de fuente para limitar el voltaje [DC 10V] [S 3,3V por pila, ilimitado]"
+			"desc": "Elige el tipo de fuente para limitar el voltaje (DC 10V) (S 3,3V por pila, ilimitado)"
 		},
 		"SleepTemperature": {
 			"text2": [
@@ -123,28 +123,28 @@
 				"Entrar",
 				"en reposo"
 			],
-			"desc": "Tiempo de inactividad para entrar en reposo [min | seg]"
+			"desc": "Tiempo de inactividad para entrar en reposo (min | seg)"
 		},
 		"ShutdownTimeout": {
 			"text2": [
 				"Tiempo de",
 				"apagado"
 			],
-			"desc": "Tiempo de inactividad para apagarse [en minutos]"
+			"desc": "Tiempo de inactividad para apagarse (en minutos)"
 		},
 		"MotionSensitivity": {
 			"text2": [
 				"Detección de",
 				"movimiento"
 			],
-			"desc": "Tiempo de reacción al agarrar [0=no | 1=menos sensible | ... | 9=más sensible]"
+			"desc": "Tiempo de reacción al agarrar (0=no | 1=menos sensible | ... | 9=más sensible)"
 		},
 		"TemperatureUnit": {
 			"text2": [
 				"Unidad de",
 				"temperatura"
 			],
-			"desc": "Unidad de temperatura [C=centígrados | F=Fahrenheit]"
+			"desc": "Unidad de temperatura (C=centígrados | F=Fahrenheit)"
 		},
 		"AdvancedIdle": {
 			"text2": [
@@ -158,7 +158,7 @@
 				"Orientación",
 				"de pantalla"
 			],
-			"desc": "Orientación de la pantalla [A=automático | I=zurdo | D=diestro]"
+			"desc": "Orientación de la pantalla (A=automático | I=zurdo | D=diestro)"
 		},
 		"BoostTemperature": {
 			"text2": [
@@ -172,7 +172,7 @@
 				"Calentar",
 				"al enchufar"
 			],
-			"desc": "Se calienta él solo al arrancar [N=no | S=entrar en modo soldar | R=solo entrar en reposo | F=en reposo pero mantiene la punta fría]"
+			"desc": "Se calienta él solo al arrancar (N=no | S=entrar en modo soldar | R=solo entrar en reposo | F=en reposo pero mantiene la punta fría)"
 		},
 		"CooldownBlink": {
 			"text2": [
@@ -214,7 +214,7 @@
 				"Velocidad",
 				"del texto"
 			],
-			"desc": "Velocidad de desplazamiento del texto [R=rápida | L=lenta]"
+			"desc": "Velocidad de desplazamiento del texto (R=rápida | L=lenta)"
 		},
 		"QCMaxVoltage": {
 			"text2": [
@@ -228,7 +228,7 @@
 				"Ajustar la",
 				"potenc. máx."
 			],
-			"desc": "Elige el límite de potencia máxima del soldador [en vatios]"
+			"desc": "Elige el límite de potencia máxima del soldador (en vatios)"
 		},
 		"ReverseButtonTempChange": {
 			"text2": [
@@ -263,21 +263,21 @@
 				"Hall Eff",
 				"Sensibilidad"
 			],
-			"desc": "Sensibilidad del sensor de efecto Hall en la detección de reposo [O=Off | L=Low | M=Medium | H=High]"
+			"desc": "Sensibilidad del sensor de efecto Hall en la detección de reposo (O=Off | L=Low | M=Medium | H=High)"
 		},
 		"LockingMode": {
 			"text2": [
 				"Permitir botones",
 				"bloqueo"
 			],
-			"desc": "Al soldar, una pulsación larga en ambos botones los bloquea [D=desactivar | B=sólo potenciar | F=bloqueo total]."
+			"desc": "Al soldar, una pulsación larga en ambos botones los bloquea (D=desactivar | B=sólo potenciar | F=bloqueo total)."
 		},
 		"MinVolCell": {
 			"text2": [
 				"Mínimo",
 				"voltaje"
 			],
-			"desc": "voltaje mínimo permitido por célula [3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V]"
+			"desc": "voltaje mínimo permitido por célula (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
 		},
 		"AnimLoop": {
 			"text2": [
@@ -291,21 +291,21 @@
 				"Anim.",
 				"velocidad"
 			],
-			"desc": "Velocidad de las animaciones de los iconos en el menú [O=off | L=low | M=medium | H=high]"
+			"desc": "Velocidad de las animaciones de los iconos en el menú (O=off | L=low | M=medium | H=high)"
 		},
 		"PowerPulseWait": {
 			"text2": [
 				"Impulso de potencia",
 				"tiempo de espera"
 			],
-			"desc": "Tiempo de espera antes de disparar cada pulso de mantenimiento de la vigilia [x 2,5s]"
+			"desc": "Tiempo de espera antes de disparar cada pulso de mantenimiento de la vigilia (x 2,5s)"
 		},
 		"PowerPulseDuration": {
 			"text2": [
 				"Impulso de potencia",
 				"duración"
 			],
-			"desc": "Duración del impulso de mantenimiento de la vigilia [x 250ms]"
+			"desc": "Duración del impulso de mantenimiento de la vigilia (x 250ms)"
 		},
 		"LanguageSwitch": {
 			"text2": [

--- a/Translations/translation_FI.json
+++ b/Translations/translation_FI.json
@@ -44,13 +44,13 @@
 		"WarningKeysLockedString": "!LUKKO!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "O",
 		"SettingLeftChar": "V",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "N",
+		"SettingOffChar": "P",
 		"SettingSlowChar": "H",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "P",
+		"SettingFastChar": "N",
 		"SettingStartNoneChar": "E",
 		"SettingStartSolderingChar": "J",
 		"SettingStartSleepChar": "L",

--- a/Translations/translation_FI.json
+++ b/Translations/translation_FI.json
@@ -44,9 +44,9 @@
 		"WarningKeysLockedString": "!LUKKO!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "O",
 		"SettingLeftChar": "V",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "P",
 		"SettingSlowChar": "H",
 		"SettingMediumChar": "M",
@@ -156,7 +156,7 @@
 				"Näytön",
 				"kierto"
 			],
-			"desc": "A=automaattinen | V=vasenkätinen | O=oikeakätinen"
+			"desc": "O=oikeakätinen | V=vasenkätinen | A=automaattinen"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_FR.json
+++ b/Translations/translation_FR.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "! VERR. !"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "D",
 		"SettingLeftChar": "G",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "R",
+		"SettingOffChar": "D",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "D",
+		"SettingFastChar": "R",
 		"SettingStartNoneChar": "D",
 		"SettingStartSolderingChar": "A",
 		"SettingStartSleepChar": "V",

--- a/Translations/translation_FR.json
+++ b/Translations/translation_FR.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "! VERR. !"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "D",
 		"SettingLeftChar": "G",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "D",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
@@ -157,7 +157,7 @@
 				"Orientation",
 				"de l'écran"
 			],
-			"desc": "A=automatique | G=gaucher | D=droitier"
+			"desc": "D=droitier | G=gaucher | A=automatique"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_HR.json
+++ b/Translations/translation_HR.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "D",
 		"SettingLeftChar": "L",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "B",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "B",
 		"SettingStartNoneChar": "I",
 		"SettingStartSolderingChar": "L",
 		"SettingStartSleepChar": "R",

--- a/Translations/translation_HR.json
+++ b/Translations/translation_HR.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "D",
 		"SettingLeftChar": "L",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
@@ -157,7 +157,7 @@
 				"Rotacija",
 				"ekrana"
 			],
-			"desc": "Orijentacija ekrana. (A=Automatski | L=Ljevoruki | D=Desnoruki)"
+			"desc": "Orijentacija ekrana. (D=Desnoruki | L=Ljevoruki | A=Automatski)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_HU.json
+++ b/Translations/translation_HU.json
@@ -48,9 +48,9 @@
 		"WarningKeysLockedString": "!LEZÁRVA!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "J",
 		"SettingLeftChar": "B",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "0",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "K",
@@ -160,7 +160,7 @@
 				"Kijelző",
 				"tájolása"
 			],
-			"desc": "Kijelző tájolása (A=automatikus | B=balkezes | J=jobbkezes)"
+			"desc": "Kijelző tájolása (J=jobbkezes | B=balkezes | A=automatikus)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_HU.json
+++ b/Translations/translation_HU.json
@@ -48,13 +48,13 @@
 		"WarningKeysLockedString": "!LEZÁRVA!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "J",
 		"SettingLeftChar": "B",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "G",
+		"SettingOffChar": "0",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "K",
-		"SettingOffChar": "0",
+		"SettingFastChar": "G",
 		"SettingStartNoneChar": "K",
 		"SettingStartSolderingChar": "F",
 		"SettingStartSleepChar": "A",

--- a/Translations/translation_IT.json
+++ b/Translations/translation_IT.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "BLOCCATO"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "D",
 		"SettingLeftChar": "S",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
@@ -157,7 +157,7 @@
 				"Orientamento",
 				"display"
 			],
-			"desc": "Imposta l'orientamento del display [A: automatico; S: mano sinistra; D: mano destra]"
+			"desc": "Imposta l'orientamento del display [D: mano destra; S: mano sinistra; A: automatico]"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_IT.json
+++ b/Translations/translation_IT.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "BLOCCATO"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "D",
 		"SettingLeftChar": "S",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "V",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "V",
 		"SettingStartNoneChar": "D",
 		"SettingStartSolderingChar": "S",
 		"SettingStartSleepChar": "R",
@@ -108,21 +108,21 @@
 				"Sorgente",
 				"alimentaz"
 			],
-			"desc": "Imposta una tensione minima di alimentazione attraverso la selezione di una sorgente [DC: 10V | 3-6S: 3,3V per cella]"
+			"desc": "Imposta una tensione minima di alimentazione attraverso la selezione di una sorgente [DC: 10 V; 3S/4S/5S/6S: 3,3 V per cella]"
 		},
 		"SleepTemperature": {
 			"text2": [
 				"Temp",
 				"riposo"
 			],
-			"desc": "Imposta la temperatura da mantenere in modalità Riposo [°C | °F]"
+			"desc": "Imposta la temperatura da mantenere in modalità Riposo [°C/°F]"
 		},
 		"SleepTimeout": {
 			"text2": [
 				"Timer",
 				"riposo"
 			],
-			"desc": "Imposta il timer per entrare in modalità Riposo [minuti | secondi]"
+			"desc": "Imposta il timer per entrare in modalità Riposo [minuti/secondi]"
 		},
 		"ShutdownTimeout": {
 			"text2": [
@@ -136,14 +136,14 @@
 				"Sensibilità",
 				"al movimento"
 			],
-			"desc": "Imposta la sensibilità al movimento per uscire dalla modalità Riposo [0=nessuna | 1=minima | ... | 9=massima]"
+			"desc": "Imposta la sensibilità al movimento per uscire dalla modalità Riposo [0: nessuna; 1: minima; 9: massima]"
 		},
 		"TemperatureUnit": {
 			"text2": [
 				"Unità di",
 				"temperatura"
 			],
-			"desc": "Scegli l'unità di misura per la temperatura [C=grado Celsius | F=grado Farenheit]"
+			"desc": "Scegli l'unità di misura per la temperatura [C: grado Celsius; F: grado Farenheit]"
 		},
 		"AdvancedIdle": {
 			"text2": [
@@ -157,21 +157,21 @@
 				"Orientamento",
 				"display"
 			],
-			"desc": "Imposta l'orientamento del display [A=automatico | S=mano sinistra | D=mano destra]"
+			"desc": "Imposta l'orientamento del display [A: automatico; S: mano sinistra; D: mano destra]"
 		},
 		"BoostTemperature": {
 			"text2": [
 				"Temp",
 				"Turbo"
 			],
-			"desc": "Imposta la temperatura della funzione Turbo [°C | °F]"
+			"desc": "Imposta la temperatura della funzione Turbo [°C/°F]"
 		},
 		"AutoStart": {
 			"text2": [
 				"Avvio",
 				"automatico"
 			],
-			"desc": "Attiva automaticamente il saldatore quando viene alimentato [D=disattiva | S=saldatura | R=riposo | A=temperatura ambiente]"
+			"desc": "Attiva automaticamente il saldatore quando viene alimentato [D: disattiva; S: saldatura; R: riposo; A: temperatura ambiente]"
 		},
 		"CooldownBlink": {
 			"text2": [
@@ -213,7 +213,7 @@
 				"Velocità",
 				"testo"
 			],
-			"desc": "Imposta la velocità di scorrimento del testo [L=lenta | V=veloce]"
+			"desc": "Imposta la velocità di scorrimento del testo [L: lenta; V: veloce]"
 		},
 		"QCMaxVoltage": {
 			"text2": [
@@ -262,21 +262,21 @@
 				"Effetto",
 				"Hall"
 			],
-			"desc": "Regola la sensibilità alla rilevazione di supporti metallici per entrare in modalità Riposo [O=OFF | B=bassa | M=media | A=alta]"
+			"desc": "Regola la sensibilità alla rilevazione di supporti metallici per entrare in modalità Riposo [O: OFF; B: bassa; M: media; A: alta]"
 		},
 		"LockingMode": {
 			"text2": [
 				"Blocco",
 				"tasti"
 			],
-			"desc": "Blocca i tasti durante la modalità Saldatura; tieni premuto entrambi per bloccare o sbloccare [D=disattiva | T=consenti Turbo | C=blocco completo]"
+			"desc": "Blocca i tasti durante la modalità Saldatura; tieni premuto entrambi per bloccare o sbloccare [D: disattiva; T: consenti Turbo; C: blocco completo]"
 		},
 		"MinVolCell": {
 			"text2": [
 				"Tensione",
 				"min celle"
 			],
-			"desc": "Modifica la tensione di minima carica delle celle di una batteria Li-Po [3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V]"
+			"desc": "Modifica la tensione di minima carica delle celle di una batteria Li-Po [3S: 3,0-3,7 V; 4S/5S/6S: 2,4-3,7 V]"
 		},
 		"AnimLoop": {
 			"text2": [
@@ -290,7 +290,7 @@
 				"Velocità",
 				"animazioni"
 			],
-			"desc": "Imposta la velocità di riproduzione delle animazioni del menù principale [O=OFF | L=lenta | M=media | V=veloce]"
+			"desc": "Imposta la velocità di riproduzione delle animazioni del menù principale [O: OFF; L: lenta; M: media; V: veloce]"
 		},
 		"PowerPulseWait": {
 			"text2": [

--- a/Translations/translation_JA_JP.json
+++ b/Translations/translation_JA_JP.json
@@ -43,13 +43,13 @@
 		"WarningKeysLockedString": "!入力ロック中!"
 	},
 	"characters": {
+		"SettingAutoChar": "自",
 		"SettingRightChar": "右",
 		"SettingLeftChar": "左",
-		"SettingAutoChar": "自",
-		"SettingFastChar": "早",
+		"SettingOffChar": "X",
 		"SettingSlowChar": "遅",
 		"SettingMediumChar": "中",
-		"SettingOffChar": "X",
+		"SettingFastChar": "早",
 		"SettingStartNoneChar": "X",
 		"SettingStartSolderingChar": "熱",
 		"SettingStartSleepChar": "待",
@@ -88,7 +88,7 @@
 	"menuOptions": {
 		"DCInCutoff": {
 			"text2": "電源",
-			"desc": "電源設定。下限電圧を指定します。 (DC=10V) (S=セルあたり3.3V | 電力制限は無効化されます)"
+			"desc": "電源設定。下限電圧を指定します。 <DC=10V> <S=セルあたり3.3V、電力制限は無効化されます>"
 		},
 		"SleepTemperature": {
 			"text2": "待機温度",
@@ -96,11 +96,11 @@
 		},
 		"SleepTimeout": {
 			"text2": "待機遅延",
-			"desc": "スタンバイモードに入るまでの待機時間 (S=秒 | M=分)"
+			"desc": "スタンバイモードに入るまでの待機時間 <S=秒 | M=分>"
 		},
 		"ShutdownTimeout": {
 			"text2": "自動オフ",
-			"desc": "自動電源オフするまでの待機時間 (M=分)"
+			"desc": "自動電源オフするまでの待機時間 <M=分>"
 		},
 		"MotionSensitivity": {
 			"text2": "動きの感度",
@@ -124,7 +124,7 @@
 		},
 		"AutoStart": {
 			"text2": "自動起動",
-			"desc": "電源投入時に自動的に起動します (X=オフ | 熱=はんだ加熱モード | 待=スタンバイモード | 室=室温スタンバイモード)"
+			"desc": "電源投入時に自動的に起動します <X=オフ | 熱=はんだ加熱モード | 待=スタンバイモード | 室=室温スタンバイモード>"
 		},
 		"CooldownBlink": {
 			"text2": "冷却中に点滅",
@@ -140,7 +140,7 @@
 		},
 		"VoltageCalibration": {
 			"text2": "電圧を校正する？",
-			"desc": "入力電圧VINの校正を開始します (長押しして終了します)"
+			"desc": "入力電圧VINの校正を開始します <長押しして終了します>"
 		},
 		"AdvancedSoldering": {
 			"text2": "詳細な作業画面",
@@ -148,7 +148,7 @@
 		},
 		"ScrollingSpeed": {
 			"text2": "スクロール速度",
-			"desc": "説明テキストがスクロールする速度 (遅=遅い | 早=早い)"
+			"desc": "説明テキストがスクロールする速度 <遅=遅い | 早=早い>"
 		},
 		"QCMaxVoltage": {
 			"text2": "QC電圧",
@@ -156,7 +156,7 @@
 		},
 		"PowerLimit": {
 			"text2": "電力制限",
-			"desc": "はんだ付てが使用できる最大電力を制限する (W=ワット)"
+			"desc": "はんだ付てが使用できる最大電力を制限する <W=ワット>"
 		},
 		"ReverseButtonTempChange": {
 			"text2": "キーを交換する",
@@ -172,19 +172,19 @@
 		},
 		"PowerPulsePower": {
 			"text2": "電力パルス",
-			"desc": "電源供給元をオンに保つための電力パルス (ワット)"
+			"desc": "電源供給元をオンに保つための電力パルス <ワット>"
 		},
 		"HallEffSensitivity": {
 			"text2": "磁界感度",
-			"desc": "スタンバイモードに入るのに使用される磁場センサーの感度 (X=オフ | 低=最低感度 | 中=中程度の感度 | 高=最高感度)"
+			"desc": "スタンバイモードに入るのに使用される磁場センサーの感度 <X=オフ | 低=最低感度 | 中=中程度の感度 | 高=最高感度>"
 		},
 		"LockingMode": {
 			"text2": "ボタンロック",
-			"desc": "はんだ付けモードの場合、2つのボタンを長押ししてボタンロックをオンにします (X=オフ | ブ=ブーストのみ許可 | 全=すべてをロック)"
+			"desc": "はんだ付けモードの場合、2つのボタンを長押ししてボタンロックをオンにします <X=オフ | ブ=ブーストのみ許可 | 全=すべてをロック>"
 		},
 		"MinVolCell": {
 			"text2": "最低電圧",
-			"desc": "セルあたりの最低電圧 (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+			"desc": "セルあたりの最低電圧 <ボルト> <3S: 3.0V - 3.7V, 4/5/6S: 2.4V - 3.7V>"
 		},
 		"AnimLoop": {
 			"text2": "動画をループ",
@@ -192,15 +192,15 @@
 		},
 		"AnimSpeed": {
 			"text2": "動画の速度",
-			"desc": "メニューアイコンのアニメーションの再生速度 (X=アニメーションを再生しない | 遅=低速 | 中=中速 | 早=高速)"
+			"desc": "メニューアイコンのアニメーションの再生速度 <X=アニメーションを再生しない | 遅=低速 | 中=中速 | 早=高速>"
 		},
 		"PowerPulseWait": {
 			"text2": "パルス間隔",
-			"desc": "電源供給元をオンに保つために使用される、電力パルス間の時間間隔 (x2.5s [秒])"
+			"desc": "電源供給元をオンに保つために使用される、電力パルス間の時間間隔 <x2.5s（秒）>"
 		},
 		"PowerPulseDuration": {
 			"text2": "パルス時間長",
-			"desc": "電源供給元をオンに保つために使用される、電力パルスの時間長 (x250ms [ミリ秒])"
+			"desc": "電源供給元をオンに保つために使用される、電力パルスの時間長 <x250ms（ミリ秒）>"
 		},
 		"LanguageSwitch": {
 			"text2": "言語： 日本語",

--- a/Translations/translation_JA_JP.json
+++ b/Translations/translation_JA_JP.json
@@ -43,9 +43,9 @@
 		"WarningKeysLockedString": "!入力ロック中!"
 	},
 	"characters": {
-		"SettingAutoChar": "自",
 		"SettingRightChar": "右",
 		"SettingLeftChar": "左",
+		"SettingAutoChar": "自",
 		"SettingOffChar": "X",
 		"SettingSlowChar": "遅",
 		"SettingMediumChar": "中",
@@ -116,7 +116,7 @@
 		},
 		"DisplayRotation": {
 			"text2": "画面の向き",
-			"desc": "自=自動 | 左=左利き | 右=右利き"
+			"desc": "右=右利き | 左=左利き | 自=自動"
 		},
 		"BoostTemperature": {
 			"text2": "ブースト温度",

--- a/Translations/translation_LT.json
+++ b/Translations/translation_LT.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "!UŽRAK!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "D",
 		"SettingLeftChar": "K",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "I",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "V",
@@ -157,7 +157,7 @@
 				"Ekrano",
 				"orientacija"
 			],
-			"desc": "Ekrano orientacija (A=Automatinė | K=Kairiarankiams | D=Dešiniarankiams)"
+			"desc": "Ekrano orientacija (D=Dešiniarankiams | K=Kairiarankiams | A=Automatinė)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_LT.json
+++ b/Translations/translation_LT.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "!UŽRAK!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "D",
 		"SettingLeftChar": "K",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "G",
+		"SettingOffChar": "I",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "V",
-		"SettingOffChar": "I",
+		"SettingFastChar": "G",
 		"SettingStartNoneChar": "N",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "M",

--- a/Translations/translation_NL.json
+++ b/Translations/translation_NL.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "!GEBLOKKEERD!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "R",
 		"SettingLeftChar": "L",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "F",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "F",
 		"SettingStartNoneChar": "F",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",

--- a/Translations/translation_NL.json
+++ b/Translations/translation_NL.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "!GEBLOKKEERD!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "R",
 		"SettingLeftChar": "L",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
@@ -157,7 +157,7 @@
 				"Scherm-",
 				"oriëntatie"
 			],
-			"desc": "Schermoriëntatie (A=Automatisch | L=Linkshandig | R=Rechtshandig)"
+			"desc": "Schermoriëntatie (R=Rechtshandig | L=Linkshandig | A=Automatisch)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_NL_BE.json
+++ b/Translations/translation_NL_BE.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "R",
 		"SettingLeftChar": "L",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "S",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "T",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "S",
 		"SettingStartNoneChar": "F",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "S",

--- a/Translations/translation_NL_BE.json
+++ b/Translations/translation_NL_BE.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "R",
 		"SettingLeftChar": "L",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "T",
 		"SettingMediumChar": "M",
@@ -157,7 +157,7 @@
 				"Scherm-",
 				"oriëntatie"
 			],
-			"desc": "Schermoriëntatie (A=Automatisch | L=Linkshandig | R=Rechtshandig)"
+			"desc": "Schermoriëntatie (R=Rechtshandig | L=Linkshandig | A=Automatisch)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_NO.json
+++ b/Translations/translation_NO.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "H",
 		"SettingLeftChar": "V",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
@@ -157,7 +157,7 @@
 				"SkRetn",
 				""
 			],
-			"desc": "Skjermretning (A=Automatisk | V=Venstrehendt | H=Høyrehendt)"
+			"desc": "Skjermretning (H=Høyrehendt | V=Venstrehendt | A=Automatisk)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_NO.json
+++ b/Translations/translation_NO.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "H",
 		"SettingLeftChar": "V",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "H",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "H",
 		"SettingStartNoneChar": "I",
 		"SettingStartSolderingChar": "L",
 		"SettingStartSleepChar": "D",

--- a/Translations/translation_PL.json
+++ b/Translations/translation_PL.json
@@ -46,13 +46,13 @@
 		"WarningKeysLockedString": "!ZABLOK!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "P",
 		"SettingLeftChar": "L",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "S",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "W",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "S",
 		"SettingStartNoneChar": "B",
 		"SettingStartSolderingChar": "T",
 		"SettingStartSleepChar": "Z",

--- a/Translations/translation_PL.json
+++ b/Translations/translation_PL.json
@@ -46,9 +46,9 @@
 		"WarningKeysLockedString": "!ZABLOK!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "P",
 		"SettingLeftChar": "L",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "W",
 		"SettingMediumChar": "M",
@@ -158,7 +158,7 @@
 				"Obrót",
 				"ekranu"
 			],
-			"desc": "Obrót ekranu (A=automatycznie | L=dla leworęcznych | P=dla praworęcznych)"
+			"desc": "Obrót ekranu (P=dla praworęcznych | L=dla leworęcznych | A=automatycznie)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_PT.json
+++ b/Translations/translation_PT.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "D",
 		"SettingLeftChar": "C",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "R",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "R",
 		"SettingStartNoneChar": "D",
 		"SettingStartSolderingChar": "S",
 		"SettingStartSleepChar": "H",

--- a/Translations/translation_PT.json
+++ b/Translations/translation_PT.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "D",
 		"SettingLeftChar": "C",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
@@ -157,7 +157,7 @@
 				"Orientação",
 				"tela"
 			],
-			"desc": "Orientação da tela (A=utomática | C=anhoto | D=estro)"
+			"desc": "Orientação da tela (D=estro | C=anhoto | A=utomática)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_RU.json
+++ b/Translations/translation_RU.json
@@ -46,13 +46,13 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
+		"SettingAutoChar": "А",
 		"SettingRightChar": "П",
 		"SettingLeftChar": "Л",
-		"SettingAutoChar": "А",
-		"SettingFastChar": "Б",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "М",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "Б",
 		"SettingStartNoneChar": "В",
 		"SettingStartSolderingChar": "П",
 		"SettingStartSleepChar": "О",
@@ -298,14 +298,14 @@
 				"Power pulse",
 				"wait time"
 			],
-			"desc": "Time to wait before triggering every keep-awake pulse (x 2,5s)"
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2,5с)"
 		},
 		"PowerPulseDuration": {
 			"text2": [
 				"Power pulse",
 				"duration"
 			],
-			"desc": "Keep-awake-pulse duration (x 250ms)"
+			"desc": "Keep-awake-pulse duration (x 250мс)"
 		},
 		"LanguageSwitch": {
 			"text2": [

--- a/Translations/translation_RU.json
+++ b/Translations/translation_RU.json
@@ -46,9 +46,9 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
-		"SettingAutoChar": "А",
 		"SettingRightChar": "П",
 		"SettingLeftChar": "Л",
+		"SettingAutoChar": "А",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "М",
 		"SettingMediumChar": "M",
@@ -158,7 +158,7 @@
 				"Ориентация",
 				"экрана"
 			],
-			"desc": "Ориентация экрана (А=Авто | Л=Левая рука | П=Правая рука)"
+			"desc": "Ориентация экрана (П=Правая рука | Л=Левая рука | А=Авто)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_SK.json
+++ b/Translations/translation_SK.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "!ZABLOK!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "P",
 		"SettingLeftChar": "L",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "Z",
 		"SettingSlowChar": "P",
 		"SettingMediumChar": "M",
@@ -157,7 +157,7 @@
 				"Orientácia",
 				"displeja"
 			],
-			"desc": "Orientácia displeja (A=Auto | L=Ľavák | P=Pravák)"
+			"desc": "Orientácia displeja (P=Pravák | L=Ľavák | A=Auto)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_SK.json
+++ b/Translations/translation_SK.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "!ZABLOK!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "P",
 		"SettingLeftChar": "L",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "R",
+		"SettingOffChar": "Z",
 		"SettingSlowChar": "P",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "Z",
+		"SettingFastChar": "R",
 		"SettingStartNoneChar": "V",
 		"SettingStartSolderingChar": "Z",
 		"SettingStartSleepChar": "S",

--- a/Translations/translation_SL.json
+++ b/Translations/translation_SL.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "ZAKLENJ."
 	},
 	"characters": {
-		"SettingAutoChar": "S",
 		"SettingRightChar": "D",
 		"SettingLeftChar": "L",
+		"SettingAutoChar": "S",
 		"SettingOffChar": "U",
 		"SettingSlowChar": "P",
 		"SettingMediumChar": "M",
@@ -157,7 +157,7 @@
 				"Orientacija",
 				"zaslona"
 			],
-			"desc": "S=samodejno | L=levičar | D=desničar"
+			"desc": "D=desničar | L=levičar | S=samodejno"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_SL.json
+++ b/Translations/translation_SL.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "ZAKLENJ."
 	},
 	"characters": {
+		"SettingAutoChar": "S",
 		"SettingRightChar": "D",
 		"SettingLeftChar": "L",
-		"SettingAutoChar": "S",
-		"SettingFastChar": "H",
+		"SettingOffChar": "U",
 		"SettingSlowChar": "P",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "U",
+		"SettingFastChar": "H",
 		"SettingStartNoneChar": "U",
 		"SettingStartSolderingChar": "S",
 		"SettingStartSleepChar": "Z",

--- a/Translations/translation_SR_CYRL.json
+++ b/Translations/translation_SR_CYRL.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
+		"SettingAutoChar": "А",
 		"SettingRightChar": "Д",
 		"SettingLeftChar": "Л",
-		"SettingAutoChar": "А",
-		"SettingFastChar": "Б",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "С",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "Б",
 		"SettingStartNoneChar": "И",
 		"SettingStartSolderingChar": "Л",
 		"SettingStartSleepChar": "С",
@@ -297,14 +297,14 @@
 				"Power pulse",
 				"wait time"
 			],
-			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5с)"
 		},
 		"PowerPulseDuration": {
 			"text2": [
 				"Power pulse",
 				"duration"
 			],
-			"desc": "Keep-awake-pulse duration (x 250ms)"
+			"desc": "Keep-awake-pulse duration (x 250мс)"
 		},
 		"LanguageSwitch": {
 			"text2": [

--- a/Translations/translation_SR_CYRL.json
+++ b/Translations/translation_SR_CYRL.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
-		"SettingAutoChar": "А",
 		"SettingRightChar": "Д",
 		"SettingLeftChar": "Л",
+		"SettingAutoChar": "А",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "С",
 		"SettingMediumChar": "M",
@@ -157,7 +157,7 @@
 				"Оријентација",
 				"екрана"
 			],
-			"desc": "Како је окренут екран. (А=аутоматски | Л=за леворуке | Д=за десноруке)"
+			"desc": "Како је окренут екран. (Д=за десноруке | Л=за леворуке | А=аутоматски)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_SR_LATN.json
+++ b/Translations/translation_SR_LATN.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "D",
 		"SettingLeftChar": "L",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "B",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "B",
 		"SettingStartNoneChar": "I",
 		"SettingStartSolderingChar": "L",
 		"SettingStartSleepChar": "S",

--- a/Translations/translation_SR_LATN.json
+++ b/Translations/translation_SR_LATN.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "D",
 		"SettingLeftChar": "L",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
@@ -157,7 +157,7 @@
 				"Orijentacija",
 				"ekrana"
 			],
-			"desc": "Kako je okrenut ekran. (A=automatski | L=za levoruke | D=za desnoruke)"
+			"desc": "Kako je okrenut ekran. (D=za desnoruke | L=za levoruke | A=automatski)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_SV.json
+++ b/Translations/translation_SV.json
@@ -45,9 +45,9 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "H",
 		"SettingLeftChar": "V",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
@@ -157,7 +157,7 @@
 				"Visnings",
 				"läge"
 			],
-			"desc": "Visningsläge (A=Automatisk | V=Vänsterhänt | H=Högerhänt)"
+			"desc": "Visningsläge (H=Högerhänt | V=Vänsterhänt | A=Automatisk)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_SV.json
+++ b/Translations/translation_SV.json
@@ -45,13 +45,13 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "H",
 		"SettingLeftChar": "V",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "S",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "L",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "S",
 		"SettingStartNoneChar": "A",
 		"SettingStartSolderingChar": "L",
 		"SettingStartSleepChar": "V",

--- a/Translations/translation_TR.json
+++ b/Translations/translation_TR.json
@@ -48,9 +48,9 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "R",
 		"SettingLeftChar": "L",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "O",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
@@ -160,7 +160,7 @@
 				"GRNYÖN",
 				""
 			],
-			"desc": "Görüntü Yönlendirme (A=Otomatik | L=Solak | R=Sağlak)"
+			"desc": "Görüntü Yönlendirme (R=Sağlak | L=Solak | A=Otomatik)"
 		},
 		"BoostEnabled": {
 			"text2": [

--- a/Translations/translation_TR.json
+++ b/Translations/translation_TR.json
@@ -48,13 +48,13 @@
 		"WarningKeysLockedString": "!LOCKED!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "R",
 		"SettingLeftChar": "L",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "F",
+		"SettingOffChar": "O",
 		"SettingSlowChar": "S",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "O",
+		"SettingFastChar": "F",
 		"SettingStartNoneChar": "K",
 		"SettingStartSolderingChar": "L",
 		"SettingStartSleepChar": "U",

--- a/Translations/translation_UK.json
+++ b/Translations/translation_UK.json
@@ -46,13 +46,13 @@
 		"WarningKeysLockedString": "!ЗАБЛОК!"
 	},
 	"characters": {
+		"SettingAutoChar": "A",
 		"SettingRightChar": "П",
 		"SettingLeftChar": "Л",
-		"SettingAutoChar": "A",
-		"SettingFastChar": "Ш",
+		"SettingOffChar": "B",
 		"SettingSlowChar": "П",
 		"SettingMediumChar": "M",
-		"SettingOffChar": "B",
+		"SettingFastChar": "Ш",
 		"SettingStartNoneChar": "В",
 		"SettingStartSolderingChar": "П",
 		"SettingStartSleepChar": "О",

--- a/Translations/translation_UK.json
+++ b/Translations/translation_UK.json
@@ -295,21 +295,21 @@
 		},
 		"PowerPulseWait": {
 			"text2": [
-				"Power pulse",
-				"wait time"
+				"Час між імп.",
+				"напруги"
 			],
-			"desc": "Time to wait before triggering every keep-awake pulse (x 2.5s)"
+			"desc": "Час між імпульсами напруги яка не дає PowerBank-у заснути (x 2.5с)"
 		},
 		"PowerPulseDuration": {
 			"text2": [
-				"Power pulse",
-				"duration"
+				"Тривалість",
+				"імп. напруги"
 			],
-			"desc": "Keep-awake-pulse duration (x 250ms)"
+			"desc": "Тривалість імпульсу напруги яка не дає PowerBank-у заснути (x 250мс)"
 		},
 		"LanguageSwitch": {
 			"text2": [
-				"Mову:",
+				"Мова:",
 				" UK  Українська"
 			],
 			"desc": ""

--- a/Translations/translation_UK.json
+++ b/Translations/translation_UK.json
@@ -46,9 +46,9 @@
 		"WarningKeysLockedString": "!ЗАБЛОК!"
 	},
 	"characters": {
-		"SettingAutoChar": "A",
 		"SettingRightChar": "П",
 		"SettingLeftChar": "Л",
+		"SettingAutoChar": "A",
 		"SettingOffChar": "B",
 		"SettingSlowChar": "П",
 		"SettingMediumChar": "M",
@@ -158,7 +158,7 @@
 				"Автоповорот",
 				"екрану"
 			],
-			"desc": "Орієнтація дисплея (A=Автоповорот | Л=Лівша | П=Правша)"
+			"desc": "Орієнтація дисплея (П=Правша | Л=Лівша | A=Автоповорот)"
 		},
 		"BoostTemperature": {
 			"text2": [

--- a/Translations/translation_YUE_HK.json
+++ b/Translations/translation_YUE_HK.json
@@ -156,7 +156,7 @@
 		},
 		"PowerLimit": {
 			"text2": "功率限制",
-			"desc": "限制辣雞可用嘅最大功率 (W=watt[火])"
+			"desc": "限制辣雞可用嘅最大功率 (W=watt [火])"
 		},
 		"ReverseButtonTempChange": {
 			"text2": "反轉加減掣",
@@ -172,7 +172,7 @@
 		},
 		"PowerPulsePower": {
 			"text2": "電源脈衝",
-			"desc": "為保持電源喚醒而通電所用嘅功率 (watt[火])"
+			"desc": "為保持電源喚醒而通電所用嘅功率 (watt [火])"
 		},
 		"HallEffSensitivity": {
 			"text2": "磁場敏感度",
@@ -196,11 +196,11 @@
 		},
 		"PowerPulseWait": {
 			"text2": "電源脈衝間隔",
-			"desc": "為保持電源喚醒，每次通電之間嘅間隔時間 (x2.5s[秒])"
+			"desc": "為保持電源喚醒，每次通電之間嘅間隔時間 (x2.5s [秒])"
 		},
 		"PowerPulseDuration": {
 			"text2": "電源脈衝時長",
-			"desc": "為保持電源喚醒，每次通電脈衝嘅時間長度 (x250ms[亳秒])"
+			"desc": "為保持電源喚醒，每次通電脈衝嘅時間長度 (x250ms [亳秒])"
 		},
 		"LanguageSwitch": {
 			"text2": "語言： 廣東話",

--- a/Translations/translation_YUE_HK.json
+++ b/Translations/translation_YUE_HK.json
@@ -43,9 +43,9 @@
 		"WarningKeysLockedString": "!撳掣鎖定!"
 	},
 	"characters": {
-		"SettingAutoChar": "自",
 		"SettingRightChar": "右",
 		"SettingLeftChar": "左",
+		"SettingAutoChar": "自",
 		"SettingOffChar": "關",
 		"SettingSlowChar": "慢",
 		"SettingMediumChar": "中",
@@ -116,7 +116,7 @@
 		},
 		"DisplayRotation": {
 			"text2": "畫面方向",
-			"desc": "自=自動 | 左=使用左手 | 右=使用右手"
+			"desc": "右=使用右手 | 左=使用左手 | 自=自動"
 		},
 		"BoostTemperature": {
 			"text2": "增熱温度",

--- a/Translations/translation_YUE_HK.json
+++ b/Translations/translation_YUE_HK.json
@@ -43,13 +43,13 @@
 		"WarningKeysLockedString": "!撳掣鎖定!"
 	},
 	"characters": {
+		"SettingAutoChar": "自",
 		"SettingRightChar": "右",
 		"SettingLeftChar": "左",
-		"SettingAutoChar": "自",
-		"SettingFastChar": "快",
+		"SettingOffChar": "關",
 		"SettingSlowChar": "慢",
 		"SettingMediumChar": "中",
-		"SettingOffChar": "關",
+		"SettingFastChar": "快",
 		"SettingStartNoneChar": "無",
 		"SettingStartSolderingChar": "焊",
 		"SettingStartSleepChar": "待",
@@ -88,7 +88,7 @@
 	"menuOptions": {
 		"DCInCutoff": {
 			"text2": "電源",
-			"desc": "輸入電源；設定自動停機電壓 (DC 10V) (S 鋰電池，以每粒3.3V計算 | 依個設定會停用功率限制)"
+			"desc": "輸入電源；設定自動停機電壓 <DC 10V> <S 鋰電池，以每粒3.3V計算；依個設定會停用功率限制>"
 		},
 		"SleepTemperature": {
 			"text2": "待機温度",
@@ -96,11 +96,11 @@
 		},
 		"SleepTimeout": {
 			"text2": "待機延時",
-			"desc": "自動進入待機模式前嘅閒置等候時間 (S=秒 | M=分鐘)"
+			"desc": "自動進入待機模式前嘅閒置等候時間 <S=秒 | M=分鐘>"
 		},
 		"ShutdownTimeout": {
 			"text2": "自動熄機",
-			"desc": "自動熄機前嘅閒置等候時間 (M=分鐘)"
+			"desc": "自動熄機前嘅閒置等候時間 <M=分鐘>"
 		},
 		"MotionSensitivity": {
 			"text2": "動作敏感度",
@@ -124,7 +124,7 @@
 		},
 		"AutoStart": {
 			"text2": "自動啓用",
-			"desc": "開機時自動啓用 (無=停用 | 焊=焊接模式 | 待=待機模式 | 室=室温待機)"
+			"desc": "開機時自動啓用 <無=停用 | 焊=焊接模式 | 待=待機模式 | 室=室温待機>"
 		},
 		"CooldownBlink": {
 			"text2": "降温時閃爍",
@@ -140,7 +140,7 @@
 		},
 		"VoltageCalibration": {
 			"text2": "輸入電壓校正？",
-			"desc": "開始校正VIN輸入電壓 (長撳以退出)"
+			"desc": "開始校正VIN輸入電壓 <長撳以退出>"
 		},
 		"AdvancedSoldering": {
 			"text2": "詳細焊接畫面",
@@ -156,7 +156,7 @@
 		},
 		"PowerLimit": {
 			"text2": "功率限制",
-			"desc": "限制辣雞可用嘅最大功率 (W=watt [火])"
+			"desc": "限制辣雞可用嘅最大功率 <W=watt（火）>"
 		},
 		"ReverseButtonTempChange": {
 			"text2": "反轉加減掣",
@@ -172,19 +172,19 @@
 		},
 		"PowerPulsePower": {
 			"text2": "電源脈衝",
-			"desc": "為保持電源喚醒而通電所用嘅功率 (watt [火])"
+			"desc": "為保持電源喚醒而通電所用嘅功率 <watt（火）>"
 		},
 		"HallEffSensitivity": {
 			"text2": "磁場敏感度",
-			"desc": "磁場感應器用嚟啓動待機模式嘅敏感度 (關=停用 | 低=最低敏感度 | 中=中等敏感度 | 高=最高敏感度)"
+			"desc": "磁場感應器用嚟啓動待機模式嘅敏感度 <關=停用 | 低=最低敏感度 | 中=中等敏感度 | 高=最高敏感度>"
 		},
 		"LockingMode": {
 			"text2": "撳掣鎖定",
-			"desc": "喺焊接模式時，同時長撳兩粒掣啓用撳掣鎖定 (無=停用 | 增=淨係容許增熱模式 | 全=鎖定全部)"
+			"desc": "喺焊接模式時，同時長撳兩粒掣啓用撳掣鎖定 <無=停用 | 增=淨係容許增熱模式 | 全=鎖定全部>"
 		},
 		"MinVolCell": {
 			"text2": "最低電壓",
-			"desc": "每粒電池嘅最低可用電壓 (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+			"desc": "每粒電池嘅最低可用電壓 <伏特> <3S: 3.0V - 3.7V, 4/5/6S: 2.4V - 3.7V>"
 		},
 		"AnimLoop": {
 			"text2": "動畫循環",
@@ -192,15 +192,15 @@
 		},
 		"AnimSpeed": {
 			"text2": "動畫速度",
-			"desc": "功能表圖示動畫嘅速度 (關=不顯示動畫 | 慢=慢速 | 中=中速 | 快=快速)"
+			"desc": "功能表圖示動畫嘅速度 <關=不顯示動畫 | 慢=慢速 | 中=中速 | 快=快速>"
 		},
 		"PowerPulseWait": {
 			"text2": "電源脈衝間隔",
-			"desc": "為保持電源喚醒，每次通電之間嘅間隔時間 (x2.5s [秒])"
+			"desc": "為保持電源喚醒，每次通電之間嘅間隔時間 <x2.5s（秒）>"
 		},
 		"PowerPulseDuration": {
 			"text2": "電源脈衝時長",
-			"desc": "為保持電源喚醒，每次通電脈衝嘅時間長度 (x250ms [亳秒])"
+			"desc": "為保持電源喚醒，每次通電脈衝嘅時間長度 <x250ms（亳秒）>"
 		},
 		"LanguageSwitch": {
 			"text2": "語言： 廣東話",

--- a/Translations/translation_ZH_CN.json
+++ b/Translations/translation_ZH_CN.json
@@ -43,13 +43,13 @@
 		"WarningKeysLockedString": "!按键锁定!"
 	},
 	"characters": {
+		"SettingAutoChar": "自",
 		"SettingRightChar": "右",
 		"SettingLeftChar": "左",
-		"SettingAutoChar": "自",
-		"SettingFastChar": "快",
+		"SettingOffChar": "关",
 		"SettingSlowChar": "慢",
 		"SettingMediumChar": "中",
-		"SettingOffChar": "关",
+		"SettingFastChar": "快",
 		"SettingStartNoneChar": "无",
 		"SettingStartSolderingChar": "焊",
 		"SettingStartSleepChar": "待",
@@ -88,7 +88,7 @@
 	"menuOptions": {
 		"DCInCutoff": {
 			"text2": "电源",
-			"desc": "输入电源；设置自动停机电压 (DC 10V) (S 锂电池，以每颗3.3V计算 | 此设置会禁用功率限制)"
+			"desc": "输入电源；设置自动停机电压 <DC 10V> <S 锂电池，以每颗3.3V计算；此设置会禁用功率限制>"
 		},
 		"SleepTemperature": {
 			"text2": "待机温度",
@@ -96,11 +96,11 @@
 		},
 		"SleepTimeout": {
 			"text2": "待机延时",
-			"desc": "自动进入待机模式前的闲置等候时间 (S=秒 | M=分钟)"
+			"desc": "自动进入待机模式前的闲置等候时间 <S=秒 | M=分钟>"
 		},
 		"ShutdownTimeout": {
 			"text2": "自动关机",
-			"desc": "自动关机前的闲置等候时间 (M=分钟)"
+			"desc": "自动关机前的闲置等候时间 <M=分钟>"
 		},
 		"MotionSensitivity": {
 			"text2": "动作灵敏度",
@@ -124,7 +124,7 @@
 		},
 		"AutoStart": {
 			"text2": "自动启用",
-			"desc": "开机时自动启用 (无=禁用 | 焊=焊接模式 | 待=待机模式 | 室=室温待机)"
+			"desc": "开机时自动启用 <无=禁用 | 焊=焊接模式 | 待=待机模式 | 室=室温待机>"
 		},
 		"CooldownBlink": {
 			"text2": "降温时闪烁",
@@ -140,7 +140,7 @@
 		},
 		"VoltageCalibration": {
 			"text2": "输入电压校正？",
-			"desc": "开始校正VIN输入电压 (长按以退出)"
+			"desc": "开始校正VIN输入电压 <长按以退出>"
 		},
 		"AdvancedSoldering": {
 			"text2": "详细焊接画面",
@@ -156,7 +156,7 @@
 		},
 		"PowerLimit": {
 			"text2": "功率限制",
-			"desc": "限制铬铁可用的最大功率 (W=watt [瓦特])"
+			"desc": "限制铬铁可用的最大功率 <W=watt（瓦特）>"
 		},
 		"ReverseButtonTempChange": {
 			"text2": "调换加减键",
@@ -172,19 +172,19 @@
 		},
 		"PowerPulsePower": {
 			"text2": "电源脉冲",
-			"desc": "为保持电源唤醒而通电所用的功率 (watt [瓦特])"
+			"desc": "为保持电源唤醒而通电所用的功率 <watt（瓦特）>"
 		},
 		"HallEffSensitivity": {
 			"text2": "磁场灵敏度",
-			"desc": "磁场感应器用作启动待机模式的灵敏度 (关=禁用 | 低=最低灵敏度 | 中=中等灵敏度 | 高=最高灵敏度)"
+			"desc": "磁场感应器用作启动待机模式的灵敏度 <关=禁用 | 低=最低灵敏度 | 中=中等灵敏度 | 高=最高灵敏度>"
 		},
 		"LockingMode": {
 			"text2": "按键锁定",
-			"desc": "于焊接模式时，同时长按两个按键启用按键锁定 (无=禁用 | 增=只容许增热模式 | 全=锁定全部)"
+			"desc": "于焊接模式时，同时长按两个按键启用按键锁定 <无=禁用 | 增=只容许增热模式 | 全=锁定全部>"
 		},
 		"MinVolCell": {
 			"text2": "最低电压",
-			"desc": "每颗电池的最低可用电压 (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+			"desc": "每颗电池的最低可用电压 <伏特> <3S: 3.0V - 3.7V, 4/5/6S: 2.4V - 3.7V>"
 		},
 		"AnimLoop": {
 			"text2": "动画循环",
@@ -192,15 +192,15 @@
 		},
 		"AnimSpeed": {
 			"text2": "动画速度",
-			"desc": "功能表图示动画的速度 (关=不显示动画 | 慢=慢速 | 中=中速 | 快=快速)"
+			"desc": "功能表图示动画的速度 <关=不显示动画 | 慢=慢速 | 中=中速 | 快=快速>"
 		},
 		"PowerPulseWait": {
 			"text2": "电源脉冲间隔",
-			"desc": "为保持电源唤醒，每次通电之间的间隔时间 (x2.5s [秒])"
+			"desc": "为保持电源唤醒，每次通电之间的间隔时间 <x2.5s（秒）>"
 		},
 		"PowerPulseDuration": {
 			"text2": "电源脉冲时长",
-			"desc": "为保持电源唤醒，每次通电脉冲的时间长度 (x250ms [亳秒])"
+			"desc": "为保持电源唤醒，每次通电脉冲的时间长度 <x250ms（亳秒）>"
 		},
 		"LanguageSwitch": {
 			"text2": "语言：简体中文",

--- a/Translations/translation_ZH_CN.json
+++ b/Translations/translation_ZH_CN.json
@@ -156,7 +156,7 @@
 		},
 		"PowerLimit": {
 			"text2": "功率限制",
-			"desc": "限制铬铁可用的最大功率 (W=watt[瓦特])"
+			"desc": "限制铬铁可用的最大功率 (W=watt [瓦特])"
 		},
 		"ReverseButtonTempChange": {
 			"text2": "调换加减键",
@@ -172,7 +172,7 @@
 		},
 		"PowerPulsePower": {
 			"text2": "电源脉冲",
-			"desc": "为保持电源唤醒而通电所用的功率 (watt[瓦特])"
+			"desc": "为保持电源唤醒而通电所用的功率 (watt [瓦特])"
 		},
 		"HallEffSensitivity": {
 			"text2": "磁场灵敏度",
@@ -196,11 +196,11 @@
 		},
 		"PowerPulseWait": {
 			"text2": "电源脉冲间隔",
-			"desc": "为保持电源唤醒，每次通电之间的间隔时间 (x2.5s[秒])"
+			"desc": "为保持电源唤醒，每次通电之间的间隔时间 (x2.5s [秒])"
 		},
 		"PowerPulseDuration": {
 			"text2": "电源脉冲时长",
-			"desc": "为保持电源唤醒，每次通电脉冲的时间长度 (x250ms[亳秒])"
+			"desc": "为保持电源唤醒，每次通电脉冲的时间长度 (x250ms [亳秒])"
 		},
 		"LanguageSwitch": {
 			"text2": "语言：简体中文",

--- a/Translations/translation_ZH_CN.json
+++ b/Translations/translation_ZH_CN.json
@@ -43,9 +43,9 @@
 		"WarningKeysLockedString": "!按键锁定!"
 	},
 	"characters": {
-		"SettingAutoChar": "自",
 		"SettingRightChar": "右",
 		"SettingLeftChar": "左",
+		"SettingAutoChar": "自",
 		"SettingOffChar": "关",
 		"SettingSlowChar": "慢",
 		"SettingMediumChar": "中",
@@ -116,7 +116,7 @@
 		},
 		"DisplayRotation": {
 			"text2": "画面方向",
-			"desc": "自=自动 | 左=使用左手 | 右=使用右手"
+			"desc": "右=使用右手 | 左=使用左手 | 自=自动"
 		},
 		"BoostTemperature": {
 			"text2": "增热温度",

--- a/Translations/translation_ZH_TW.json
+++ b/Translations/translation_ZH_TW.json
@@ -43,9 +43,9 @@
 		"WarningKeysLockedString": "!按鍵鎖定!"
 	},
 	"characters": {
-		"SettingAutoChar": "自",
 		"SettingRightChar": "右",
 		"SettingLeftChar": "左",
+		"SettingAutoChar": "自",
 		"SettingOffChar": "關",
 		"SettingSlowChar": "慢",
 		"SettingMediumChar": "中",
@@ -116,7 +116,7 @@
 		},
 		"DisplayRotation": {
 			"text2": "畫面方向",
-			"desc": "自=自動 | 左=使用左手 | 右=使用右手"
+			"desc": "右=使用右手 | 左=使用左手 | 自=自動"
 		},
 		"BoostTemperature": {
 			"text2": "增熱溫度",

--- a/Translations/translation_ZH_TW.json
+++ b/Translations/translation_ZH_TW.json
@@ -43,13 +43,13 @@
 		"WarningKeysLockedString": "!按鍵鎖定!"
 	},
 	"characters": {
+		"SettingAutoChar": "自",
 		"SettingRightChar": "右",
 		"SettingLeftChar": "左",
-		"SettingAutoChar": "自",
-		"SettingFastChar": "快",
+		"SettingOffChar": "關",
 		"SettingSlowChar": "慢",
 		"SettingMediumChar": "中",
-		"SettingOffChar": "關",
+		"SettingFastChar": "快",
 		"SettingStartNoneChar": "無",
 		"SettingStartSolderingChar": "焊",
 		"SettingStartSleepChar": "待",
@@ -88,7 +88,7 @@
 	"menuOptions": {
 		"DCInCutoff": {
 			"text2": "電源",
-			"desc": "輸入電源；設定自動停機電壓 (DC 10V) (S 鋰電池，以每顆3.3V計算 | 此設定會停用功率限制)"
+			"desc": "輸入電源；設定自動停機電壓 <DC 10V> <S 鋰電池，以每顆3.3V計算；此設定會停用功率限制>"
 		},
 		"SleepTemperature": {
 			"text2": "待機溫度",
@@ -96,11 +96,11 @@
 		},
 		"SleepTimeout": {
 			"text2": "待機延時",
-			"desc": "自動進入待機模式前的閒置等候時間 (S=秒 | M=分鐘)"
+			"desc": "自動進入待機模式前的閒置等候時間 <S=秒 | M=分鐘>"
 		},
 		"ShutdownTimeout": {
 			"text2": "自動關機",
-			"desc": "自動關機前的閒置等候時間 (M=分鐘)"
+			"desc": "自動關機前的閒置等候時間 <M=分鐘>"
 		},
 		"MotionSensitivity": {
 			"text2": "動作敏感度",
@@ -124,7 +124,7 @@
 		},
 		"AutoStart": {
 			"text2": "自動啟用",
-			"desc": "開機時自動啟用 (無=停用 | 焊=焊接模式 | 待=待機模式 | 室=室溫待機)"
+			"desc": "開機時自動啟用 <無=停用 | 焊=焊接模式 | 待=待機模式 | 室=室溫待機>"
 		},
 		"CooldownBlink": {
 			"text2": "降溫時閃爍",
@@ -140,7 +140,7 @@
 		},
 		"VoltageCalibration": {
 			"text2": "輸入電壓校正？",
-			"desc": "開始校正VIN輸入電壓 (長按以退出)"
+			"desc": "開始校正VIN輸入電壓 <長按以退出>"
 		},
 		"AdvancedSoldering": {
 			"text2": "詳細焊接畫面",
@@ -156,7 +156,7 @@
 		},
 		"PowerLimit": {
 			"text2": "功率限制",
-			"desc": "限制鉻鐵可用的最大功率 (W=watt [瓦特])"
+			"desc": "限制鉻鐵可用的最大功率 <W=watt（瓦特）>"
 		},
 		"ReverseButtonTempChange": {
 			"text2": "調換加減鍵",
@@ -172,19 +172,19 @@
 		},
 		"PowerPulsePower": {
 			"text2": "電源脈衝",
-			"desc": "為保持電源喚醒而通電所用的功率 (watt [瓦特])"
+			"desc": "為保持電源喚醒而通電所用的功率 <watt（瓦特）>"
 		},
 		"HallEffSensitivity": {
 			"text2": "磁場敏感度",
-			"desc": "磁場感應器用作啟動待機模式的敏感度 (關=停用 | 低=最低敏感度 | 中=中等敏感度 | 高=最高敏感度)"
+			"desc": "磁場感應器用作啟動待機模式的敏感度 <關=停用 | 低=最低敏感度 | 中=中等敏感度 | 高=最高敏感度>"
 		},
 		"LockingMode": {
 			"text2": "按鍵鎖定",
-			"desc": "於焊接模式時，同時長按兩個按鍵啟用按鍵鎖定 (無=停用 | 增=只容許增熱模式 | 全=鎖定全部)"
+			"desc": "於焊接模式時，同時長按兩個按鍵啟用按鍵鎖定 <無=停用 | 增=只容許增熱模式 | 全=鎖定全部>"
 		},
 		"MinVolCell": {
 			"text2": "最低電壓",
-			"desc": "每顆電池的最低可用電壓 (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+			"desc": "每顆電池的最低可用電壓 <伏特> <3S: 3.0V - 3.7V, 4/5/6S: 2.4V - 3.7V>"
 		},
 		"AnimLoop": {
 			"text2": "動畫循環",
@@ -192,15 +192,15 @@
 		},
 		"AnimSpeed": {
 			"text2": "動畫速度",
-			"desc": "功能表圖示動畫的速度 (關=不顯示動畫 | 慢=慢速 | 中=中速 | 快=快速)"
+			"desc": "功能表圖示動畫的速度 <關=不顯示動畫 | 慢=慢速 | 中=中速 | 快=快速>"
 		},
 		"PowerPulseWait": {
 			"text2": "電源脈衝間隔",
-			"desc": "為保持電源喚醒，每次通電之間的間隔時間 (x2.5s [秒])"
+			"desc": "為保持電源喚醒，每次通電之間的間隔時間 <x2.5s（秒）>"
 		},
 		"PowerPulseDuration": {
 			"text2": "電源脈衝時長",
-			"desc": "為保持電源喚醒，每次通電脈衝的時間長度 (x250ms [亳秒])"
+			"desc": "為保持電源喚醒，每次通電脈衝的時間長度 <x250ms（亳秒）>"
 		},
 		"LanguageSwitch": {
 			"text2": "語言：正體中文",


### PR DESCRIPTION
With this, I tried to update all the present languages to the most recent state in terms of consistency.

Please feel free to correct certain expressions, in the different languages, maybe I missed something here and there. 😅

1. I mostly changed from **`<>`** to **`()`**, although I left some custom choices in certain cases alone.
2. I tried to get the **`Auto start`** description for all languages set.
### I am very certain, that some of my decisions, whether to use this or that word, are not the ones a nativ speaker would make. 
My intention was, to **give the user an idea** and than they could change it to the way it should sound in the respective language.

kind regards