### PR TITLE
Added LT translations to new entries.

### DIFF
--- a/Translations/translation_LT.json
+++ b/Translations/translation_LT.json
@@ -31,7 +31,7 @@
     "LockingKeysString": " UŽRAKIN",
     "UnlockingKeysString": "ATRAKIN",
     "WarningKeysLockedString": "!UŽRAK!",
-    "WarningThermalRunaway": ["Thermal", "Runaway"]
+    "WarningThermalRunaway": ["Perkaitimo", "pavojus"]
   },
   "characters": {
     "SettingRightChar": "D",
@@ -202,12 +202,12 @@
       "desc": ""
     },
     "Brightness": {
-      "text2": ["Screen", "Brightness"],
-      "desc": "Adjust the contrast/brightness of the OLED screen"
+      "text2": ["Ekrano", "šviesumas"],
+      "desc": "Nustato OLED ekrano kontrastą/šviesumą."
     },
     "ColourInversion": {
-      "text2": ["Screen", "Invert"],
-      "desc": "Invert the colours of the OLED screen"
+      "text2": ["Ekrano", "invertavimas"],
+      "desc": "Invertuoja OLED ekrano spalvas."
     }
   }
 }


### PR DESCRIPTION
Tested locally on TS80P, TS100.

On both devices on English and Lithuanian languages `"text2": ["Screen", "Brightness"],` and `"text2": ["Screen", "Invert"],` doesn't show up on the menus. Only sunny and inverting icons are showed with their respective values without text2.