### PR TITLE
Generic shellscripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
-#!/usr/bin/env bash
+#!/bin/sh
 docker-compose run --rm builder /bin/bash /build/ci/buildAll.sh

--- a/ci/buildAll.sh
+++ b/ci/buildAll.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 set -e
 set -u
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 set -e
 # Setup shell file to setup the environment on an ubuntu machine
-sudo apt-get update && sudo apt-get install -y make bzip2 git python3 python3-pip wget  dfu-util
+sudo apt-get update && sudo apt-get install -y make bzip2 git python3 python3-pip wget dfu-util
 python3 -m pip install bdflib black flake8
 sudo mkdir -p /build
 cd /build
@@ -12,7 +12,7 @@ cd /build
 MDPATH=${GITHUB_WORKSPACE:-/build/source/}
 sudo mkdir -p /build/cache
 cd /build/cache/
-if md5sum -c $MDPATH/ci/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2.md5; then
+if md5sum -c "$MDPATH"/ci/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2.md5; then
     echo "Good MD5 ARM"
 else
     echo "ARM MD5 Mismatch, downloading fresh"
@@ -20,7 +20,7 @@ else
     sudo wget -q "https://developer.arm.com/-/media/Files/downloads/gnu-rm/10-2020q4/gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2" -O gcc-arm-none-eabi-10-2020-q4-major-x86_64-linux.tar.bz2
 fi
 
-if md5sum -c $MDPATH/ci/nuclei_riscv_newlibc_prebuilt_linux64_2020.08.tar.bz2.md5; then
+if md5sum -c "$MDPATH"/ci/nuclei_riscv_newlibc_prebuilt_linux64_2020.08.tar.bz2.md5; then
     echo "Good MD5 RISCV"
 else
     echo "RISCV MD5 Mismatch, downloading fresh"

--- a/source/build.sh
+++ b/source/build.sh
@@ -77,7 +77,7 @@ echo "*********************************************"
 
 # Calculate available languages
 for f in "$TRANSLATION_DIR"/translation_*.json; do
-    AVAILABLE_LANGUAGES+=($(echo $f | tr "[:lower:]" "[:upper:]" | sed "s/[^_]*_//" | sed "s/\.JSON//g"))
+    AVAILABLE_LANGUAGES+=("$(echo "$f" | tr "[:lower:]" "[:upper:]" | sed "s/[^_]*_//" | sed "s/\.JSON//g")")
 done
 
 # Checking requested language
@@ -124,8 +124,8 @@ if [ ${#BUILD_LANGUAGES[@]} -gt 0 ] && [ ${#BUILD_MODELS[@]} -gt 0 ]; then
     checkLastCommand
 
     for model in "${BUILD_MODELS[@]}"; do
-        echo "Building firmware for $model in ${BUILD_LANGUAGES[@]}"
-        make -j$(nproc) model="$model" "${BUILD_LANGUAGES[@]/#/firmware-}" >/dev/null
+        echo "Building firmware for $model in ${BUILD_LANGUAGES[*]}"
+        make -j"$(nproc)" model="$model" "${BUILD_LANGUAGES[@]/#/firmware-}" >/dev/null
         checkLastCommand
     done
 else

--- a/start_dev.sh
+++ b/start_dev.sh
@@ -1,2 +1,2 @@
-#!/usr/bin/env bash
+#!/bin/sh
 docker-compose run --rm builder


### PR DESCRIPTION
Modifies shell scripts to be use a more generic /bin/sh where possible with minor changes for portability and otherwise has small changes in variable quoting and such as recommended by the shellcheck utility.

The source/build.sh script has been left as a bash, as it uses a lot of array functionality that isn't present in POSIX.