### PR TITLE
Fix flash ts100 linux

### DIFF
--- a/Flashing/flash_ts100_linux.sh
+++ b/Flashing/flash_ts100_linux.sh
@@ -1,7 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 # TS100 Flasher for Linux by Alex Wigen (https://github.com/awigen)
+# Jan 2021 - Update by Ysard (https://github.com/ysard)
 
 DIR_TMP="/tmp/ts100"
+HEX_FIRMWARE="$DIR_TMP/ts100.hex"
 
 usage() {
     echo
@@ -76,6 +78,21 @@ umount_ts100() {
     rmdir "$DIR_TMP"
 }
 
+check_flash() {
+    RDY_FIRMWARE="${HEX_FIRMWARE%.*}.rdy"
+    ERR_FIRMWARE="${HEX_FIRMWARE%.*}.err"
+    if [ -f "$RDY_FIRMWARE" ]; then
+        echo -e "\e[92mFlash is done\e[0m"
+        echo "Disconnect the USB and power up the iron. You're good to go."
+    elif [ -f "$ERR_FIRMWARE" ]; then
+        echo -e "\e[91mFlash error; Please retry!\e[0m"
+    else
+        echo -e "\e[91mUNKNOWN error\e[0m"
+        echo "Flash result: "
+        ls "$DIR_TMP"/ts100*
+    fi
+}
+
 cleanup() {
     enable_gautomount
     if [ -d "$DIR_TMP" ]; then
@@ -109,7 +126,7 @@ echo "Found TS100 config disk device on $DEVICE"
 
 mount_ts100
 echo "Mounted config disk drive, flashing..."
-cp -v "$1" "$DIR_TMP/ts100.hex"
+cp -v "$1" "$HEX_FIRMWARE"
 sync
 
 echo "Waiting for TS100 to flash"
@@ -119,6 +136,5 @@ echo "Remounting config disk drive"
 umount_ts100
 wait_for_ts100
 mount_ts100
+check_flash
 
-echo "Flash result: "
-ls "$DIR_TMP"/ts100*

--- a/Flashing/flash_ts100_linux.sh
+++ b/Flashing/flash_ts100_linux.sh
@@ -69,7 +69,7 @@ mount_ts100() {
 }
 
 umount_ts100() {
-    if ! mountpoint "$DIR_TMP" > /dev/null && sudo umount "$DIR_TMP"; then
+    if ! (mountpoint "$DIR_TMP" > /dev/null && sudo umount "$DIR_TMP"); then
         echo "Failed to unmount $DIR_TMP"
         exit 1
     fi


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [ ] There are no breaking changes

* **What kind of change does this PR introduce?**
- Bug fix: Fix the following errors due to forgotten brackets in a test.:
```Remounting config disk drive
rmdir: impossible de de supprimer « /tmp/ts100 »: Device or resource busy
Flash result:
/tmp/ts100/ts100.rdy
rmdir: impossible de de supprimer « /tmp/ts100 »: Device or resource busy
```
- Add a method to automatically check if the flash is done correctly or not.
The user no longer has to read the list of files on the partition and deduce whether everything is ok or not.

* **Other information**:
Please note that error messages in the checking function are now colored for better and faster understanding (in my opinion);
BUT, this requires to use bash instead of the legacy sh Bourne Shell. And this is partially against 48b9097.
Why I suggest this: No systems have been using sh by default for a very long time, and users who have voluntarily changed this setting have surely migrated to much more complete shells (tsh, zsh, etc.) that support this functionality.
Note that the script will run on sh shell but the colors codes will be printed instead of interpreted.
Of course, I can revert this specific part on your request.
