### PR TITLE
HALL only on Pinecil

### DIFF
--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -127,9 +127,7 @@ def get_debug_menu() -> List[str]:
         "ACC  ",
         "PWR  ",
         "Max  ",
-        #ifdef HALL_SENSOR
         "Hall ",
-        #endif
     ]
 
 

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -127,7 +127,9 @@ def get_debug_menu() -> List[str]:
         "ACC  ",
         "PWR  ",
         "Max  ",
+        #ifdef HALL_SENSOR
         "Hall ",
+        #endif
     ]
 
 

--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -782,19 +782,17 @@ void showDebugMenu(void) {
       // Max deg C limit
       OLED::printNumber(TipThermoModel::getTipMaxInC(), 3, FontStyle::SMALL);
       break;
+#ifdef HALL_SENSOR
     case 13:
       // Print raw hall effect value if availabe, none if hall effect disabled.
-#ifdef HALL_SENSOR
-    {
-      int16_t hallEffectStrength = getRawHallEffect();
-      if (hallEffectStrength < 0)
-        hallEffectStrength = -hallEffectStrength;
-      OLED::printNumber(hallEffectStrength, 6, FontStyle::SMALL);
-    }
-#else
-      OLED::print(translatedString(Tr->OffString), FontStyle::SMALL);
+      {
+        int16_t hallEffectStrength = getRawHallEffect();
+        if (hallEffectStrength < 0)
+          hallEffectStrength = -hallEffectStrength;
+        OLED::printNumber(hallEffectStrength, 6, FontStyle::SMALL);
+      }
+      break;
 #endif
-    break;
     default:
       break;
     }
@@ -805,7 +803,11 @@ void showDebugMenu(void) {
       return;
     else if (b == BUTTON_F_SHORT) {
       screen++;
+#ifdef HALL_SENSOR
       screen = screen % 14;
+#else
+      screen = screen % 13;
+#endif
     }
     GUIDelay();
   }


### PR DESCRIPTION
I don't know, if it's only me, but I think this should be limited only to devices supporting this feature.
Otherwise this may cause confusion and unnecessary questions about why the hall sensor is turned off (and how to turn it on) on certain irons (all current ones except for the Pinecil).

I've tested this on my TS80P and the Pinecil. It worked for both!
However CI spits out an formatting error. 🤷‍♂️ (I could not figure out what's wrong!)