### PR TITLE
Pinecil mod detection

### DIFF
--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -148,6 +148,7 @@ def get_power_source_list() -> List[str]:
         "DC",
         "QC",
         "PD",
+        "PD No VBus",
     ]
 
 

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -147,7 +147,7 @@ def get_power_source_list() -> List[str]:
     return [
         "DC",
         "QC",
-        "PD",
+        "PD W. VBus",
         "PD No VBus",
     ]
 

--- a/source/Core/Drivers/USBPD.cpp
+++ b/source/Core/Drivers/USBPD.cpp
@@ -67,6 +67,17 @@ bool USBPowerDelivery::fusbPresent() {
   return detectionState == 1;
 }
 
+bool USBPowerDelivery::isVBUSConnected() {
+  // Check the status reg
+
+  FUSB302::fusb_status status;
+  if (fusb.fusb_get_status(&status)) {
+    return status.status0 & 0x80;
+  }
+  // As we are using this to detect the mod fail safe
+  return true;
+}
+
 bool pdbs_dpm_evaluate_capability(const pd_msg *capabilities, pd_msg *request) {
 
   /* Get the number of PDOs */

--- a/source/Core/Drivers/USBPD.cpp
+++ b/source/Core/Drivers/USBPD.cpp
@@ -67,16 +67,7 @@ bool USBPowerDelivery::fusbPresent() {
   return detectionState == 1;
 }
 
-bool USBPowerDelivery::isVBUSConnected() {
-  // Check the status reg
-
-  FUSB302::fusb_status status;
-  if (fusb.fusb_get_status(&status)) {
-    return status.status0 & 0x80;
-  }
-  // As we are using this to detect the mod fail safe
-  return true;
-}
+bool USBPowerDelivery::isVBUSConnected() { return fusb.isVBUSConnected(); }
 
 bool pdbs_dpm_evaluate_capability(const pd_msg *capabilities, pd_msg *request) {
 

--- a/source/Core/Drivers/USBPD.h
+++ b/source/Core/Drivers/USBPD.h
@@ -16,9 +16,9 @@ public:
   static void    PPSTimerCallback();      // PPS Timer
   static void    IRQOccured();            // Thread callback that an irq occured
   static void    step();                  // Iterate the step machine
-  static bool    negotiationHasWorked();  //
-  static uint8_t getStateNumber();        //
-
+  static bool    negotiationHasWorked();  // Has PD negotiation worked (are we in a PD contract)
+  static uint8_t getStateNumber();        // Debugging - Get the internal state number
+  static bool    isVBUSConnected();       // Is the VBus pin connected on the FUSB302
 private:
   //
   static int detectionState;

--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -732,7 +732,7 @@ void showDebugMenu(void) {
         } else {
           // We are not powered via DC, so want to display the appropriate state for PD or QC
           bool poweredbyPD        = false;
-          bool pdHasVBUSConnected = false;
+          bool pdHasVBUSConnected = true;
 #if POW_PD
           if (USBPowerDelivery::fusbPresent()) {
             // We are PD capable

--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -731,18 +731,23 @@ void showDebugMenu(void) {
           sourceNumber = 0;
         } else {
           // We are not powered via DC, so want to display the appropriate state for PD or QC
-          bool poweredbyPD = false;
+          bool poweredbyPD        = false;
+          bool pdHasVBUSConnected = false;
 #if POW_PD
           if (USBPowerDelivery::fusbPresent()) {
             // We are PD capable
             if (USBPowerDelivery::negotiationComplete()) {
               // We are powered via PD
-              poweredbyPD = true;
+              poweredbyPD        = true;
+              pdHasVBUSConnected = USBPowerDelivery::isVBUSConnected();
             }
           }
 #endif
           if (poweredbyPD) {
             sourceNumber = 2;
+            if (!pdHasVBUSConnected) {
+              sourceNumber = 3;
+            }
           } else {
             sourceNumber = 1;
           }


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
Expanding the shown type in the debug menu to indicate if VBus is connected or not.
This allows user to check the VBus mod presence on a Pinecil for use over 21V

* **Other information**:


Would love _any_ pinecil testers (both modded and not).

It should show `PD W. VBus` if you have not done the mod, and `PD No VBus` if you have done the mod.