### PR TITLE
adapting input format

### DIFF
--- a/Translations/BitmapEditor.html
+++ b/Translations/BitmapEditor.html
@@ -387,8 +387,8 @@
             if (bS.length < 2) bS = "0" + bS;
             pushy.push(bS);
           }
-          escapedToMatrix("\\x" + pushy.join("\\x"));
-          //			bodyAppend("p","\\x"+pushy.join("\\x"));
+          escapedToMatrix("0x" + pushy.join(", 0x"));
+          //			bodyAppend("p","0x"+pushy.join(", 0x"));
         }
       }
       function bodyAppend(tagName, innerHTML) {


### PR DESCRIPTION
When importing a **`.png`** in [BitmapEditor](https://github.com/Ralim/IronOS/blob/master/Translations/BitmapEditor.html) the corresponding **`hex`** code was not formatted as **IronOS** would need it.
So I tried fixing this.