### PR TITLE
Update translation_PL.json

### DIFF
--- a/Translations/translation_PL.json
+++ b/Translations/translation_PL.json
@@ -132,8 +132,8 @@
       "desc": "Szybkość przewijania tekstu"
     },
     "QCMaxVoltage": {
-      "text2": ["Moc", "w W"],
-      "desc": "Moc używanego zasilacza w (W)"
+      "text2": ["QC", "napięcie"],
+      "desc": "Maksymalne napięcie, które lutownica będzie próbowała wynegocjować z ładowarką Quick Charge (V)"
     },
     "PDNegTimeout": {
       "text2": ["Limit czasu", "PD"],


### PR DESCRIPTION
Corrected the definition of QCMaxVoltage which was previously mentioning power and wattage rather than QC voltage as it should


* **Please check if the PR fulfills these requirements**
- [No] The changes have been tested locally
- [Yes] There are no breaking changes

* **What kind of change does this PR introduce?**
Polish translation correction to align with English meaning