### PR TITLE
Fix #1335 (Slow boot animation on Pinecil) and add #1334 (Allow startup heating during boot logo)

### DIFF
--- a/source/Core/Drivers/BootLogo.cpp
+++ b/source/Core/Drivers/BootLogo.cpp
@@ -52,7 +52,7 @@ void BootLogo::showNewFormat(const uint8_t *ptrLogoArea) {
     buttons = getButtonState();
 
     if (interFrameDelay) {
-      osDelay(interFrameDelay * 5);
+      osDelay(interFrameDelay);
     }
     // 1024 less the header type byte and the inter-frame-delay
     if (getSettingValue(SettingsOptions::LOGOTime) > 0 && (position == 1022 || len == 0)) {

--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -972,6 +972,21 @@ void startGUITask(void const *argument) {
   }
 #endif
 #endif
+  // If the boot logo is enabled (but it times out) and the autostart mode is enabled (but not set to sleep w/o heat), start heating during boot logo
+  if (getSettingValue(SettingsOptions::LOGOTime) > 0 &&
+      getSettingValue(SettingsOptions::LOGOTime) < 5 &&
+      getSettingValue(SettingsOptions::AutoStartMode) > 0 &&
+      getSettingValue(SettingsOptions::AutoStartMode) < 3) {
+    uint16_t sleepTempDegC;
+    if (getSettingValue(SettingsOptions::TemperatureInF)) {
+      sleepTempDegC = TipThermoModel::convertFtoC(getSettingValue(SettingsOptions::SleepTemp));
+    } else {
+      sleepTempDegC = getSettingValue(SettingsOptions::SleepTemp);
+    }
+    // Only heat to sleep temperature (but no higher than 75*C for safety)
+    currentTempTargetDegC = min(sleepTempDegC, 75);
+  }
+
   BootLogo::handleShowingLogo((uint8_t *)FLASH_LOGOADDR);
 
   showWarnings();


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [✓] The changes have been tested locally
- [✓] There are no breaking changes

* **What kind of change does this PR introduce?**
One bug fix (#1335, the boot logo played animations at 1/5 speed) and one feature (#1334, allows the iron to start preheating during the boot animation)

* **What is the current behavior?**
See #1335 and #1334
* **What is the new behavior (if this is a feature change)?**
See #1335 and #1334
* **Other information**:
See #1335 and #1334