### PR TITLE
Fix slow boot animation (#1335)

### DIFF
--- a/source/Core/Drivers/BootLogo.cpp
+++ b/source/Core/Drivers/BootLogo.cpp
@@ -52,7 +52,7 @@ void BootLogo::showNewFormat(const uint8_t *ptrLogoArea) {
     buttons = getButtonState();
 
     if (interFrameDelay) {
-      osDelay(interFrameDelay * 5);
+      osDelay(interFrameDelay);
     }
     // 1024 less the header type byte and the inter-frame-delay
     if (getSettingValue(SettingsOptions::LOGOTime) > 0 && (position == 1022 || len == 0)) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [✓] The changes have been tested locally
- [✓] There are no breaking changes

* **What kind of change does this PR introduce?**
Bug fix

* **What is the current behavior?**
The boot animation plays at 1/5 speed

* **What is the new behavior (if this is a feature change)?**
The boot animation plays at normal (full) speed

* **Other information**:
Fixes #1335 