### PR TITLE
Allow preheating iron during boot logo (fixes #1334)

### DIFF
--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -972,6 +972,22 @@ void startGUITask(void const *argument) {
   }
 #endif
 #endif
+  // If the boot logo is enabled (but it times out) and the autostart mode is enabled (but not set to sleep w/o heat), start heating during boot logo
+  if (getSettingValue(SettingsOptions::LOGOTime) > 0 &&
+      getSettingValue(SettingsOptions::LOGOTime) < 5 &&
+      getSettingValue(SettingsOptions::AutoStartMode) > 0 &&
+      getSettingValue(SettingsOptions::AutoStartMode) < 3) {
+    uint16_t sleepTempDegC;
+    if (getSettingValue(SettingsOptions::TemperatureInF)) {
+      sleepTempDegC = TipThermoModel::convertFtoC(getSettingValue(SettingsOptions::SleepTemp));
+    } else {
+      sleepTempDegC = getSettingValue(SettingsOptions::SleepTemp);
+    }
+    // Only heat to sleep temperature (but no higher than 75*C for safety)
+    currentTempTargetDegC = min(sleepTempDegC, 75);
+  }
+
+
   BootLogo::handleShowingLogo((uint8_t *)FLASH_LOGOADDR);
 
   showWarnings();


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [✓] The changes have been tested locally
- [✓] There are no breaking changes

* **What kind of change does this PR introduce?**
Feature

* **What is the current behavior?**
When plugging in the iron with both autostart and a boot logo/animation enabled, the iron doesn't start heating until after the boot logo/animation finishes. If the iron heats up slowly, this means that the user either has to wait that much longer to use their iron or disable the boot logo/animation altogether.

* **What is the new behavior (if this is a feature change)?**
The iron will preheat to your sleep temperature (as long as it's no more than 75*C, otherwise it will heat to 75) during the boot logo/animation, then heat the rest of the way afterwards.

* **Other information**:
See #1334