### PR TITLE
Bump timeout for menu actions

### DIFF
--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -1021,7 +1021,7 @@ void gui_Menu(const menuitem *menu) {
       autoRepeatAcceleration = PRESS_ACCEL_INTERVAL_MAX - PRESS_ACCEL_INTERVAL_MIN;
     }
 
-    if ((xTaskGetTickCount() - lastButtonTime) > (TICKS_SECOND * 30)) {
+    if ((xTaskGetTickCount() - lastButtonTime) > (TICKS_SECOND * 2 * 60)) {
       // If user has not pressed any buttons in 30 seconds, exit back a menu layer
       // This will trickle the user back to the main screen eventually
       earlyExit = true;


### PR DESCRIPTION
Should Close #1379
Bumps menu timeout.

This is really only there so that an iron left in the menu will eventually shutdown.
So fairly harmless to have this be longer.