### PR TITLE
Update translation_RO.json

### DIFF
--- a/Translations/translation_RO.json
+++ b/Translations/translation_RO.json
@@ -7,7 +7,7 @@
 	],
 	"tempUnitFahrenheit": true,
 	"messages": {
-		"SettingsCalibrationWarning": "Please make sure tip & handle are at room temperature at next boot!",
+		"SettingsCalibrationWarning": "Vă rugăm să vă asigurați că vârful și mânerul sunt la temperatura camerei la următoarea pornire!",
 		"SettingsResetWarning": "Sigur doriti să restaurati la setările implicite?",
 		"UVLOWarningString": "DC LOW",
 		"UndervoltageString": "Sub tensiune",
@@ -166,7 +166,7 @@
 				"Sensibilitate",
 				"la mişcare"
 			],
-			"desc": "0=oprit | 1=putin sensibil | ... | 9=cel mai sensibil"
+			"desc": "Sensibilitate senzor mișcare (0=oprit | 1=putin sensibil | ... | 9=cel mai sensibil)"
 		},
 		"SleepTemperature": {
 			"text2": [
@@ -261,10 +261,10 @@
 		},
 		"LOGOTime": {
 			"text2": [
-				"Boot logo",
-				"duration"
+				"Durată",
+				"logo încărcare"
 			],
-			"desc": "Set boot logo duration (s=seconds)"
+			"desc": "Setați durata logo de pornire (s=secunde)"
 		},
 		"AdvancedIdle": {
 			"text2": [
@@ -289,10 +289,10 @@
 		},
 		"CalibrateCJC": {
 			"text2": [
-				"Calibrate CJC",
-				"at next boot"
+				"Calibrare CJC",
+				"la următoarea pornire"
 			],
-			"desc": "Calibrate tip Cold Junction Compensation at the next boot (not required if Delta T is < 5°C)"
+			"desc": "Calibrați vârful Cold Jonction Compensation la următoarea pornire (nu este necesar dacă Delta T este < 5°C)"
 		},
 		"VoltageCalibration": {
 			"text2": [

--- a/Translations/translation_RO.json
+++ b/Translations/translation_RO.json
@@ -7,7 +7,7 @@
 	],
 	"tempUnitFahrenheit": true,
 	"messages": {
-		"SettingsCalibrationWarning": "Vă rugăm să vă asigurați că vârful și mânerul sunt la temperatura camerei la următoarea pornire!",
+		"SettingsCalibrationWarning": "Vă rugăm să vă asigurati că vârful si mânerul sunt la temperatura camerei la următoarea pornire!",
 		"SettingsResetWarning": "Sigur doriti să restaurati la setările implicite?",
 		"UVLOWarningString": "DC LOW",
 		"UndervoltageString": "Sub tensiune",
@@ -166,7 +166,7 @@
 				"Sensibilitate",
 				"la mişcare"
 			],
-			"desc": "Sensibilitate senzor mișcare (0=oprit | 1=putin sensibil | ... | 9=cel mai sensibil)"
+			"desc": "Sensibilitate senzor miscare (0=oprit | 1=putin sensibil | ... | 9=cel mai sensibil)"
 		},
 		"SleepTemperature": {
 			"text2": [
@@ -264,7 +264,7 @@
 				"Durată",
 				"logo încărcare"
 			],
-			"desc": "Setați durata logo de pornire (s=secunde)"
+			"desc": "Setati durata logo de pornire (s=secunde)"
 		},
 		"AdvancedIdle": {
 			"text2": [
@@ -292,7 +292,7 @@
 				"Calibrare CJC",
 				"la următoarea pornire"
 			],
-			"desc": "Calibrați vârful Cold Jonction Compensation la următoarea pornire (nu este necesar dacă Delta T este < 5°C)"
+			"desc": "Calibrati vârful Cold Jonction Compensation la următoarea pornire (nu este necesar dacă Delta T este < 5°C)"
 		},
 		"VoltageCalibration": {
 			"text2": [

--- a/Translations/translation_RO.json
+++ b/Translations/translation_RO.json
@@ -164,7 +164,7 @@
 		"MotionSensitivity": {
 			"text2": [
 				"Sensibilitate",
-				"la mişcare"
+				"la miscare"
 			],
 			"desc": "Sensibilitate senzor miscare (0=oprit | 1=putin sensibil | ... | 9=cel mai sensibil)"
 		},

--- a/Translations/translation_RO.json
+++ b/Translations/translation_RO.json
@@ -292,7 +292,7 @@
 				"Calibrare CJC",
 				"la următoarea pornire"
 			],
-			"desc": "Calibrati vârful Cold Jonction Compensation la următoarea pornire (nu este necesar dacă Delta T este < 5°C)"
+			"desc": "Calibrati vârful Cold Junction Compensation la următoarea pornire (nu este necesar dacă Delta T este < 5°C)"
 		},
 		"VoltageCalibration": {
 			"text2": [


### PR DESCRIPTION
@cipyyy
Your changes should be implemented with this PR.
Unfortunately 2 specific letters (ț and ș) could not be used, remember this was discussed when this language pack was about to be implemented @sandmanRO suggested to leave these out (https://github.com/Ralim/IronOS/pull/1056).