### PR TITLE
Update translation_RU.json

### DIFF
--- a/Translations/translation_RU.json
+++ b/Translations/translation_RU.json
@@ -8,7 +8,7 @@
 	],
 	"tempUnitFahrenheit": false,
 	"messages": {
-		"SettingsCalibrationWarning": "Пожалуйста, убедитесь, что кончик и ручка имеют комнатную температуру при следующей загрузке!",
+		"SettingsCalibrationWarning": "Пожалуйста, убедитесь, что жало и корпус имеют комнатную температуру при следующей загрузке!",
 		"SettingsResetWarning": "Вы уверены, что хотите сбросить настройки к значениям по умолчанию?",
 		"UVLOWarningString": "НАПРЯЖ--",
 		"UndervoltageString": "Низ. напряжение",
@@ -37,8 +37,8 @@
 		"UnlockingKeysString": "РАЗБЛОК",
 		"WarningKeysLockedString": "!ЗАБЛОК!",
 		"WarningThermalRunaway": [
-			"Утечка",
-			"Температуры"
+			"Thermal",
+			"Runaway"
 		]
 	},
 	"characters": {
@@ -293,7 +293,7 @@
 				"Калибровка",
 				"температуры"
 			],
-			"desc": "Калибровка компенсации холодного спая жала при следующей загрузке (не требуется, если Delta T < 5°C)"
+			"desc": "Калибровка датчика температуры жала при следующей загрузке (не требуется, если разница меньше 5°C)""
 		},
 		"VoltageCalibration": {
 			"text2": [


### PR DESCRIPTION
thermal runaway - shouldn't be translated, otherwise it will not be possible to search for the problem
tip - жало паяльника, кончик не точный перевод. handle - не ручка, а корпус паяльника
CJC calibration clean up for better understanding

- [] There are no breaking changes
