### PR TITLE
Only send on display change

### DIFF
--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -25,7 +25,7 @@ bool               OLED::initDone = false;
 uint8_t            OLED::displayOffset;
 uint8_t            OLED::screenBuffer[16 + (OLED_WIDTH * 2) + 10]; // The data buffer
 uint8_t            OLED::secondFrameBuffer[OLED_WIDTH * 2];
-
+uint32_t           OLED::displayChecksum;
 /*Setup params for the OLED screen*/
 /*http://www.displayfuture.com/Display/datasheet/controller/SSD1307.pdf*/
 /*All commands are prefixed with 0x80*/
@@ -222,7 +222,7 @@ void OLED::maskScrollIndicatorOnOLED() {
   // it from the screen buffer which is updated by `OLED::setRotation`.
   uint8_t rightmostColumn = screenBuffer[7];
   uint8_t maskCommands[]  = {
-      // Set column address:
+       // Set column address:
       //  A[6:0] - Column start address = rightmost column
       //  B[6:0] - Column end address = rightmost column
       0x80,

--- a/source/Core/Drivers/OLED.hpp
+++ b/source/Core/Drivers/OLED.hpp
@@ -10,10 +10,12 @@
 #ifndef OLED_HPP_
 #define OLED_HPP_
 #include "Font.h"
+#include "cmsis_os.h"
 #include "configuration.h"
 #include <BSP.h>
 #include <stdbool.h>
 #include <string.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -63,8 +65,13 @@ public:
   }
 
   static void setDisplayState(DisplayState state) {
-    displayState    = state;
-    screenBuffer[1] = (state == ON) ? 0xAF : 0xAE;
+    if (state != displayState) {
+      displayState    = state;
+      screenBuffer[1] = (state == ON) ? 0xAF : 0xAE;
+      // Dump the screen state change out _now_
+      I2C_CLASS::Transmit(DEVICEADDR_OLED, screenBuffer, FRAMEBUFFER_START - 1);
+      osDelay(TICKS_10MS);
+    }
   }
 
   static void setRotation(bool leftHanded); // Set the rotation for the screen


### PR DESCRIPTION
Using a small checksum on the OLED update; to only send the screen contents data.
This is to reduce activity on the I2C bus when we dont need to.