### PR TITLE
Fix the calibrate voltage screen, when it exits, it used to overlay t…

### DIFF
--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -682,6 +682,7 @@ static bool setCalibrateVIN(void) {
     case BUTTON_F_LONG:
     case BUTTON_B_LONG:
       saveSettings();
+      OLED::clearScreen();
       OLED::setCursor(0, 0);
       OLED::printNumber(getSettingValue(SettingsOptions::VoltageDiv), 3, FontStyle::LARGE);
       OLED::refresh();


### PR DESCRIPTION
…he calibrated divider over the previous displayed image, causing confusion. Now it clears the screen before printing the calibrated value


<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
Bugfix to what it looks like when exiting voltage calibration


* **What is the current behavior?**
<!-- (You can also just link to an open issue here) -->

* **What is the new behavior (if this is a feature change)?**

* **Other information**:
