### PR TITLE
Miniware+Pinecil: fix number of items in uVtoDegC array. This only af…

### DIFF
--- a/source/Core/BSP/Miniware/ThermoModel.cpp
+++ b/source/Core/BSP/Miniware/ThermoModel.cpp
@@ -125,6 +125,6 @@ const int32_t uVtoDegC[] = {
     38137, 500, //
 };
 #endif
-const int uVtoDegCItems = sizeof(uVtoDegC) / (2 * sizeof(uint16_t));
+const int uVtoDegCItems = sizeof(uVtoDegC) / (2 * sizeof(uVtoDegC[0]));
 
 uint32_t TipThermoModel::convertuVToDegC(uint32_t tipuVDelta) { return Utils::InterpolateLookupTable(uVtoDegC, uVtoDegCItems, tipuVDelta); }

--- a/source/Core/BSP/Pinecil/ThermoModel.cpp
+++ b/source/Core/BSP/Pinecil/ThermoModel.cpp
@@ -67,6 +67,6 @@ const int32_t uVtoDegC[] = {
 };
 #endif
 
-const int uVtoDegCItems = sizeof(uVtoDegC) / (2 * sizeof(uint16_t));
+const int uVtoDegCItems = sizeof(uVtoDegC) / (2 * sizeof(uVtoDegC[0]));
 
 uint32_t TipThermoModel::convertuVToDegC(uint32_t tipuVDelta) { return Utils::InterpolateLookupTable(uVtoDegC, uVtoDegCItems, tipuVDelta); }


### PR DESCRIPTION
…fects us in case we go above 500degC, in which case we'll be reading invalid memory


<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
Bugfix. Interpolator will think that there are twice as many elements in lookup table. Not very likely unless temperature goes above the max in the table, in which case we'll be accessing invalid memory.
![image](https://user-images.githubusercontent.com/544648/212586665-e32231cc-2c49-4bbe-b853-e6b37d2fd5b6.png)



* **What is the current behavior?**
<!-- (You can also just link to an open issue here) -->

* **What is the new behavior (if this is a feature change)?**

* **Other information**:
