### PR TITLE
Drop decimal when > 99.9W

### DIFF
--- a/source/Core/Threads/OperatingModes/Soldering.cpp
+++ b/source/Core/Threads/OperatingModes/Soldering.cpp
@@ -127,10 +127,20 @@ void gui_solderingMode(uint8_t jumpToSleep) {
       } else {
         OLED::setCursor(67, 0);
       }
-      OLED::printNumber(x10WattHistory.average() / 10, 2, FontStyle::SMALL);
-      OLED::print(SmallSymbolDot, FontStyle::SMALL);
-      OLED::printNumber(x10WattHistory.average() % 10, 1, FontStyle::SMALL);
-      OLED::print(SmallSymbolWatts, FontStyle::SMALL);
+      // Print wattage
+      {
+        uint32_t x10Watt = x10WattHistory.average();
+        if (x10Watt > 999) { // If we exceed 99.9W we drop the decimal place to keep it all fitting
+          OLED::print(SmallSymbolSpace, FontStyle::SMALL);
+          OLED::printNumber(x10WattHistory.average() / 10, 3, FontStyle::SMALL);
+          OLED::print(SmallSymbolWatts, FontStyle::SMALL);
+        } else {
+          OLED::printNumber(x10WattHistory.average() / 10, 2, FontStyle::SMALL);
+          OLED::print(SmallSymbolDot, FontStyle::SMALL);
+          OLED::printNumber(x10WattHistory.average() % 10, 1, FontStyle::SMALL);
+          OLED::print(SmallSymbolWatts, FontStyle::SMALL);
+        }
+      }
 
       if (OLED::getRotation()) {
         OLED::setCursor(0, 8);


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
When the estimated wattage is > 99.9W we drop the decimal and just print 100W



* **What is the current behavior?**
#1496

* **Other information**:
Closes #1496 when merged