### PR TITLE
track and return Operating Mode with BLE

### DIFF
--- a/source/Core/BSP/Pinecilv2/ble_handlers.cpp
+++ b/source/Core/BSP/Pinecilv2/ble_handlers.cpp
@@ -20,18 +20,18 @@
 #include "log.h"
 #include "uuid.h"
 
+#include "OperatingModes.h"
 #include "USBPD.h"
 #include "ble_characteristics.h"
 #include "ble_handlers.h"
 #include "pd.h"
 #include "power.hpp"
-#include "OperatingModes.h"
 #if POW_PD
 #include "USBPD.h"
 #include "pd.h"
 #endif
 
-extern TickType_t lastMovementTime;
+extern TickType_t    lastMovementTime;
 extern OperatingMode currentMode;
 
 int ble_char_read_status_callback(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf, u16_t len, u16_t offset) {

--- a/source/Core/BSP/Pinecilv2/ble_handlers.cpp
+++ b/source/Core/BSP/Pinecilv2/ble_handlers.cpp
@@ -25,12 +25,14 @@
 #include "ble_handlers.h"
 #include "pd.h"
 #include "power.hpp"
+#include "OperatingModes.h"
 #if POW_PD
 #include "USBPD.h"
 #include "pd.h"
 #endif
 
 extern TickType_t lastMovementTime;
+OperatingMode currentMode = OperatingMode::idle;
 
 int ble_char_read_status_callback(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf, u16_t len, u16_t offset) {
   if (attr == NULL || attr->uuid == NULL) {
@@ -123,6 +125,9 @@ int ble_char_read_status_callback(struct bt_conn *conn, const struct bt_gatt_att
   case 13:
     // Operating mode
     // TODO: Needs tracking
+    temp = currentMode;
+    memcpy(buf, &temp, sizeof(temp));
+    return sizeof(temp);
     break;
   case 14:
     // Estimated watts

--- a/source/Core/BSP/Pinecilv2/ble_handlers.cpp
+++ b/source/Core/BSP/Pinecilv2/ble_handlers.cpp
@@ -32,7 +32,7 @@
 #endif
 
 extern TickType_t lastMovementTime;
-OperatingMode currentMode = OperatingMode::idle;
+extern OperatingMode currentMode;
 
 int ble_char_read_status_callback(struct bt_conn *conn, const struct bt_gatt_attr *attr, void *buf, u16_t len, u16_t offset) {
   if (attr == NULL || attr->uuid == NULL) {

--- a/source/Core/Threads/OperatingModes/DebugMenu.cpp
+++ b/source/Core/Threads/OperatingModes/DebugMenu.cpp
@@ -2,8 +2,10 @@
 extern osThreadId GUITaskHandle;
 extern osThreadId MOVTaskHandle;
 extern osThreadId PIDTaskHandle;
+extern OperatingMode currentMode;
 
 void showDebugMenu(void) {
+  currentMode = OperatingMode::debug;
   uint8_t     screen = 0;
   ButtonState b;
   for (;;) {

--- a/source/Core/Threads/OperatingModes/DebugMenu.cpp
+++ b/source/Core/Threads/OperatingModes/DebugMenu.cpp
@@ -5,7 +5,7 @@ extern osThreadId PIDTaskHandle;
 extern OperatingMode currentMode;
 
 void showDebugMenu(void) {
-  currentMode = OperatingMode::debug;
+  currentMode        = OperatingMode::debug;
   uint8_t     screen = 0;
   ButtonState b;
   for (;;) {

--- a/source/Core/Threads/OperatingModes/HomeScreen.cpp
+++ b/source/Core/Threads/OperatingModes/HomeScreen.cpp
@@ -8,6 +8,7 @@
 uint8_t buttonAF[sizeof(buttonA)];
 uint8_t buttonBF[sizeof(buttonB)];
 uint8_t disconnectedTipF[sizeof(disconnectedTip)];
+extern OperatingMode currentMode;
 
 void renderHomeScreenAssets(void) {
 
@@ -29,6 +30,7 @@ void drawHomeScreen(bool buttonLockout) {
   renderHomeScreenAssets();
 
   for (;;) {
+    currentMode = OperatingMode::idle;
     ButtonState buttons = getButtonState();
     if (buttons != BUTTON_NONE) {
       OLED::setDisplayState(OLED::DisplayState::ON);
@@ -63,6 +65,7 @@ void drawHomeScreen(bool buttonLockout) {
       }
       break;
     case BUTTON_B_SHORT:
+      currentMode = OperatingMode::settings;
       enterSettingsMenu(); // enter the settings menu
       {
         OLED::useSecondaryFramebuffer(true);

--- a/source/Core/Threads/OperatingModes/HomeScreen.cpp
+++ b/source/Core/Threads/OperatingModes/HomeScreen.cpp
@@ -30,7 +30,7 @@ void drawHomeScreen(bool buttonLockout) {
   renderHomeScreenAssets();
 
   for (;;) {
-    currentMode = OperatingMode::idle;
+    currentMode         = OperatingMode::idle;
     ButtonState buttons = getButtonState();
     if (buttons != BUTTON_NONE) {
       OLED::setDisplayState(OLED::DisplayState::ON);

--- a/source/Core/Threads/OperatingModes/OperatingModes.cpp
+++ b/source/Core/Threads/OperatingModes/OperatingModes.cpp
@@ -1,0 +1,8 @@
+//
+// Created by Thomas White on 3/02/2023.
+//
+
+#include "OperatingModes.h"
+
+// Global variables
+OperatingMode currentMode = OperatingMode::idle;

--- a/source/Core/Threads/OperatingModes/OperatingModes.h
+++ b/source/Core/Threads/OperatingModes/OperatingModes.h
@@ -24,6 +24,13 @@ extern "C" {
 #endif
 
 // Exposed modes
+enum OperatingMode {
+    idle      = 0,
+    soldering = 1,
+    sleeping  = 2,
+    settings  = 3,
+    debug     = 4
+};
 
 void performCJCC(void);                                            // Used to calibrate the Cold Junction offset
 void gui_solderingTempAdjust(void);                                // For adjusting the setpoint temperature of the iron

--- a/source/Core/Threads/OperatingModes/Sleep.cpp
+++ b/source/Core/Threads/OperatingModes/Sleep.cpp
@@ -1,7 +1,10 @@
 #include "OperatingModes.h"
 
+extern OperatingMode currentMode;
+
 int gui_SolderingSleepingMode(bool stayOff, bool autoStarted) {
   // Drop to sleep temperature and display until movement or button press
+  currentMode = OperatingMode::sleeping;
 
   for (;;) {
     // user moved or pressed a button, go back to soldering

--- a/source/Core/Threads/OperatingModes/Soldering.cpp
+++ b/source/Core/Threads/OperatingModes/Soldering.cpp
@@ -2,6 +2,7 @@
 #include "OperatingModes.h"
 
 extern bool heaterThermalRunaway;
+extern OperatingMode currentMode;
 
 void gui_solderingMode(uint8_t jumpToSleep) {
   /*
@@ -20,6 +21,7 @@ void gui_solderingMode(uint8_t jumpToSleep) {
    */
   bool boostModeOn   = false;
   bool buttonsLocked = false;
+  currentMode = OperatingMode::soldering;
 
   if (jumpToSleep) {
     if (gui_SolderingSleepingMode(jumpToSleep == 2, true) == 1) {

--- a/source/Core/Threads/OperatingModes/Soldering.cpp
+++ b/source/Core/Threads/OperatingModes/Soldering.cpp
@@ -1,7 +1,7 @@
 
 #include "OperatingModes.h"
 
-extern bool heaterThermalRunaway;
+extern bool          heaterThermalRunaway;
 extern OperatingMode currentMode;
 
 void gui_solderingMode(uint8_t jumpToSleep) {
@@ -21,7 +21,7 @@ void gui_solderingMode(uint8_t jumpToSleep) {
    */
   bool boostModeOn   = false;
   bool buttonsLocked = false;
-  currentMode = OperatingMode::soldering;
+  currentMode        = OperatingMode::soldering;
 
   if (jumpToSleep) {
     if (gui_SolderingSleepingMode(jumpToSleep == 2, true) == 1) {


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

**Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

**What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
feature


**What is the current behavior?**
<!-- (You can also just link to an open issue here) -->
nothing is returned for the Operating Mode BLE characteristic

**What is the new behavior (if this is a feature change)?**
it will now return an int depending on what mode it is in.

idle -> 0
soldering -> 1
sleeping -> 2
settings menu -> 3
debug menu -> 4

**Other information**:
