### PR TITLE
Use the scan response to advertise some of the available service UUID…

### DIFF
--- a/source/Core/BSP/Pinecilv2/ble_peripheral.c
+++ b/source/Core/BSP/Pinecilv2/ble_peripheral.c
@@ -268,12 +268,17 @@ int ble_start_adv(void) {
       .interval_max = BT_GAP_ADV_FAST_INT_MAX_3,
   };
 
+  // scan and response data must each stay < 31 bytes
   struct bt_data adv_data[2] = {
       BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_NO_BREDR | BT_LE_AD_GENERAL)),
-      BT_DATA(BT_DATA_NAME_COMPLETE, DEVICE_BLE_NAME, strlen(DEVICE_BLE_NAME)),
+      BT_DATA(BT_DATA_NAME_COMPLETE, DEVICE_BLE_NAME, strlen(DEVICE_BLE_NAME))
   };
 
-  return bt_le_adv_start(&adv_param, adv_data, ARRAY_SIZE(adv_data), &adv_data[1], 1);
+  struct bt_data scan_response_data[1] = {
+      BT_DATA(BT_DATA_UUID128_SOME, ((struct bt_uuid_128 *)BT_UUID_SVC_BULK_DATA)->val, 16)
+  };
+
+  return bt_le_adv_start(&adv_param, adv_data,   ARRAY_SIZE(adv_data), scan_response_data, ARRAY_SIZE(scan_response_data));
 }
 
 // Callback that the ble stack will call once it has been kicked off running


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [X] The changes have been tested locally
- [X] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
We can **use the BLE scan response to advertise some of the available service UUIDs**, rather than just repeating the device name in the scan response packet.

This allows users to effectively filter available BLE devices for those which support the BLE services/characteristics defined in IronOS, without being dependent on the name of the device being equal to, or prefixed with, "Pinecil".I could see this potentially helping with e.g. #1545 or even allowing completely custom bluetooth names with little/no complications.

Without advertising a service UUID in the advertisement or scan response data, potential users would have to connect to the device in order to discover all its services, before being _sure_ it's going to work.

I've tentatively chosen here to advertise the bulk data service, but a case could be made to advertise the live data service instead.

* **What is the current behavior?**
Scan response packet only contains the device name repeated, with no service info. This results in e.g. android seeing the Pinecil like this:
![image](https://user-images.githubusercontent.com/20997804/216796824-7c7bda1b-b61a-412f-abaf-9067bc538646.png)
![image](https://user-images.githubusercontent.com/20997804/216796839-b65d92b0-ad1f-4728-8d34-40fbaac321dc.png)


* **What is the new behavior (if this is a feature change)?**
The scan response now includes details of one of the service UUIDs, with a "some 128bit service UUIDs" flag:
![image](https://user-images.githubusercontent.com/20997804/216796595-68a7aa9f-7bc9-4482-a2cd-f8564f08bee2.png)
![image](https://user-images.githubusercontent.com/20997804/216796600-3580f449-c5aa-4097-9b86-65517963fcf6.png)


* **Other information**:
I reckon this could be useful for a few reasons, what comes to mind:
Several libraries I've looked at use service as their primary filter for devices which seems reasonably intuitive to me.
**Bonus:** If any future devices are supported by IronOS and we want them to support the same services/characteristics, they would be instantly compatible even if not called "Pinecil"