### PR TITLE
Fix README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-![CI](https://github.com/Ralim/ts100/workflows/CI%20Build%20all/badge.svg)
-![GitHub all](https://img.shields.io/github/downloads/ralim/IronOS/total)
-![GitHub contributors](https://img.shields.io/github/contributors-anon/ralim/ironos?color=blue&style=flat)
-![Latest Release](https://img.shields.io/github/v/release/ralim/IronOS)
+[![CI Build](https://github.com/Ralim/IronOS/actions/workflows/push.yml/badge.svg)](https://github.com/Ralim/IronOS/actions/workflows/push.yml)
+[![Total Downloads](https://img.shields.io/github/downloads/ralim/IronOS/total)](https://github.com/Ralim/IronOS)
+[![Contributors](https://img.shields.io/github/contributors-anon/ralim/ironos?color=blue&style=flat)](https://github.com/Ralim/IronOS/graphs/contributors)
+[![Latest Release](https://img.shields.io/github/v/release/ralim/IronOS)](https://github.com/Ralim/IronOS/releases/latest)
 
 # IronOS - Flexible Soldering iron control Firmware
 


### PR DESCRIPTION


<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [X] The changes have been tested locally
- [X] There are no breaking changes

* **What kind of change does this PR introduce?**
  * Updates the README.md file to have correct links

* **What is the current behavior?**
  * Currently, as per #1603 The CI Build badge is broken.
The other 3 badges all link to their images, rather than the intended locations
(the latest release page for the release badge, etc)

* **What is the new behavior (if this is a feature change)?**
  * The badges all now point to their correct link locations, and the CI badge image has been fixed.

* **Other information**:
  * Resolves #1603
