### PR TITLE
Update settings icon description

### DIFF
--- a/Documentation/Flashing/Pinecil V2.md
+++ b/Documentation/Flashing/Pinecil V2.md
@@ -29,7 +29,7 @@ Then this works the same as a production release (use the correct file).
 - The MCU in Pinecil V2 is Bouffalo BL706 and does _not_ use usb-dfu for flashing as the previous Pinecil V1 MCU did.
 - See the Pinecil Wiki page [here](https://wiki.pine64.org/wiki/Pinecil#Firmware_&_Updates) for instructions.
 - The V2 uses the [BLISP flasher](https://github.com/pine64/blisp) to upload the firmware to the MCU.
-- The [Pinecil Wiki] (https://wiki.pine64.org/wiki/Pinecil) is a great resource for all things Pinecil.
+- The [Pinecil Wiki](https://wiki.pine64.org/wiki/Pinecil) is a great resource for all things Pinecil.
 - Community chat: if there are issues updating, then join the Pine64 > Pinecil channel [here](https://wiki.pine64.org/wiki/Pinecil#Live_Community_Chat). There are knowledgeable members in Discord/Telegram/Matrix. Discord has a bridge bot connection to Telegram and Matrix so that all pine64 volunteers/members can see advice for Pinecil and related items or just get tips on which power supply to purchase.
 - One advantage of Pinecil is that you cannot permanently damage it doing a firmware update (because BIN is in ROM); an update could render Pinecil temporarily inoperable if you flash an invalid firmware. But no worries, simply re-flashing with a working firmware copy will fix everything.
 - USB-C cable is required to do an update. Generally, all USB controllers work, but some hubs have issues, so it is preferred to avoid USB hubs for updates.

--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -28,7 +28,7 @@ Note that this may be drawn mirrored depending on the orientation of your screen
 
 The soldering iron symbol on the screen will appear near the tip. This is here to indicate that pressing the button closest to the front of the iron will enter soldering mode.
 
-And naturally, the spanner like icon represents that pressing the button near the rear of the soldering iron will enter the settings menu.
+And naturally, the slider controls icon (or spanner icon in older versions) represents that pressing the button near the rear of the soldering iron will enter the settings menu.
 
 In the settings, you can turn on a detailed idle screen instead. The buttons still function the same, however, the image will be swapped for a text telling you the current status of the iron with extra details.
 


### PR DESCRIPTION
This just updates the getting started page description of the startup icons. It talks about a "spanner like icon" for the settings menu, but that didn't reflect the latest release or the screenshot image above this section. I don't know if that is a legacy icon, but the current settings icon looks like a set of three slider controls. I updated this section to reflect that.

[Edit: also threw in a quick Markdown syntax typo fix. Hope that isn't a problem.]

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
docs update
