### PR TITLE
fixing power limit display

### DIFF
--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -273,7 +273,7 @@ const menuitem advancedMenu[] = {
 #ifdef BLE_ENABLED
     {SETTINGS_DESC(SettingsItemIndex::BLEEnabled), nullptr, displayBLEEnabled, nullptr, SettingsOptions::BLEEnabled, SettingsItemIndex::BLEEnabled, 7}, /*Advanced idle screen*/
 #endif
-    {SETTINGS_DESC(SettingsItemIndex::PowerLimit), nullptr, displayPowerLimit, nullptr, SettingsOptions::PowerLimit, SettingsItemIndex::PowerLimit, 5}, /*Power limit*/
+    {SETTINGS_DESC(SettingsItemIndex::PowerLimit), nullptr, displayPowerLimit, nullptr, SettingsOptions::PowerLimit, SettingsItemIndex::PowerLimit, 4}, /*Power limit*/
     {SETTINGS_DESC(SettingsItemIndex::CalibrateCJC), setCalibrate, displayCalibrate, nullptr, SettingsOptions::SettingsOptionsLength, SettingsItemIndex::CalibrateCJC,
      7}, /*Calibrate Cold Junktion Compensation at next boot*/
     {SETTINGS_DESC(SettingsItemIndex::VoltageCalibration), setCalibrateVIN, displayCalibrateVIN, nullptr, SettingsOptions::SettingsOptionsLength, SettingsItemIndex::VoltageCalibration,
@@ -651,7 +651,7 @@ static void displayPowerLimit(void) {
   if (getSettingValue(SettingsOptions::PowerLimit) == 0) {
     OLED::print(translatedString(Tr->OffString), FontStyle::LARGE);
   } else {
-    OLED::printNumber(getSettingValue(SettingsOptions::PowerLimit), 2, FontStyle::LARGE);
+    OLED::printNumber(getSettingValue(SettingsOptions::PowerLimit), 3, FontStyle::LARGE);
     OLED::print(LargeSymbolWatts, FontStyle::LARGE);
   }
 }


### PR DESCRIPTION
@Ralim

Since the **first digit was cut off**, the displayed value was misleading  unless one was careful to notice that the scrollbar _**didn't blink**_ after **`95`** was reached.

Not sure if this solution is correct as the **`Pinecil V2`** side says max **88W**.
But after seeing the wiki I'm even more confused as there are several different statements about the maximum wattage allowed. Also, the current **`MAX_POWER_LIMIT is 220`**.

Do we need to lower the **`MAX_POWER_LIMIT`** or should this fix be implemented?