### PR TITLE
Unify sha-bangs for python scripts

### DIFF
--- a/source/dfuse-pack.py
+++ b/source/dfuse-pack.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # Written by Antonio Galea - 2010/11/18
 # Distributed under Gnu LGPL 3.0

--- a/source/metadata.py
+++ b/source/metadata.py
@@ -1,4 +1,4 @@
-#! python3
+#!/usr/bin/env python3
 
 import json
 from pathlib import Path


### PR DESCRIPTION
Unify sha-bangs for python scripts - put the same line as in the other py scripts.