### PR TITLE
Show power source type on detailed screen in soldering mode (#1708)

### DIFF
--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -188,8 +188,8 @@ def get_power_source_list() -> List[str]:
     return [
         "DC",
         "QC",
-        "PD W. VBus",
-        "PD No VBus",
+        "PV:PDwVBus",
+        "PD:No VBus",
     ]
 
 

--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -405,8 +405,9 @@ void OLED::setInverseDisplay(bool inverse) {
 }
 
 // print a string to the current cursor location
-void OLED::print(const char *const str, FontStyle fontStyle) {
+void OLED::print(const char *const str, FontStyle fontStyle, uint8_t n) {
   const uint8_t *next = reinterpret_cast<const uint8_t *>(str);
+  bool cut = n ? true : false;
   if (next[0] == 0x01) {
     fontStyle = FontStyle::LARGE;
     next++;
@@ -424,6 +425,9 @@ void OLED::print(const char *const str, FontStyle fontStyle) {
       next += 2;
     }
     drawChar(index, fontStyle);
+    if (cut && !--n) {
+      return;
+    }
   }
 }
 

--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -404,15 +404,14 @@ void OLED::setInverseDisplay(bool inverse) {
   I2C_CLASS::I2C_RegisterWrite(DEVICEADDR_OLED, 0x80, normalInverseCmd);
 }
 
-// print a string to the current cursor location
-void OLED::print(const char *const str, FontStyle fontStyle, uint8_t n) {
+// print a string to the current cursor location, len chars MAX
+void OLED::print(const char *const str, FontStyle fontStyle, uint8_t len) {
   const uint8_t *next = reinterpret_cast<const uint8_t *>(str);
-  bool cut = n ? true : false;
   if (next[0] == 0x01) {
     fontStyle = FontStyle::LARGE;
     next++;
   }
-  while (next[0]) {
+  while (next[0] && len--) {
     uint16_t index;
     if (next[0] <= 0xF0) {
       index = next[0];
@@ -425,9 +424,6 @@ void OLED::print(const char *const str, FontStyle fontStyle, uint8_t n) {
       next += 2;
     }
     drawChar(index, fontStyle);
-    if (cut && !--n) {
-      return;
-    }
   }
 }
 

--- a/source/Core/Drivers/OLED.hpp
+++ b/source/Core/Drivers/OLED.hpp
@@ -105,7 +105,7 @@ public:
   static void    setBrightness(uint8_t contrast);
   static void    setInverseDisplay(bool inverted);
   static int16_t getCursorX() { return cursor_x; }
-  static void    print(const char *string, FontStyle fontStyle, uint8_t num = 0); // Draw a string (or only a number of chars from string if specified) to the current location, with selected font
+  static void    print(const char *string, FontStyle fontStyle, uint8_t length = 255); // Draw a string to the current location, with selected font; optionally - with MAX length only
   static void    printWholeScreen(const char *string);
   // Set the cursor location by pixels
   static void setCursor(int16_t x, int16_t y) {

--- a/source/Core/Drivers/OLED.hpp
+++ b/source/Core/Drivers/OLED.hpp
@@ -105,7 +105,7 @@ public:
   static void    setBrightness(uint8_t contrast);
   static void    setInverseDisplay(bool inverted);
   static int16_t getCursorX() { return cursor_x; }
-  static void    print(const char *string, FontStyle fontStyle); // Draw a string to the current location, with selected font
+  static void    print(const char *string, FontStyle fontStyle, uint8_t num = 0); // Draw a string (or only a number of chars from string if specified) to the current location, with selected font
   static void    printWholeScreen(const char *string);
   // Set the cursor location by pixels
   static void setCursor(int16_t x, int16_t y) {

--- a/source/Core/Threads/OperatingModes/DebugMenu.cpp
+++ b/source/Core/Threads/OperatingModes/DebugMenu.cpp
@@ -4,39 +4,6 @@ extern osThreadId    MOVTaskHandle;
 extern osThreadId    PIDTaskHandle;
 extern OperatingMode currentMode;
 
-int8_t getPowerSourceNumber(void) {
-  int8_t sourceNumber = 0;
-  if (getIsPoweredByDCIN()) {
-    sourceNumber = 0;
-  } else {
-    // We are not powered via DC, so want to display the appropriate state for PD or QC
-    bool poweredbyPD        = false;
-    bool pdHasVBUSConnected = false;
-#ifdef POW_PD
-    if (USBPowerDelivery::fusbPresent()) {
-      // We are PD capable
-      if (USBPowerDelivery::negotiationComplete()) {
-        // We are powered via PD
-        poweredbyPD = true;
-#ifdef VBUS_MOD_TEST
-        pdHasVBUSConnected = USBPowerDelivery::isVBUSConnected();
-#endif
-      }
-    }
-#endif
-    if (poweredbyPD) {
-      if (pdHasVBUSConnected) {
-        sourceNumber = 2;
-      } else {
-        sourceNumber = 3;
-      }
-    } else {
-      sourceNumber = 1;
-    }
-  }
-  return sourceNumber;
-}
-
 void showDebugMenu(void) {
   currentMode        = OperatingMode::debug;
   uint8_t     screen = 0;

--- a/source/Core/Threads/OperatingModes/OperatingModes.h
+++ b/source/Core/Threads/OperatingModes/OperatingModes.h
@@ -33,15 +33,18 @@ enum OperatingMode {
     debug     = 5
 };
 
+// Main functions
 void performCJCC(void);                                            // Used to calibrate the Cold Junction offset
 void gui_solderingTempAdjust(void);                                // For adjusting the setpoint temperature of the iron
 int  gui_SolderingSleepingMode(bool stayOff, bool autoStarted);    // Sleep mode
 void gui_solderingMode(uint8_t jumpToSleep);                       // Main mode for hot pointy tool
 void gui_solderingProfileMode();                                   // Profile mode for hot likely-not-so-pointy tool
 void showDebugMenu(void);                                          // Debugging values
-void showPDDebug(void);                                            // Debugging menu that hows PD adaptor info
+void showPDDebug(void);                                            // Debugging menu that shows PD adaptor info
 void showWarnings(void);                                           // Shows user warnings if required
 void drawHomeScreen(bool buttonLockout) __attribute__((noreturn)); // IDLE / Home screen
 void renderHomeScreenAssets(void);                                 // Called to act as start delay and used to render out flipped images for home screen graphics
-//
+
+// Common helpers
+int8_t getPowerSourceNumber(void);                                 // Returns number ID of power source
 #endif

--- a/source/Core/Threads/OperatingModes/Soldering.cpp
+++ b/source/Core/Threads/OperatingModes/Soldering.cpp
@@ -129,6 +129,13 @@ void gui_solderingMode(uint8_t jumpToSleep) {
           OLED::setCursor(55, 8);
         }
         OLED::print(SmallSymbolPlus, FontStyle::SMALL);
+      } else {
+        if (OLED::getRotation()) {
+          OLED::setCursor(32, 8);
+        } else {
+          OLED::setCursor(47, 8);
+        }
+        OLED::print(PowerSourceNames[getPowerSourceNumber()], FontStyle::SMALL, 2);
       }
 
       detailedPowerStatus();

--- a/source/Core/Threads/OperatingModes/utils/SolderingCommon.cpp
+++ b/source/Core/Threads/OperatingModes/utils/SolderingCommon.cpp
@@ -121,3 +121,36 @@ bool checkExitSoldering(void) {
 
   return false;
 }
+
+int8_t getPowerSourceNumber(void) {
+  int8_t sourceNumber = 0;
+  if (getIsPoweredByDCIN()) {
+    sourceNumber = 0;
+  } else {
+    // We are not powered via DC, so want to display the appropriate state for PD or QC
+    bool poweredbyPD        = false;
+    bool pdHasVBUSConnected = false;
+#ifdef POW_PD
+    if (USBPowerDelivery::fusbPresent()) {
+      // We are PD capable
+      if (USBPowerDelivery::negotiationComplete()) {
+        // We are powered via PD
+        poweredbyPD = true;
+#ifdef VBUS_MOD_TEST
+        pdHasVBUSConnected = USBPowerDelivery::isVBUSConnected();
+#endif
+      }
+    }
+#endif
+    if (poweredbyPD) {
+      if (pdHasVBUSConnected) {
+        sourceNumber = 2;
+      } else {
+        sourceNumber = 3;
+      }
+    } else {
+      sourceNumber = 1;
+    }
+  }
+  return sourceNumber;
+}


### PR DESCRIPTION
[UX perspective](https://github.com/Ralim/IronOS/issues/1708)
But nasty hacks may apply, sorry :(

A few comments:
  * I was considering a few approaches - this one turned out to be less invasive.
  * As much as strange trick with _overloading_ `OLED::print` may look - it works **for my own surprise** and, what's more important - doesn't break **any other visible** OLED functionality.
  * I thought that _shrtn_ existed strings anyway better than adding another one set of arrays of chars considering how valuable space is for some supported devices.  
  
Waiting for a feedback crossing fingers.