### PR TITLE
source/Makefile: update for -C support

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -655,14 +655,14 @@ Core/Gen/Translation.%.cpp $(OUTPUT_DIR)/Core/Gen/translation.files/%.pickle: ..
 	@test -d $(OUTPUT_DIR)/Core/Gen/translation.files || mkdir -p $(OUTPUT_DIR)/Core/Gen/translation.files
 	@echo 'Generating translations for language $*'
 	@$(HOST_PYTHON) ../Translations/make_translation.py \
-		--macros $(PWD)/Core/Gen/macros.txt \
-		-o $(PWD)/Core/Gen/Translation.$*.cpp \
+		--macros $(CURDIR)/Core/Gen/macros.txt \
+		-o $(CURDIR)/Core/Gen/Translation.$*.cpp \
 		--output-pickled $(OUTPUT_DIR)/Core/Gen/translation.files/$*.pickle \
 		$*
 
 Core/Gen/macros.txt: Makefile
-	@test -d Core/Gen || mkdir -p Core/Gen
-	echo "#include <configuration.h>" | $(CC) -dM -E $(CFLAGS) -MF Core/Gen/macros.tmp - > $(PWD)/Core/Gen/macros.txt
+	@test -d $(CURDIR)/Core/Gen || mkdir -p $(CURDIR)/Core/Gen
+	echo "#include <configuration.h>" | $(CC) -dM -E $(CFLAGS) -MF $(CURDIR)/Core/Gen/macros.tmp - > $(CURDIR)/Core/Gen/macros.txt
 
 
 #


### PR DESCRIPTION
Hello.

  * Command `make  -C source  model=TS80P  firmware-EN` from root directory should produce build.

  * What actually happens:
```
$ make -C source  model=TS80P firmware-EN
make: Entering directory '/root/tree/ironos/source'
Building for Miniware 
Building file: ./Startup/startup_stm32f103t8ux.S
[skip log]
echo "#include <configuration.h>" | arm-none-eabi-gcc -dM -E -D VECT_TAB_OFFSET=0x4000U -mcpu=cortex-m3 -mthumb -mfloat-abi=soft -I./Core/Inc -I./Core/brieflz -I./Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS -I./Middlewares/Third_Party/FreeRTOS/Source/include -I./Core/Drivers -I./Core/BSP -I./Core/Threads -I./Core/Threads/OperatingModes -I./Core/Threads/OperatingModes/utils -I./Core/Drivers/usb-pd/include -I./Core/BSP/Miniware -I./Core/BSP/Miniware/Vendor/CMSIS/Device/ST/STM32F1xx/Include -I./Core/BSP/Miniware/Vendor/CMSIS/Include -I./Core/BSP/Miniware/Vendor/STM32F1xx_HAL_Driver/Inc -I./Core/BSP/Miniware/Vendor/STM32F1xx_HAL_Driver/Inc/Legacy  -Wtrigraphs -Wuninitialized -Wmissing-braces -Wfloat-equal -Wunreachable-code -Wswitch-default -Wreturn-type -Wundef -Wparentheses -Wnonnull -Winit-self -Wmissing-include-dirs -Wsequence-point -Wswitch -Wformat -Wsign-compare -Waddress -Waggregate-return -Wmissing-field-initializers -Wshadow -Wno-unused-parameter -Wdouble-promotion  -Wbad-function-cast -D STM32F103T8Ux -D STM32F1 -D STM32 -D USE_HAL_DRIVER -D STM32F103xB -D USE_RTOS_SYSTICK -D GCC_ARMCM3 -D ARM_MATH_CM3 -D STM32F10X_MD -finline-limit=9999999 -D USE_RTOS_SYSTICK -D MODEL_TS80P -D VECT_TAB_OFFSET=0x4000U -fshort-wchar -Dgcc -MMD -std=gnu11 -Os -fno-jump-tables -foptimize-strlen -faggressive-loop-optimizations -fdevirtualize-at-ltrans -fmerge-all-constants -fshort-wchar -flto -finline-small-functions -finline-functions -findirect-inlining -fdiagnostics-color -ffunction-sections -fdata-sections -fshort-enums -fsingle-precision-constant  -fno-common -fno-math-errno -ffast-math -ffinite-math-only -fno-signed-zeros -fsingle-precision-constant -T./Core/BSP/Miniware/stm32f103.ld -c                       -MF Core/Gen/macros.tmp - > /root/tree/ironos/Core/Gen/macros.txt
/bin/sh: 1: cannot create /root/tree/ironos/Core/Gen/macros.txt: Directory nonexistent
Makefile:664: recipe for target 'Core/Gen/macros.txt' failed
make: *** [Core/Gen/macros.txt] Error 2
make: Leaving directory '/root/tree/ironos/source'
$ 
```

  * This patch updates `Makefile` with `-C source` support to be location-agnostic:
```
$ make -C source  model=TS80P firmware-EN
[skipped]
echo "#include <configuration.h>" | arm-none-eabi-gcc -dM -E -D VECT_TAB_OFFSET=0x4000U -mcpu=cortex-m3 -mthumb -mfloat-abi=soft -I./Core/Inc -I./Core/brieflz -I./Middlewares/Third_Party/FreeRTOS/Source/CMSIS_RTOS -I./Middlewares/Third_Party/FreeRTOS/Source/include -I./Core/Drivers -I./Core/BSP -I./Core/Threads -I./Core/Threads/OperatingModes -I./Core/Threads/OperatingModes/utils -I./Core/Drivers/usb-pd/include -I./Core/BSP/Miniware -I./Core/BSP/Miniware/Vendor/CMSIS/Device/ST/STM32F1xx/Include -I./Core/BSP/Miniware/Vendor/CMSIS/Include -I./Core/BSP/Miniware/Vendor/STM32F1xx_HAL_Driver/Inc -I./Core/BSP/Miniware/Vendor/STM32F1xx_HAL_Driver/Inc/Legacy  -Wtrigraphs -Wuninitialized -Wmissing-braces -Wfloat-equal -Wunreachable-code -Wswitch-default -Wreturn-type -Wundef -Wparentheses -Wnonnull -Winit-self -Wmissing-include-dirs -Wsequence-point -Wswitch -Wformat -Wsign-compare -Waddress -Waggregate-return -Wmissing-field-initializers -Wshadow -Wno-unused-parameter -Wdouble-promotion  -Wbad-function-cast -D STM32F103T8Ux -D STM32F1 -D STM32 -D USE_HAL_DRIVER -D STM32F103xB -D USE_RTOS_SYSTICK -D GCC_ARMCM3 -D ARM_MATH_CM3 -D STM32F10X_MD -finline-limit=9999999 -D USE_RTOS_SYSTICK -D MODEL_TS80P -D VECT_TAB_OFFSET=0x4000U -fshort-wchar -Dgcc -MMD -std=gnu11 -Os -fno-jump-tables -foptimize-strlen -faggressive-loop-optimizations -fdevirtualize-at-ltrans -fmerge-all-constants -fshort-wchar -flto -finline-small-functions -finline-functions -findirect-inlining -fdiagnostics-color -ffunction-sections -fdata-sections -fshort-enums -fsingle-precision-constant  -fno-common -fno-math-errno -ffast-math -ffinite-math-only -fno-signed-zeros -fsingle-precision-constant -T./Core/BSP/Miniware/stm32f103.ld -c                       -MF /root/tree/ironos/source/Core/Gen/macros.tmp - > /root/tree/ironos/source/Core/Gen/macros.txt
Generating translations for language EN
[skipped]
arm-none-eabi-objcopy Hexfile/TS80P_EN.elf -O ihex Hexfile/TS80P_EN.hex
arm-none-eabi-objcopy Hexfile/TS80P_EN.elf -O binary Hexfile/TS80P_EN.bin
arm-none-eabi-size Hexfile/TS80P_EN.elf
   text	   data	    bss	    dec	    hex	filename
  44632	    108	  12984	  57724	   e17c	Hexfile/TS80P_EN.elf
python3.8 dfuse-pack.py -b 0x08004000@0:Hexfile/TS80P_EN.bin -D 0x1209:0xDB42 Hexfile/TS80P_EN.dfu
make: Leaving directory '/root/tree/ironos/source'
```