### PR TITLE
Remove 0.5 ohm increase to resistance

### DIFF
--- a/source/Core/Drivers/USBPD.cpp
+++ b/source/Core/Drivers/USBPD.cpp
@@ -119,8 +119,7 @@ bool parseCapabilitiesArray(const uint8_t numCaps, uint8_t *bestIndex, uint16_t 
   *bestIndex   = 0xFF; // Mark unselected
   *bestVoltage = 5000; // Default 5V
 
-  // Fudge of 0.5 ohms to round up a little to account for us always having off periods in PWM
-  uint8_t tipResistance = getTipResistanceX10() + 5;
+  uint8_t tipResistance = getTipResistanceX10();
 #ifdef MODEL_HAS_DCDC
   // If this device has step down DC/DC inductor to smooth out current spikes
   // We can instead ignore resistance and go for max voltage we can accept; and rely on the DC/DC regulation to keep under current limit


### PR DESCRIPTION
Currently, IronOS increases the tip resistance by 0.5 ohms for the purposes of USB-PD negotiation.  On the Pinecil V2, this can cause issues with power supplies that only supply 60W, such as the Framework 60W supply.  At 6.2 ohms, 20V will produce 3.2A, but at 6.7 ohms it will produce 2.985 ohms.  This 0.5 ohms increase will cause the V2 to negotiate 20V, draw more than 3A, and trip the overcurrent protection, causing it to reboot.  Removing this increase will therefore cause it to fall back to the next highest voltage it can achieve.

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [] There are no breaking changes

* **What kind of change does this PR introduce?**

* **What is the current behavior?**
[On devices such as the Framework charger](https://cdn.discordapp.com/attachments/769635442969542676/1123600946845454379/IMG_0525.mov), attempting to operate the iron at 20V will cause it to reboot.  This is not a device-specific issue, as [other chargers](https://cdn.discordapp.com/attachments/769635442969542676/1123602348451835925/IMG_0526.mov) do not cause this reboot to occur.

* **What is the new behavior (if this is a feature change)?**
[Reducing the voltage limit to 15V](https://cdn.discordapp.com/attachments/769635442969542676/1123722110754377810/IMG_0543.mov) does fix the issue, but this is obviously a problematic solution given that it cuts off higher voltages and power levels.  Removing the increase to tip resistance [allows the iron to negotiate higher voltages when they are offered](https://cdn.discordapp.com/attachments/769635442969542676/1123725546216489050/IMG_0544.mov) while not tripping overcurrent protection.

* **Other information**:
