### PR TITLE
Implement printSymbolDeg() helper function as method for OLED class

### DIFF
--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -481,6 +481,14 @@ void OLED::printWholeScreen(const char *string) {
   }
 }
 
+void OLED::printSymbolDeg(const FontStyle fontStyle) {
+  if (getSettingValue(SettingsOptions::TemperatureInF)) {
+    OLED::print(fontStyle == FontStyle::LARGE ? LargeSymbolDegF : SmallSymbolDegF, fontStyle);
+  } else {
+    OLED::print(fontStyle == FontStyle::LARGE ? LargeSymbolDegC : SmallSymbolDegC, fontStyle);
+  }
+}
+
 inline void stripLeaderZeros(char *buffer, uint8_t places) {
   // Removing the leading zero's by swapping them to SymbolSpace
   // Stop 1 short so that we dont blank entire number if its zero

--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -481,7 +481,7 @@ void OLED::printWholeScreen(const char *string) {
   }
 }
 
-// print *C or *F, large or small
+// Print *F or *C - in font style of Small, Large (by default) or Extra based on input arg
 void OLED::printSymbolDeg(const FontStyle fontStyle) {
   if (FontStyle::EXTRAS == fontStyle) {
     OLED::drawSymbol(getSettingValue(SettingsOptions::TemperatureInF) ? 0 : 1);

--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -485,6 +485,7 @@ void OLED::printWholeScreen(const char *string) {
 void OLED::printSymbolDeg(const FontStyle fontStyle) {
   switch (fontStyle) {
   case FontStyle::EXTRAS:
+    // Picks *F or *C in ExtraFontChars[] from Font.h
     OLED::drawSymbol(getSettingValue(SettingsOptions::TemperatureInF) ? 0 : 1);
     break;
   case FontStyle::LARGE:

--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -481,11 +481,16 @@ void OLED::printWholeScreen(const char *string) {
   }
 }
 
+// print *C or *F, large or small
 void OLED::printSymbolDeg(const FontStyle fontStyle) {
-  if (getSettingValue(SettingsOptions::TemperatureInF)) {
-    OLED::print(fontStyle == FontStyle::LARGE ? LargeSymbolDegF : SmallSymbolDegF, fontStyle);
+  if (FontStyle::EXTRAS == fontStyle) {
+    OLED::drawSymbol(getSettingValue(SettingsOptions::TemperatureInF) ? 0 : 1);
   } else {
-    OLED::print(fontStyle == FontStyle::LARGE ? LargeSymbolDegC : SmallSymbolDegC, fontStyle);
+    if (getSettingValue(SettingsOptions::TemperatureInF)) {
+      OLED::print(fontStyle == FontStyle::LARGE ? LargeSymbolDegF : SmallSymbolDegF, fontStyle);
+    } else {
+      OLED::print(fontStyle == FontStyle::LARGE ? LargeSymbolDegC : SmallSymbolDegC, fontStyle);
+    }
   }
 }
 

--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -483,14 +483,17 @@ void OLED::printWholeScreen(const char *string) {
 
 // Print *F or *C - in font style of Small, Large (by default) or Extra based on input arg
 void OLED::printSymbolDeg(const FontStyle fontStyle) {
-  if (FontStyle::EXTRAS == fontStyle) {
+  switch (fontStyle) {
+  case FontStyle::EXTRAS:
     OLED::drawSymbol(getSettingValue(SettingsOptions::TemperatureInF) ? 0 : 1);
-  } else {
-    if (getSettingValue(SettingsOptions::TemperatureInF)) {
-      OLED::print(fontStyle == FontStyle::LARGE ? LargeSymbolDegF : SmallSymbolDegF, fontStyle);
-    } else {
-      OLED::print(fontStyle == FontStyle::LARGE ? LargeSymbolDegC : SmallSymbolDegC, fontStyle);
-    }
+    break;
+  case FontStyle::LARGE:
+    OLED::print(getSettingValue(SettingsOptions::TemperatureInF) ? LargeSymbolDegF : LargeSymbolDegC, fontStyle);
+    break;
+  case FontStyle::SMALL:
+  default:
+    OLED::print(getSettingValue(SettingsOptions::TemperatureInF) ? SmallSymbolDegF : SmallSymbolDegC, fontStyle);
+    break;
   }
 }
 

--- a/source/Core/Drivers/OLED.hpp
+++ b/source/Core/Drivers/OLED.hpp
@@ -119,7 +119,7 @@ public:
   // Draw a string to the current location, with selected font; optionally - with MAX length only
   static void    print(const char *string, FontStyle fontStyle, uint8_t length = 255);
   static void    printWholeScreen(const char *string);
-  // Print *C or *F based on user settings, large or small based on input arg
+  // Print *F or *C - in font style of Small, Large (by default) or Extra based on input arg
   static void    printSymbolDeg(FontStyle fontStyle = FontStyle::LARGE);
   // Set the cursor location by pixels
   static void setCursor(int16_t x, int16_t y) {

--- a/source/Core/Drivers/OLED.hpp
+++ b/source/Core/Drivers/OLED.hpp
@@ -103,7 +103,8 @@ public:
     }
   }
 
-  static void setRotation(bool leftHanded); // Set the rotation for the screen
+  // Set the rotation for the screen
+  static void setRotation(bool leftHanded);
   // Get the current rotation of the LCD
   static bool getRotation() {
 #ifdef OLED_FLIP
@@ -115,8 +116,11 @@ public:
   static void    setBrightness(uint8_t contrast);
   static void    setInverseDisplay(bool inverted);
   static int16_t getCursorX() { return cursor_x; }
-  static void    print(const char *string, FontStyle fontStyle, uint8_t length = 255); // Draw a string to the current location, with selected font; optionally - with MAX length only
+  // Draw a string to the current location, with selected font; optionally - with MAX length only
+  static void    print(const char *string, FontStyle fontStyle, uint8_t length = 255);
   static void    printWholeScreen(const char *string);
+  // Print *C or *F based on user settings, large or small based on input arg
+  static void    printSymbolDeg(FontStyle fontStyle = FontStyle::LARGE);
   // Set the cursor location by pixels
   static void setCursor(int16_t x, int16_t y) {
     cursor_x = x;

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -757,7 +757,7 @@ static bool setTempF(void) {
   return res;
 }
 
-static void displayTempF(void) { OLED::print((getSettingValue(SettingsOptions::TemperatureInF)) ? LargeSymbolDegF : LargeSymbolDegC, FontStyle::LARGE); }
+static void displayTempF(void) { OLED::printSymbolDeg(FontStyle::LARGE); }
 
 #ifndef NO_DISPLAY_ROTATE
 

--- a/source/Core/Threads/OperatingModes/HomeScreen.cpp
+++ b/source/Core/Threads/OperatingModes/HomeScreen.cpp
@@ -116,11 +116,9 @@ void drawDetailedHomeScreen(uint32_t tipTemp) {
     }
     // draw set temp
     OLED::printNumber(getSettingValue(SettingsOptions::SolderingTemp), 3, FontStyle::SMALL);
-    if (getSettingValue(SettingsOptions::TemperatureInF)) {
-      OLED::print(SmallSymbolDegF, FontStyle::SMALL);
-    } else {
-      OLED::print(SmallSymbolDegC, FontStyle::SMALL);
-    }
+
+    OLED::printSymbolDeg(FontStyle::SMALL);
+
     if (OLED::getRotation()) {
       OLED::setCursor(0, 8);
     } else {

--- a/source/Core/Threads/OperatingModes/OperatingModes.h
+++ b/source/Core/Threads/OperatingModes/OperatingModes.h
@@ -46,5 +46,6 @@ void drawHomeScreen(bool buttonLockout) __attribute__((noreturn)); // IDLE / Hom
 void renderHomeScreenAssets(void);                                 // Called to act as start delay and used to render out flipped images for home screen graphics
 
 // Common helpers
-int8_t getPowerSourceNumber(void);                                 // Returns number ID of power source
+int8_t   getPowerSourceNumber(void);                               // Returns number ID of power source
+uint16_t getTipTemp(void);                                         // Returns temperature of the tip in *C/*F (based on user settings)
 #endif

--- a/source/Core/Threads/OperatingModes/Sleep.cpp
+++ b/source/Core/Threads/OperatingModes/Sleep.cpp
@@ -35,11 +35,7 @@ int gui_SolderingSleepingMode(bool stayOff, bool autoStarted) {
       OLED::print(translatedString(Tr->SleepingTipAdvancedString), FontStyle::SMALL);
       OLED::printNumber(tipTemp, 3, FontStyle::SMALL);
 
-      if (getSettingValue(SettingsOptions::TemperatureInF)) {
-        OLED::print(SmallSymbolDegF, FontStyle::SMALL);
-      } else {
-        OLED::print(SmallSymbolDegC, FontStyle::SMALL);
-      }
+      OLED::printSymbolDeg(FontStyle::SMALL);
 
       OLED::print(SmallSymbolSpace, FontStyle::SMALL);
       printVoltage();

--- a/source/Core/Threads/OperatingModes/Sleep.cpp
+++ b/source/Core/Threads/OperatingModes/Sleep.cpp
@@ -34,21 +34,14 @@ int gui_SolderingSleepingMode(bool stayOff, bool autoStarted) {
       OLED::setCursor(0, 8);
       OLED::print(translatedString(Tr->SleepingTipAdvancedString), FontStyle::SMALL);
       OLED::printNumber(tipTemp, 3, FontStyle::SMALL);
-
       OLED::printSymbolDeg(FontStyle::SMALL);
-
       OLED::print(SmallSymbolSpace, FontStyle::SMALL);
       printVoltage();
       OLED::print(SmallSymbolVolts, FontStyle::SMALL);
     } else {
       OLED::print(translatedString(Tr->SleepingSimpleString), FontStyle::LARGE);
       OLED::printNumber(tipTemp, 3, FontStyle::LARGE);
-
-      if (getSettingValue(SettingsOptions::TemperatureInF)) {
-        OLED::drawSymbol(0);
-      } else {
-        OLED::drawSymbol(1);
-      }
+      OLED::printSymbolDeg(FontStyle::EXTRAS);
     }
 
     OLED::refresh();

--- a/source/Core/Threads/OperatingModes/Sleep.cpp
+++ b/source/Core/Threads/OperatingModes/Sleep.cpp
@@ -25,7 +25,7 @@ int gui_SolderingSleepingMode(bool stayOff, bool autoStarted) {
     }
 
     // draw the lcd
-    uint16_t tipTemp = getSettingValue(SettingsOptions::TemperatureInF) ? TipThermoModel::getTipInF() : TipThermoModel::getTipInC();
+    uint16_t tipTemp = getTipTemp();
 
     OLED::clearScreen();
     OLED::setCursor(0, 0);

--- a/source/Core/Threads/OperatingModes/SolderingProfile.cpp
+++ b/source/Core/Threads/OperatingModes/SolderingProfile.cpp
@@ -54,7 +54,7 @@ void gui_solderingProfileMode() {
       break;
     }
 
-    tipTemp = getSettingValue(SettingsOptions::TemperatureInF) ? TipThermoModel::getTipInF() : TipThermoModel::getTipInC();
+    tipTemp = getTipTemp();
 
     // if start temp is unknown (preheat), we're setting it now
     if (phaseStartTemp == 0) {

--- a/source/Core/Threads/OperatingModes/SolderingProfile.cpp
+++ b/source/Core/Threads/OperatingModes/SolderingProfile.cpp
@@ -155,12 +155,7 @@ void gui_solderingProfileMode() {
       OLED::printNumber(tipTemp, 3, FontStyle::SMALL);
       OLED::print(SmallSymbolSlash, FontStyle::SMALL);
       OLED::printNumber(profileCurrentTargetTemp, 3, FontStyle::SMALL);
-
-      if (getSettingValue(SettingsOptions::TemperatureInF)) {
-        OLED::print(SmallSymbolDegF, FontStyle::SMALL);
-      } else {
-        OLED::print(SmallSymbolDegC, FontStyle::SMALL);
-      }
+      OLED::printSymbolDeg(FontStyle::SMALL);
 
       // print phase
       if (profilePhase > 0 && profilePhase <= getSettingValue(SettingsOptions::ProfilePhases)) {

--- a/source/Core/Threads/OperatingModes/SolderingProfile.cpp
+++ b/source/Core/Threads/OperatingModes/SolderingProfile.cpp
@@ -54,11 +54,7 @@ void gui_solderingProfileMode() {
       break;
     }
 
-    if (getSettingValue(SettingsOptions::TemperatureInF)) {
-      tipTemp = TipThermoModel::getTipInF();
-    } else {
-      tipTemp = TipThermoModel::getTipInC();
-    }
+    tipTemp = getSettingValue(SettingsOptions::TemperatureInF) ? TipThermoModel::getTipInF() : TipThermoModel::getTipInC();
 
     // if start temp is unknown (preheat), we're setting it now
     if (phaseStartTemp == 0) {

--- a/source/Core/Threads/OperatingModes/TemperatureAdjust.cpp
+++ b/source/Core/Threads/OperatingModes/TemperatureAdjust.cpp
@@ -107,11 +107,7 @@ void gui_solderingTempAdjust(void) {
 
     OLED::print(LargeSymbolSpace, FontStyle::LARGE);
     OLED::printNumber(getSettingValue(SettingsOptions::SolderingTemp), 3, FontStyle::LARGE);
-    if (getSettingValue(SettingsOptions::TemperatureInF)) {
-      OLED::drawSymbol(0);
-    } else {
-      OLED::drawSymbol(1);
-    }
+    OLED::printSymbolDeg(FontStyle::EXTRAS);
     OLED::print(LargeSymbolSpace, FontStyle::LARGE);
     if (OLED::getRotation()) {
       OLED::print(getSettingValue(SettingsOptions::ReverseButtonTempChangeEnabled) ? LargeSymbolMinus : LargeSymbolPlus, FontStyle::LARGE);

--- a/source/Core/Threads/OperatingModes/utils/DrawTipTemperature.cpp
+++ b/source/Core/Threads/OperatingModes/utils/DrawTipTemperature.cpp
@@ -3,25 +3,11 @@
 
 void gui_drawTipTemp(bool symbol, const FontStyle font) {
   // Draw tip temp handling unit conversion & tolerance near setpoint
-  uint32_t Temp = 0;
-  if (getSettingValue(SettingsOptions::TemperatureInF)) {
-    Temp = TipThermoModel::getTipInF();
-  } else {
-    Temp = TipThermoModel::getTipInC();
-  }
+  uint32_t Temp = getSettingValue(SettingsOptions::TemperatureInF) ? TipThermoModel::getTipInF() : TipThermoModel::getTipInC();
 
   OLED::printNumber(Temp, 3, font); // Draw the tip temp out
   if (symbol) {
-    if (font == FontStyle::LARGE) {
-      // Big font, can draw nice symbols
-      if (getSettingValue(SettingsOptions::TemperatureInF)) {
-        OLED::drawSymbol(0);
-      } else {
-        OLED::drawSymbol(1);
-      }
-    } else {
-      // Otherwise fall back to chars
-      OLED::printSymbolDeg(font);
-    }
+    // For big font, can draw nice symbols, otherwise fall back to chars
+    OLED::printSymbolDeg(font == FontStyle::LARGE ? FontStyle::EXTRAS : font);
   }
 }

--- a/source/Core/Threads/OperatingModes/utils/DrawTipTemperature.cpp
+++ b/source/Core/Threads/OperatingModes/utils/DrawTipTemperature.cpp
@@ -21,11 +21,7 @@ void gui_drawTipTemp(bool symbol, const FontStyle font) {
       }
     } else {
       // Otherwise fall back to chars
-      if (getSettingValue(SettingsOptions::TemperatureInF)) {
-        OLED::print(SmallSymbolDegF, FontStyle::SMALL);
-      } else {
-        OLED::print(SmallSymbolDegC, FontStyle::SMALL);
-      }
+      OLED::printSymbolDeg(font);
     }
   }
 }

--- a/source/Core/Threads/OperatingModes/utils/DrawTipTemperature.cpp
+++ b/source/Core/Threads/OperatingModes/utils/DrawTipTemperature.cpp
@@ -3,7 +3,7 @@
 
 void gui_drawTipTemp(bool symbol, const FontStyle font) {
   // Draw tip temp handling unit conversion & tolerance near setpoint
-  uint32_t Temp = getSettingValue(SettingsOptions::TemperatureInF) ? TipThermoModel::getTipInF() : TipThermoModel::getTipInC();
+  uint16_t Temp = getTipTemp();
 
   OLED::printNumber(Temp, 3, font); // Draw the tip temp out
   if (symbol) {

--- a/source/Core/Threads/OperatingModes/utils/DrawTipTemperature.cpp
+++ b/source/Core/Threads/OperatingModes/utils/DrawTipTemperature.cpp
@@ -1,4 +1,5 @@
 #include "OperatingModeUtilities.h"
+#include "OperatingModes.h"
 #include "TipThermoModel.h"
 
 void gui_drawTipTemp(bool symbol, const FontStyle font) {

--- a/source/Core/Threads/OperatingModes/utils/PrintVoltage.cpp
+++ b/source/Core/Threads/OperatingModes/utils/PrintVoltage.cpp
@@ -6,3 +6,4 @@ void printVoltage(void) {
   OLED::print(SmallSymbolDot, FontStyle::SMALL);
   OLED::printNumber(volt % 10, 1, FontStyle::SMALL);
 }
+

--- a/source/Core/Threads/OperatingModes/utils/PrintVoltage.cpp
+++ b/source/Core/Threads/OperatingModes/utils/PrintVoltage.cpp
@@ -6,4 +6,3 @@ void printVoltage(void) {
   OLED::print(SmallSymbolDot, FontStyle::SMALL);
   OLED::printNumber(volt % 10, 1, FontStyle::SMALL);
 }
-

--- a/source/Core/Threads/OperatingModes/utils/SolderingCommon.cpp
+++ b/source/Core/Threads/OperatingModes/utils/SolderingCommon.cpp
@@ -160,3 +160,6 @@ int8_t getPowerSourceNumber(void) {
   }
   return sourceNumber;
 }
+
+// Returns temperature of the tip in *C/*F (based on user settings)
+uint16_t getTipTemp(void) { return getSettingValue(SettingsOptions::TemperatureInF) ? TipThermoModel::getTipInF() : TipThermoModel::getTipInC(); }


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Implement helper function for repetitive blocks of code.

* **What is the current behavior?**
The same snippet used a few times in code base to print degree symbol & temperature symbol.

* **What is the new behavior (if this is a feature change)?**
Helper function to make snippet reusable in more convenient way.

* **Other information**:
I have a couple of questions though.

Is my intuitive speculation correct that [this block](https://github.com/Ralim/IronOS/blob/d95af7d1a0ddd5a93a0827d08294c5504c9e9a94/source/Core/Threads/OperatingModes/utils/DrawTipTemperature.cpp#L17):
```
      if (getSettingValue(SettingsOptions::TemperatureInF)) {
        OLED::drawSymbol(0);
      } else {
        OLED::drawSymbol(1);
      }
```
is a full equivalent to this:
```
      if (getSettingValue(SettingsOptions::TemperatureInF)) {
        OLED::print(LargeSymbolDegF, FontStyle::LARGE);
      } else {
        OLED::print(LargeSymbolDegC, FontStyle::LARGE);
      }
```
I tried to figure it out myself but I couldn't dig out how exactly (according to which table of decoding chars?) `charCode` `0` turns into `*F` with large font inside `drawChar`. Could you, please, elaborate a bit on that? The point here is that if my assumption is correct, then the other part of code block could be put inside the helper function as well. Thanks.

And what you would say about putting all the functions from all files inside `utils/` [dir](https://github.com/Ralim/IronOS/tree/dev/source/Core/Threads/OperatingModes/utils) into one pair of files (like `Utils.cpp` / `Utils.h` ) instead? By brief calculations the resulting `Utils.cpp` should be about something `~500` lines of code which should be relatively manageable than having file-per-function approach. Just a question / suggestion from the side.