### PR TITLE
Documentation/index.md: add Feedback section (Ralim#1552) as suggested

### DIFF
--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -70,3 +70,21 @@ When on the main screen and having the tip plugged in, the unit shows a pair of 
 - Holding down the button near the USB end will show the _[debug menu](https://ralim.github.io/IronOS/DebugMenu/)._ In _soldering mode_ this ends the heating.
 
 Operation details are over in the [Menu information.](https://ralim.github.io/IronOS/Menu/)
+
+## Feedback
+
+If you would like to:
+- report any issue related to IronOS
+- request a feature
+- provide some suggestion
+then you can [fill this form](https://github.com/Ralim/IronOS/issues/new/choose) using github account[^gh].
+
+And if you would like to:
+- ask more generic question about IronOS/supported hardware/something you're curious about/etc.
+- reach out community to chat with
+- share your soldering & DIY skills
+- share some interesting finding
+- share useful related hardware/software with others
+or _anything_ like that, then you can use forum-like [Discussions here](https://github.com/Ralim/IronOS/discussions).
+
+[^gh]: You may need to create it first if you don't have one - it's free of charge.


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Update `Documentation/index.md` which is exported as [ReadTheDocs online documentation](https://ralim.github.io/IronOS/).

* **What is the current behavior?**
As described in [this report](https://github.com/Ralim/IronOS/issues/1552):Ralim#1552, if a user opens the main online documentation page, there is no any information about _feedback_ to the project nor how to report a bug or ask community for help.

* **What is the new behavior (if this is a feature change)?**
if a user opens the main online documentation page, there is a clear "feedback welcome" section with direct links to _github Issue report form of the project_ and _direct link to Discussions board_.

* **Other information**:
Very good & smart suggestion BTW.