### PR TITLE
Move related pieces of documentation from wiki to Documentation/

### DIFF
--- a/Documentation/Development.md
+++ b/Documentation/Development.md
@@ -133,7 +133,7 @@ On Windows follow the instructions on the official documentation to install 'Win
 3. Build the firmware for Pinecil V2:
 
     ```sh
-    cd source/source
+    cd source/
     ./build.sh -l EN -m Pinecilv2
     ```
 

--- a/Documentation/Hardware.md
+++ b/Documentation/Hardware.md
@@ -43,3 +43,12 @@ MHP30 is a **M**ini **H**ot **P**late:
 - the OLED is the same SSD1306 as everything else, but it’s on a bit-banged bus.
 
 
+### Pinecil
+
+Pincecil:
+- first model of soldering iron from PINE64;
+- the default firmware can be found [here](https://files.pine64.org/os/Pinecil/Pinecil_firmware_20201115.zip).
+
+![](https://pine64.com/wp-content/uploads/2020/11/pinecil-bb2-04.jpg?v=0446c16e2e66)
+
+

--- a/Documentation/Hardware.md
+++ b/Documentation/Hardware.md
@@ -3,7 +3,8 @@
 
 ### TS100
 
-TS100 is a neat soldering iron:
+TS100[^1] is a neat soldering iron:
+
 - can run from 9-25V DC;
 - provides a power range that is determined by the input voltage;
 - voltages below 12V don't overly work well for any substantial mass;
@@ -14,7 +15,8 @@ TS100 is a neat soldering iron:
 
 ### TS80
 
-TS80 is a successor to TS100:
+TS80[^1] is a successor to TS100:
+
 - uses _Quick Charge 3.0_ / _QC3_ capable charger only (18W max);
 - doesn't support PD as it is not designed on the hardware level;
 - the default firmware can be found [here](https://www.minidso.com/forum.php?mod=viewthread&tid=3208&extra=page%3D1).
@@ -24,12 +26,13 @@ TS80 is a successor to TS100:
 
 ### TS80P
 
-TS80P is a successor to TS80:
+TS80P[^1] is a successor to TS80:
+
 - supports _Quick Charge 3.0_ (_QC3_: 9V/3A, 18W max);
-- supports _Power Delivery_ (_PD_: 9V/3A & 12V/3A, 30W max)[^pd];
+- supports _Power Delivery_ (_PD_: 9V/3A & 12V/3A, 30W max)[^2];
 - the default firmware can be found [here](https://www.minidso.com/forum.php?mod=viewthread&tid=4085&extra=page%3D1).
 
-[^pd]: use valid PD device that supports 12V/3A as power source to get full 30W potential, otherwise the iron will fall back to QC/18W power mode.
+[^2]: use valid PD device that supports 12V/3A as power source to get full 30W potential, otherwise the iron will fall back to QC/18W power mode.
 
 ![](https://static.eleshop.nl/mage/media/catalog/product/cache/10/image/800x/040ec09b1e35df139433887a97daa66f/s/-/s-l1600_5.jpg)
 
@@ -45,10 +48,14 @@ MHP30 is a **M**ini **H**ot **P**late:
 
 ### Pinecil
 
-Pincecil:
+Pincecil[^1]:
 - first model of soldering iron from PINE64;
 - the default firmware can be found [here](https://files.pine64.org/os/Pinecil/Pinecil_firmware_20201115.zip).
 
 ![](https://pine64.com/wp-content/uploads/2020/11/pinecil-bb2-04.jpg?v=0446c16e2e66)
+
+
+[^1]: Please note: this soldering iron do *NOT* contain DC/DC converters.
+  This means that your power at the tip is a function of the supplied voltage. Just because an iron "supports" running at a wide range of voltages, you should always use a voltage near the upper limit where possible. It is highly recommended to use a PD adapter where possible as this allows the Iron to _know_ the limitations of your supply. This iron can only turn the tip on and off in software, this means that it can't control the maximum power drawn from the supply. This is why when using PD the iron may select a lower voltage than your power supplies maximum. This is to prevent your power supply failing from over current.
 
 

--- a/Documentation/Hardware.md
+++ b/Documentation/Hardware.md
@@ -1,5 +1,16 @@
 ## Notes on the various supported hardware
 
+
+### TS100
+
+TS100 is a neat soldering iron:
+- Can run from 9-25V DC
+- Provides a power range that is determined by the input voltage
+- Voltages below 12V don't overly work well for any substantial mass
+- The default firmware can be found [here](https://www.minidso.com/forum.php?mod=viewthread&tid=892&extra=page%3D1)
+
+![](https://brushlesswhoop.com/images/ts100-og.jpg)
+
 ### MHP30
 
 - Accelerometer is the MSA301, this is mounted roughly in the middle of the unit

--- a/Documentation/Hardware.md
+++ b/Documentation/Hardware.md
@@ -15,11 +15,23 @@ TS100 is a neat soldering iron:
 ### TS80
 
 TS80 is a successor to TS100:
-- uses _Quick Charge 3.0_ / _QC3_ capable charger only;
+- uses _Quick Charge 3.0_ / _QC3_ capable charger only (18W max);
 - doesn't support PD as it is not designed on the hardware level;
 - the default firmware can be found [here](https://www.minidso.com/forum.php?mod=viewthread&tid=3208&extra=page%3D1).
 
 ![](https://core-electronics.com.au/media/catalog/product/4/2/4244-01.jpg)
+
+
+### TS80P
+
+TS80P is a successor to TS80:
+- supports _Quick Charge 3.0_ (_QC3_: 9V/3A, 18W max);
+- supports _Power Delivery_ (_PD_: 9V/3A & 12V/3A, 30W max)[^pd];
+- the default firmware can be found [here](https://www.minidso.com/forum.php?mod=viewthread&tid=4085&extra=page%3D1).
+
+[^pd]: use valid PD device that supports 12V/3A as power source to get full 30W potential, otherwise the iron will fall back to QC/18W power mode.
+
+![](https://static.eleshop.nl/mage/media/catalog/product/cache/10/image/800x/040ec09b1e35df139433887a97daa66f/s/-/s-l1600_5.jpg)
 
 
 ### MHP30

--- a/Documentation/Hardware.md
+++ b/Documentation/Hardware.md
@@ -57,6 +57,6 @@ Pincecil\*:
 ![](https://pine64.com/wp-content/uploads/2020/11/pinecil-bb2-04.jpg?v=0446c16e2e66)
 
 
-\*\*: Please note: this soldering iron do *NOT* contain DC/DC converters. This means that your power at the tip is a function of the supplied voltage. Just because an iron "supports" running at a wide range of voltages, you should always use a voltage near the upper limit where possible. It is highly recommended to use a PD adapter where possible as this allows the Iron to _know_ the limitations of your supply. This iron can only turn the tip on and off in software, this means that it can't control the maximum power drawn from the supply. This is why when using PD the iron may select a lower voltage than your power supplies maximum. This is to prevent your power supply failing from over current.
+\*: Please note: these soldering irons do *NOT* contain DC/DC converters. This means that your power at the tip is a function of the supplied voltage. Just because the iron "supports" running at a wide range of voltages, you should always use a voltage near the upper limit where possible. It is highly recommended to use a PD adapter where possible as this allows the iron to _know_ the limitations of your supply. The marked irons can only turn the tip on and off in software, this means that they can't control the maximum power drawn from the supply. This is why when using PD the iron may select a lower voltage than your power supplies maximum. This is to prevent your power supply failing from over current.
 
 

--- a/Documentation/Hardware.md
+++ b/Documentation/Hardware.md
@@ -3,7 +3,7 @@
 
 ### TS100
 
-TS100[^1] is a neat soldering iron:
+TS100\* is a neat soldering iron:
 
 - can run from 9-25V DC;
 - provides a power range that is determined by the input voltage;
@@ -15,7 +15,7 @@ TS100[^1] is a neat soldering iron:
 
 ### TS80
 
-TS80[^1] is a successor to TS100:
+TS80\* is a successor to TS100:
 
 - uses _Quick Charge 3.0_ / _QC3_ capable charger only (18W max);
 - doesn't support PD as it is not designed on the hardware level;
@@ -26,13 +26,13 @@ TS80[^1] is a successor to TS100:
 
 ### TS80P
 
-TS80P[^1] is a successor to TS80:
+TS80P\* is a successor to TS80:
 
 - supports _Quick Charge 3.0_ (_QC3_: 9V/3A, 18W max);
-- supports _Power Delivery_ (_PD_: 9V/3A & 12V/3A, 30W max)[^2];
+- supports _Power Delivery_ (_PD_: 9V/3A & 12V/3A, 30W max)\*\*;
 - the default firmware can be found [here](https://www.minidso.com/forum.php?mod=viewthread&tid=4085&extra=page%3D1).
 
-[^2]: use valid PD device that supports 12V/3A as power source to get full 30W potential, otherwise the iron will fall back to QC/18W power mode.
+\*\*: use valid PD device that supports 12V/3A as power source to get full 30W potential, otherwise the iron will fall back to QC/18W power mode.
 
 ![](https://static.eleshop.nl/mage/media/catalog/product/cache/10/image/800x/040ec09b1e35df139433887a97daa66f/s/-/s-l1600_5.jpg)
 
@@ -40,6 +40,7 @@ TS80P[^1] is a successor to TS80:
 ### MHP30
 
 MHP30 is a **M**ini **H**ot **P**late:
+
 - accelerometer is the MSA301, this is mounted roughly in the middle of the unit;
 - USB-PD is using the FUSB302;
 - the hardware I2C bus on PB6/7 is used for the MSA301 and FUSB302;
@@ -48,14 +49,14 @@ MHP30 is a **M**ini **H**ot **P**late:
 
 ### Pinecil
 
-Pincecil[^1]:
+Pincecil\*:
+
 - first model of soldering iron from PINE64;
 - the default firmware can be found [here](https://files.pine64.org/os/Pinecil/Pinecil_firmware_20201115.zip).
 
 ![](https://pine64.com/wp-content/uploads/2020/11/pinecil-bb2-04.jpg?v=0446c16e2e66)
 
 
-[^1]: Please note: this soldering iron do *NOT* contain DC/DC converters.
-  This means that your power at the tip is a function of the supplied voltage. Just because an iron "supports" running at a wide range of voltages, you should always use a voltage near the upper limit where possible. It is highly recommended to use a PD adapter where possible as this allows the Iron to _know_ the limitations of your supply. This iron can only turn the tip on and off in software, this means that it can't control the maximum power drawn from the supply. This is why when using PD the iron may select a lower voltage than your power supplies maximum. This is to prevent your power supply failing from over current.
+\*\*: Please note: this soldering iron do *NOT* contain DC/DC converters. This means that your power at the tip is a function of the supplied voltage. Just because an iron "supports" running at a wide range of voltages, you should always use a voltage near the upper limit where possible. It is highly recommended to use a PD adapter where possible as this allows the Iron to _know_ the limitations of your supply. This iron can only turn the tip on and off in software, this means that it can't control the maximum power drawn from the supply. This is why when using PD the iron may select a lower voltage than your power supplies maximum. This is to prevent your power supply failing from over current.
 
 

--- a/Documentation/Hardware.md
+++ b/Documentation/Hardware.md
@@ -4,16 +4,30 @@
 ### TS100
 
 TS100 is a neat soldering iron:
-- Can run from 9-25V DC
-- Provides a power range that is determined by the input voltage
-- Voltages below 12V don't overly work well for any substantial mass
-- The default firmware can be found [here](https://www.minidso.com/forum.php?mod=viewthread&tid=892&extra=page%3D1)
+- can run from 9-25V DC;
+- provides a power range that is determined by the input voltage;
+- voltages below 12V don't overly work well for any substantial mass;
+- the default firmware can be found [here](https://www.minidso.com/forum.php?mod=viewthread&tid=892&extra=page%3D1).
 
 ![](https://brushlesswhoop.com/images/ts100-og.jpg)
 
+
+### TS80
+
+TS80 is a successor to TS100:
+- uses _Quick Charge 3.0_ / _QC3_ capable charger only;
+- doesn't support PD as it is not designed on the hardware level;
+- the default firmware can be found [here](https://www.minidso.com/forum.php?mod=viewthread&tid=3208&extra=page%3D1).
+
+![](https://core-electronics.com.au/media/catalog/product/4/2/4244-01.jpg)
+
+
 ### MHP30
 
-- Accelerometer is the MSA301, this is mounted roughly in the middle of the unit
-- USB-PD is using the FUSB302
-- The hardware I2C bus on PB6/7 is used for the MSA301 and FUSB302
-- The OLED is the same SSD1306 as everything else, but it’s on a bit-banged bus
+MHP30 is a **M**ini **H**ot **P**late:
+- accelerometer is the MSA301, this is mounted roughly in the middle of the unit;
+- USB-PD is using the FUSB302;
+- the hardware I2C bus on PB6/7 is used for the MSA301 and FUSB302;
+- the OLED is the same SSD1306 as everything else, but it’s on a bit-banged bus.
+
+

--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -40,6 +40,7 @@ For notes on installation for your device, please refer to the flashing guide fo
 - [TS100](https://ralim.github.io/IronOS/Flashing/TS100)
 
 But the _generic_ [TL;DR](https://www.merriam-webster.com/dictionary/TL%3BDR) is to:
+
 - [download firmware from here](https://github.com/Ralim/IronOS/releases) for the correct model with suitable language support;
 - put a device into DFU/bootloader mode (usually by keep holding A/+/front button while connecting a device to power source to power device on);
 - flash the firmware by drag-n-drop the firmware file using a file manager of your OS **or** using a separate flashing tool.
@@ -79,17 +80,21 @@ Operation details are over in the [Menu information.](https://ralim.github.io/Ir
 ## Feedback
 
 If you would like to:
+
 - report any issue related to IronOS
 - request a feature
 - provide some suggestion
-then you can [fill this form](https://github.com/Ralim/IronOS/issues/new/choose) using github account[^gh].
+
+then you can [fill this form](https://github.com/Ralim/IronOS/issues/new/choose) using github account\*.
 
 And if you would like to:
+
 - ask more generic question about IronOS/supported hardware/something you're curious about/etc.
 - reach out community to chat with
 - share your soldering & DIY skills
 - share some interesting finding
 - share useful related hardware/software with others
+
 or _anything_ like that, then you can use forum-like [Discussions here](https://github.com/Ralim/IronOS/discussions).
 
-[^gh]: You may need to create it first if you don't have one - it's free of charge.
+\*: You may need to create it first if you don't have one - it's free of charge.

--- a/Documentation/index.md
+++ b/Documentation/index.md
@@ -8,18 +8,18 @@ For soldering irons that are designed to be powered by batteries (TS100 & Pineci
 
 Currently **31** languages are supported. When downloading the firmware for your soldering iron, take note of the language code in the file name.
 
-This project is considered feature complete for use as a soldering iron, _so please suggest any feature improvements you would like!_
+This project is considered stable & feature complete for everyday use with a supported device, _so please suggest any feature improvements you would like!_
 
 _This firmware does **NOT** support the USB port while running for changing settings. This is done through the onscreen menu only. Logos are edited on a computer and flashed like firmware._
 
 |   Device   | DC  | QC  | PD  | EPR | BLE | Battery | Recommended |
 | :--------: | :-: | :-: | :-: | :-: | :-: | :-----: | :---------: |
-|   MHP30    | ❌  | ❌  | ✔️  | ❌  | ❌  |   ❌    |     ✔️      |
-| Pinecil V1 | ✔️  | ✔️  | ✔️  | ❌  | ❌  |   ✔️    |     ✔️      |
-| Pinecil V2 | ✔️  | ✔️  | ✔️  | ✔️  | ✔️  |   ✔️    |     ✔️      |
-|   TS80P    | ❌  | ✔️  | ✔️  | ❌  | ❌  |   ✔️    |     ✔️      |
-|   TS100    | ✔️  | ❌  | ❌  | ❌  | ❌  |   ✔️    |     ❌      |
-|    TS80    | ❌  | ✔️  | ❌  | ❌  | ❌  |   ✔️    |     ❌      |
+|   MHP30    | ❌  | ❌  | ✔️   | ❌  | ❌  |   ❌    |     ✔️       |
+| Pinecil V1 | ✔️   | ✔️   | ✔️   | ❌  | ❌  |   ✔️     |     ✔️       |
+| Pinecil V2 | ✔️   | ✔️   | ✔️   | ✔️   | ✔️   |   ✔️     |     ✔️       |
+|   TS80P    | ❌  | ✔️   | ✔️   | ❌  | ❌  |   ✔️     |     ✔️       |
+|   TS100    | ✔️   | ❌  | ❌  | ❌  | ❌  |   ✔️     |     ❌      |
+|    TS80    | ❌  | ✔️   | ❌  | ❌  | ❌  |   ✔️     |     ❌      |
 
 \*Please note that Miniware started shipping TS100's using cloned STM32 Chips. While these do work with IronOS, their DFU bootloader works terribly, and it is hard to get it to successfully flash larger firmware images like IronOS without timing out. This is the main reason why the TS100 is **_no longer recommended_**.
 
@@ -38,6 +38,11 @@ For notes on installation for your device, please refer to the flashing guide fo
 - [Pinecil V2](https://ralim.github.io/IronOS/Flashing/Pinecil%20V2/)
 - [TS80 / TS80P](https://ralim.github.io/IronOS/Flashing/TS80%28P%29/)
 - [TS100](https://ralim.github.io/IronOS/Flashing/TS100)
+
+But the _generic_ [TL;DR](https://www.merriam-webster.com/dictionary/TL%3BDR) is to:
+- [download firmware from here](https://github.com/Ralim/IronOS/releases) for the correct model with suitable language support;
+- put a device into DFU/bootloader mode (usually by keep holding A/+/front button while connecting a device to power source to power device on);
+- flash the firmware by drag-n-drop the firmware file using a file manager of your OS **or** using a separate flashing tool.
 
 ## Key Features
 

--- a/scripts/IronOS-mkdocs.yml
+++ b/scripts/IronOS-mkdocs.yml
@@ -1,14 +1,10 @@
 # Project info
 site_name: IronOS
-# !!! REVERT BEFORE PR !!!
-# site_url: https://ralim.github.io/IronOS/
-site_url: https://ia.github.io/IronOS-plus/
+site_url: https://ralim.github.io/IronOS/
 site_description: "IronOS Open Source Soldering Iron firmware for Miniware and Pinecil"
 
 # Repo config
-# !!! REVERT BEFORE PR !!!
-# repo_url: https://github.com/ralim/IronOS/
-repo_url: https://github.com/ia/IronOS-plus/
+repo_url: https://github.com/ralim/IronOS/
 
 # Dir & location config
 docs_dir: ../Documentation

--- a/scripts/IronOS-mkdocs.yml
+++ b/scripts/IronOS-mkdocs.yml
@@ -1,10 +1,14 @@
 # Project info
 site_name: IronOS
-site_url: https://ralim.github.io/IronOS/
+# !!! REVERT BEFORE PR !!!
+# site_url: https://ralim.github.io/IronOS/
+site_url: https://ia.github.io/IronOS-plus/
 site_description: "IronOS Open Source Soldering Iron firmware for Miniware and Pinecil"
 
 # Repo config
-repo_url: https://github.com/ralim/IronOS/
+# !!! REVERT BEFORE PR !!!
+# repo_url: https://github.com/ralim/IronOS/
+repo_url: https://github.com/ia/IronOS-plus/
 
 # Dir & location config
 docs_dir: ../Documentation


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Move related pieces of documentation from wiki to Documentation/.

* **What is the current behavior?**
Wiki is out-of-dated but still may have some valuable information to keep as project documentation.

* **What is the new behavior (if this is a feature change)?**
The single entry point into project documentation is [online RtD generated site](https://ralim.github.io/IronOS).

* **Other information**:
There are two things which I have a question about:
- should I move [info about STMCubeIDE & Atollic](https://github.com/ia/IronOS-plus/wiki/Building) from `wiki/Building.md` to `rtd/Development.md`?
- should I move [QC3 chargers for TS80 table](https://github.com/ia/IronOS-plus/wiki/TS80) from `wiki/TS80.md` to ... new file probably?..
- or do we say goodbye to a couple of these?

The updated current version can be surfed [here](https://ia.github.io/IronOS-plus/). Basically, besides main `index.md` page & `Hardware.md` [being updated a bit](https://ia.github.io/IronOS-plus/Hardware/) there is nothing else from wiki.