### PR TITLE
Replace /build/source by /build/ironos to eliminate ambiguity with /build/source/source

### DIFF
--- a/Env.yml
+++ b/Env.yml
@@ -10,4 +10,4 @@ services:
     command: /bin/sh
     volumes:
       - ./scripts/ci:/build/ci:Z
-      - ./:/build/source:Z
+      - ./:/build/ironos:Z

--- a/scripts/IronOS.Dockerfile
+++ b/scripts/IronOS.Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:3.16
 LABEL maintainer="Ben V. Brown <ralim@ralimtek.com>"
 
 # Default current dir when container starts
-WORKDIR /build/source
+WORKDIR /build/ironos
 
 # Installing the two compilers (ARM & RISCV), python3 & pip, clang tools:
 ## - compilers: gcc-*, newlib-*
@@ -29,7 +29,7 @@ RUN apk add --no-cache ${APK_COMPS} ${APK_PYTHON} ${APK_MISC} ${APK_DEV}
 RUN python3 -m pip install ${PIP_PKGS}
 
 # Git trust to avoid related warning
-RUN git config --global --add safe.directory /build/source
+RUN git config --global --add safe.directory /build/ironos
 
-COPY . /build/source
+COPY . /build/ironos
 COPY ./scripts/ci /build/ci

--- a/scripts/ci/buildAll.sh
+++ b/scripts/ci/buildAll.sh
@@ -2,12 +2,17 @@
 set -e
 set -u
 
-mkdir -p /build/ci/artefacts
+# Init vars & prepare dir
+dir_ci="/build/ci"
+dir_artefacts="${dir_ci}/artefacts"
+dir_ironos="/build/ironos"
+dir_source="${dir_ironos}/source"
+mkdir -p "${dir_artefacts}"
 
-# Build STM code
-cd /build/source/source/
+# Build firmware
+cd "${dir_source}"
 bash ./build.sh || exit 1
 echo "All Firmware built"
+
 # Copy out all the final resulting files we would like to store for the next op
-cp -r /build/source/source/Hexfile/*.hex  /build/ci/artefacts/
-cp -r /build/source/source/Hexfile/*.bin  /build/ci/artefacts/
+cp -r "${dir_source}"/Hexfile/{*.hex,*.bin}  "${dir_artefacts}"

--- a/scripts/ci/buildAll.sh
+++ b/scripts/ci/buildAll.sh
@@ -2,11 +2,13 @@
 set -e
 set -u
 
-# Init vars & prepare dir
+# Init vars
 dir_ci="/build/ci"
-dir_artefacts="${dir_ci}/artefacts"
 dir_ironos="/build/ironos"
 dir_source="${dir_ironos}/source"
+
+# Prepare output dir
+dir_artefacts="${dir_ci}/artefacts"
 mkdir -p "${dir_artefacts}"
 
 # Build firmware
@@ -15,4 +17,5 @@ bash ./build.sh || exit 1
 echo "All Firmware built"
 
 # Copy out all the final resulting files we would like to store for the next op
-cp -r "${dir_source}"/Hexfile/{*.hex,*.bin}  "${dir_artefacts}"
+cp -r "${dir_source}"/Hexfile/*.bin  "${dir_artefacts}"
+cp -r "${dir_source}"/Hexfile/*.hex  "${dir_artefacts}"


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Tiny change of the directory name inside docker container.

* **What is the current behavior?**
The root project directory mapped/copied to `/build/source/` inside of docker container. But since there is `source` directory inside the root project directory already, sometimes it leads to ambiguity.

* **What is the new behavior (if this is a feature change)?**
The root project directory mapped/copied to `/build/ironos` inside of docker container.
Plus tiny refactoring `buildAll.sh` only to use variables for directories instead of hardcoded paths just in case.

* **Other information**:
Just another one tiny _"ci beautify"_ suggestion. :)
It shouldn't affect anything else though - I tested it locally by running `make docker-build` and all output files have been generated where they supposed to be.