### PR TITLE
Fix github CI clang-format related check_c-cpp job

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -143,7 +143,7 @@ jobs:
 
     steps:
       - name: Install dependencies (apk)
-        run: apk add --no-cache make git diffutils findutils clang-extra-tools
+        run: apk add --no-cache make git diffutils findutils clang-extra-tools bash
 
       - uses: actions/checkout@v3
         with:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -95,9 +95,12 @@ check_style_file()
 	#   * https://clang.llvm.org/docs/ClangFormatStyleOptions.html#insertbraces
 	# - since reference env is alpine 3.16 with clang-format 13, implement custom parser to do the similar thing here with grep:
 	#   it used to trace missing { and } for if/else/do/while/for BUT IT'S VERY SPECULATIVE, very-very hacky & dirty.
-	test -z "${LIST}" || silent_opt="-q"
-	# if file is problematic but filename only requested make final grep in pipe silent ...
-	grep -H -n  -e "^ .*if .*)$"  -e "^ .*else$"  -e "^ .* do$"  -e "^ .*while .*)$"  -e "^ .*for .*)$"  "${src}" | grep -v  -e "^.*//"  -e "^.*:.*: .*if ((.*[^)])$" | sed 's,^,\n\n,; s,: ,:1: error: probably missing { or } for conditional or loop block:\n>>>,;' | grep  $(eval "${silent_opt}") -e "^.*$"
+	# - if file is problematic but filename only requested make final grep in pipe silent ... UPD: make code messy but shellcheck happy
+	if [ -z "${LIST}" ]; then
+		grep -H -n  -e "^ .*if .*)$"  -e "^ .*else$"  -e "^ .* do$"  -e "^ .*while .*)$"  -e "^ .*for .*)$"  "${src}" | grep -v  -e "^.*//"  -e "^.*:.*: .*if ((.*[^)])$" | sed 's,^,\n\n,; s,: ,:1: error: probably missing { or } for conditional or loop block:\n>>>,;' | grep -e "^.*$"
+	else
+		grep -H -n  -e "^ .*if .*)$"  -e "^ .*else$"  -e "^ .* do$"  -e "^ .*while .*)$"  -e "^ .*for .*)$"  "${src}" | grep -v  -e "^.*//"  -e "^.*:.*: .*if ((.*[^)])$" | sed 's,^,\n\n,; s,: ,:1: error: probably missing { or } for conditional or loop block:\n>>>,;' | grep -q -e "^.*$"
+	fi;
 	if [ "${?}" -ne 1 ]; then
 		# ... and only print the filename
 		test -z "${LIST}" || echo "${src}"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -97,7 +97,7 @@ check_style_file()
 	#   it used to trace missing { and } for if/else/do/while/for BUT IT'S VERY SPECULATIVE, very-very hacky & dirty.
 	test -z "${LIST}" || silent_opt="-q"
 	# if file is problematic but filename only requested make final grep in pipe silent ...
-	grep -H -n  -e "^ .*if .*)$"  -e "^ .*else$"  -e "^ .* do$"  -e "^ .*while .*)$"  -e "^ .*for .*)$"  "${src}" | grep -v  -e "^.*//"  -e "^.*:.*: .*if ((.*[^)])$" | sed 's,^,\n\n,; s,: ,:1: error: probably missing { or } for conditional or loop block:\n>>>,;' | grep  "${silent_opt}" -e "^.*$"
+	grep -H -n  -e "^ .*if .*)$"  -e "^ .*else$"  -e "^ .* do$"  -e "^ .*while .*)$"  -e "^ .*for .*)$"  "${src}" | grep -v  -e "^.*//"  -e "^.*:.*: .*if ((.*[^)])$" | sed 's,^,\n\n,; s,: ,:1: error: probably missing { or } for conditional or loop block:\n>>>,;' | grep  $(eval "${silent_opt}") -e "^.*$"
 	if [ "${?}" -ne 1 ]; then
 		# ... and only print the filename
 		test -z "${LIST}" || echo "${src}"


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Fix github CI clang-format related check_c-cpp job.

* **What is the current behavior?**
After `check-style` logic has been moved to shell script, `make check-style` calls it but because bash is missing in the container, [script can't run the check](https://github.com/Ralim/IronOS/actions/runs/5605990076/job/15187555096#step:5:13)!

* **What is the new behavior (if this is a feature change)?**
It _should be_ fixed with these changes.

* **Other information**:
**I'm terribly sorry!!!** But it seems this particular job is cursed! It's the second time already when according to log there is a problem but github CI just can't track down such ease-to-automate checks for users. Not excusing my own responsibility here though! (going to a chalk board) _I will be checking build steps' logs on github after changing scripts for build steps. I will be checking build steps' logs on github after changing scripts for build steps. I will be ..._ (not copy pasted BTW)