### PR TITLE
Simplify commands for jobs in push.yml

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,7 +30,7 @@ jobs:
         run: cd source && ./build.sh -m ${{ matrix.model }}
 
       - name: Copy license files
-        run: cp  LICENSE  scripts/LICENSE_RELEASE.md  source/Hexfile/
+        run: cp LICENSE scripts/LICENSE_RELEASE.md  source/Hexfile/
 
       - name: Archive ${{ matrix.model }} artifacts
         uses: actions/upload-artifact@v3
@@ -77,11 +77,10 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Build ${{ matrix.model }}
-        run: make  -C source/  -j$(nproc) model="${{ matrix.model }}" firmware-multi_compressed_European firmware-multi_compressed_Bulgarian+Russian+Serbian+Ukrainian firmware-multi_Chinese+Japanese
+        run: make -j$(nproc) model="${{ matrix.model }}" firmware-multi_compressed_European firmware-multi_compressed_Bulgarian+Russian+Serbian+Ukrainian firmware-multi_Chinese+Japanese
 
       - name: Copy license files
-        run: |
-          cp  LICENSE  scripts/LICENSE_RELEASE.md  source/Hexfile/
+        run: cp LICENSE scripts/LICENSE_RELEASE.md  source/Hexfile/
 
       - name: Archive ${{ matrix.model }} artifacts
         uses: actions/upload-artifact@v3
@@ -142,7 +141,7 @@ jobs:
           submodules: true
 
       - name: Check format style with clang-format
-        run: make  -C source/  clean  check-style
+        run: make  clean  check-style
 
 
   check_python:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,9 +30,7 @@ jobs:
         run: cd source && ./build.sh -m ${{ matrix.model }}
 
       - name: Copy license files
-        run: |
-          cp LICENSE source/Hexfile/LICENSE
-          cp scripts/LICENSE_RELEASE.md source/Hexfile/LICENSE_RELEASE.md
+        run: cp  LICENSE  scripts/LICENSE_RELEASE.md  source/Hexfile/
 
       - name: Archive ${{ matrix.model }} artifacts
         uses: actions/upload-artifact@v3
@@ -47,7 +45,7 @@ jobs:
           if-no-files-found: error
 
       - name: Generate json index file
-        run: cd source && python3 metadata.py ${{ matrix.model }}.json
+        run: ./source/metadata.py ${{ matrix.model }}.json
 
       - name: Archive ${{ matrix.model }} index file
         uses: actions/upload-artifact@v3
@@ -79,12 +77,11 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Build ${{ matrix.model }}
-        run: cd source && make -j$(nproc) model="${{ matrix.model }}" firmware-multi_compressed_European firmware-multi_compressed_Bulgarian+Russian+Serbian+Ukrainian firmware-multi_Chinese+Japanese
+        run: make  -C source/  -j$(nproc) model="${{ matrix.model }}" firmware-multi_compressed_European firmware-multi_compressed_Bulgarian+Russian+Serbian+Ukrainian firmware-multi_Chinese+Japanese
 
       - name: Copy license files
         run: |
-          cp LICENSE source/Hexfile/LICENSE
-          cp scripts/LICENSE_RELEASE.md source/Hexfile/LICENSE_RELEASE.md
+          cp  LICENSE  scripts/LICENSE_RELEASE.md  source/Hexfile/
 
       - name: Archive ${{ matrix.model }} artifacts
         uses: actions/upload-artifact@v3
@@ -99,7 +96,7 @@ jobs:
           if-no-files-found: error
 
       - name: Generate json index file
-        run: cd source && python3 metadata.py ${{ matrix.model }}_multi-lang.json
+        run: ./source/metadata.py ${{ matrix.model }}_multi-lang.json
 
       - name: Archive ${{ matrix.model }} index file
         uses: actions/upload-artifact@v3
@@ -125,15 +122,10 @@ jobs:
         run: python3 -m pip install bdflib
 
       - name: Run python tests
-        run: cd Translations && chmod +x make_translation_test.py && ./make_translation_test.py
+        run: ./Translations/make_translation_test.py
 
       - name: Run BriefLZ tests
-        run: |
-          cd source
-          make Objects/host/brieflz/libbrieflz.so
-          cd ../Translations
-          chmod +x brieflz_test.py
-          ./brieflz_test.py
+        run: make  -C source/  Objects/host/brieflz/libbrieflz.so && ./Translations/brieflz_test.py
 
 
   check_c-cpp:
@@ -150,7 +142,7 @@ jobs:
           submodules: true
 
       - name: Check format style with clang-format
-        run: cd source && make clean && make check-style
+        run: make  -C source/  clean  check-style
 
 
   check_python:

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ test-py:
 	@echo ""
 	flake8  Translations
 	black  --check  Translations
-	@make  -C source/  Objects/host/brieflz/libbrieflz.so
+	@$(MAKE)  -C source/  Objects/host/brieflz/libbrieflz.so
 	./Translations/brieflz_test.py
 	./Translations/make_translation_test.py
 
@@ -149,7 +149,7 @@ test-ccpp:
 	@echo ""
 	@echo "---- Checking C/C++ code... ----"
 	@echo ""
-	make  -C source/  clean  check-style
+	$(MAKE)  -C source/  clean  check-style
 
 # meta target for tests & checks based on .github/workflows/push
 tests: test-md  test-sh  test-py  test-ccpp
@@ -159,11 +159,11 @@ tests: test-md  test-sh  test-py  test-ccpp
 
 # pass-through target for Makefile inside source/ dir
 %:
-	make  -C source/  $@
+	$(MAKE)  -C source/  $@
 
 # global clean-up target for produced/generated files inside tree
 clean-build:
-	make  -C source/  clean-all
+	$(MAKE)  -C source/  clean-all
 	rm  -Rf  site
 	rm  -Rf  scripts/ci/artefacts
 

--- a/source/Makefile
+++ b/source/Makefile
@@ -875,9 +875,9 @@ style:
 #   * process STOP env variable
 check-style:
 	@error=0; export LIST=$$LIST; for src in $(ALL_SOURCE) $(ALL_INCLUDES) ; do \
-	      ../scripts/deploy.sh  check_style_file  "$$src" ; \
-	      test "$${?}" -eq 1 && export error=1 ; \
-	      test "$${error}" -eq 1 && test -n "$${STOP}" && break; \
+		../scripts/deploy.sh  check_style_file  "$$src" ; \
+		test "$${?}" -eq 1 && export error=1 ; \
+		test "$${error}" -eq 1 && test -n "$${STOP}" && break; \
 	done; \
 	if [ $$error -eq 0 ] ; then  echo "" && echo "" && echo "Style check: PASS" && echo "" && echo "" && exit 0 ; \
 	else  echo "" && echo "" && echo "Style check: FAIL! Please, check the log above for the details." && echo "If there is a false-negative trigger, please, report an issue attaching the log or link to the log!" && echo "" && echo "" && exit 1 ; \

--- a/source/Makefile
+++ b/source/Makefile
@@ -765,15 +765,15 @@ Core/Gen/Translation_brieflz.%.cpp: $(OUTPUT_DIR)/Core/Gen/translation.files/%.o
 	@test -d $(@D) || mkdir -p $(@D)
 	@echo Generating BriefLZ compressed translation for $*
 	@OBJCOPY=$(OBJCOPY) $(HOST_PYTHON) ../Translations/make_translation.py \
-		--macros $(PWD)/Core/Gen/macros.txt           \
-		-o $(PWD)/Core/Gen/Translation_brieflz.$*.cpp \
+		--macros $(CURDIR)/Core/Gen/macros.txt           \
+		-o $(CURDIR)/Core/Gen/Translation_brieflz.$*.cpp \
 		--input-pickled $(OUTPUT_DIR)/Core/Gen/translation.files/$*.pickle \
 		--strings-obj $(OUTPUT_DIR)/Core/Gen/translation.files/$*.o        \
 		$*
 
 Core/Gen/Translation_brieflz_font.%.cpp: $(OUTPUT_DIR)/Core/Gen/translation.files/%.pickle $(HOST_OUTPUT_DIR)/brieflz/libbrieflz.so Core/Gen/macros.txt
 	@test -d $(@D) || mkdir -p $(@D)
-	@echo Generating BriefLZ compressed translation for $*
+	@echo Generating BriefLZ compressed translation font for $*
 	@$(HOST_PYTHON) ../Translations/make_translation.py        \
 		--macros $(PWD)/Core/Gen/macros.txt                \
 		-o $(PWD)/Core/Gen/Translation_brieflz_font.$*.cpp \
@@ -820,8 +820,8 @@ Core/Gen/Translation_multi.$(1).cpp: $(patsubst %,../Translations/translation_%.
 	@test -d $(OUTPUT_DIR)/Core/Gen/translation.files || mkdir -p $(OUTPUT_DIR)/Core/Gen/translation.files
 	@echo 'Generating translations for multi-language $(2)'
 	@$(HOST_PYTHON) ../Translations/make_translation.py   \
-		--macros $(PWD)/Core/Gen/macros.txt           \
-		-o $(PWD)/Core/Gen/Translation_multi.$(1).cpp \
+		--macros $(CURDIR)/Core/Gen/macros.txt           \
+		-o $(CURDIR)/Core/Gen/Translation_multi.$(1).cpp \
 		--output-pickled $(OUTPUT_DIR)/Core/Gen/translation.files/multi.$(1).pickle \
 		$(3)
 
@@ -831,8 +831,8 @@ Core/Gen/Translation_brieflz_multi.$(1).cpp: $(OUTPUT_DIR)/Core/Gen/translation.
 	@test -d $$(@D) || mkdir -p $$(@D)
 	@echo Generating BriefLZ compressed translation for multi-language $(2)
 	@OBJCOPY=$(OBJCOPY) $(HOST_PYTHON) ../Translations/make_translation.py \
-		--macros $(PWD)/Core/Gen/macros.txt                   \
-		-o $(PWD)/Core/Gen/Translation_brieflz_multi.$(1).cpp \
+		--macros $(CURDIR)/Core/Gen/macros.txt                   \
+		-o $(CURDIR)/Core/Gen/Translation_brieflz_multi.$(1).cpp \
 		--input-pickled $(OUTPUT_DIR)/Core/Gen/translation.files/multi.$(1).pickle \
 		--strings-obj $(OUTPUT_DIR)/Core/Gen/translation.files/multi.$(1).o        \
 		--compress-font \


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Simplifying commands in `push.yml`.

* **What is the current behavior?**
`push.yml` may contain extra commands.

* **What is the new behavior (if this is a feature change)?**
Now since the permissions for script files are fixed and `make`-based build system is _almost fully_ location-agnostic we can call some commands on github CI in a shorter way.

* **Other information**:
Tested locally & successfully all the commands from `push.yml` but let's see what github CI will tell about that. I will check & double check the logs & artifacts to make sure that all the builds steps are being performed as expected after creating PR.