### PR TITLE
Implement proper git SHA ID marking for builds during pull-requests

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,8 +29,9 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git meta info
-        env: GITHUB_CI_PR_SHA: ${{ github.event.pull_request.head.sha }}
-        run: echo "GITHUB_CI_PR_SHA=${GITHUB_CI_PR_SHA}" >> "${GITHUB_ENV}"
+        env:
+          GITHUB_CI_PR: ${{ github.event.pull_request.head.sha }}
+        run: echo "GITHUB_CI_PR_SHA=${{github.event_name}}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
         run: cd source && ./build.sh -m ${{ matrix.model }}
@@ -83,8 +84,9 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git meta info
-        env: GITHUB_CI_PR_SHA: ${{ github.event.pull_request.head.sha }}
-        run: echo "GITHUB_CI_PR_SHA=${GITHUB_CI_PR_SHA}" >> "${GITHUB_ENV}"
+        env:
+          GITHUB_CI_PR: ${{ github.event.pull_request.head.sha }}
+        run: echo "GITHUB_CI_PR_SHA=${{github.event_name}}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
         run: make -C source/ -j$(nproc) model="${{ matrix.model }}" firmware-multi_compressed_European firmware-multi_compressed_Bulgarian+Russian+Serbian+Ukrainian firmware-multi_Chinese+Japanese

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,7 +27,8 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git meta info
-        env: GITHUB_CONTEXT: ${{ toJson(github) }}
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "cmd echo gh_ctx: ${GITHUB_CONTEXT}"; echo ""; echo ""; echo "cmd echo gh_env: ${GITHUB_ENV}"; echo ""; echo ""; ./scripts/deploy.sh  gh_ci_id
 
       - name: Build ${{ matrix.model }}
@@ -81,7 +82,8 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git meta info
-        env: GITHUB_CONTEXT: ${{ toJson(github) }}
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "cmd echo gh_ctx: ${GITHUB_CONTEXT}"; echo ""; echo ""; echo "cmd echo gh_env: ${GITHUB_ENV}"; echo ""; echo ""; ./scripts/deploy.sh  gh_ci_id
 
       - name: Build ${{ matrix.model }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -87,7 +87,8 @@ jobs:
         shell: bash
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "cmd echo gh_ctx: ${GITHUB_CONTEXT}"; echo ""; echo ""; echo "cmd echo gh_env: ${GITHUB_ENV}"; echo ""; echo ""; ./scripts/deploy.sh  gh_ci_id
+        run: |
+          echo "cmd echo gh_ctx: ${GITHUB_CONTEXT}" && echo "cmd echo gh_env: ${GITHUB_ENV}" && ./scripts/deploy.sh  gh_ci_id
 
       - name: Build ${{ matrix.model }}
         run: make -C source/ -j$(nproc) model="${{ matrix.model }}" firmware-multi_compressed_European firmware-multi_compressed_Bulgarian+Russian+Serbian+Ukrainian firmware-multi_Chinese+Japanese

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "cmd echo gh_ctx: ${GITHUB_CONTEXT}"; echo ""; echo ""; echo "cmd echo gh_env: ${GITHUB_ENV}"; echo ""; echo ""; ./scripts/deploy.sh  gh_ci_id
+        run: echo "cmd echo gh_ctx: ${GITHUB_CONTEXT}" && echo "cmd echo gh_env: ${GITHUB_ENV}" && ./scripts/deploy.sh  gh_ci_id
 
       - name: Build ${{ matrix.model }}
         run: cd source && ./build.sh -m ${{ matrix.model }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           GITHUB_CI_EVENT: ${{ github.event_name }}
           GITHUB_CI_SHA: ${{ github.event.pull_request.head.sha }}
-        run: echo "GITHUB_CI_EVENT=${GITHUB_CI_EVENT}" >> "${GITHUB_ENV}" && echo "GITHUB_CI_EVENT=${GITHUB_CI_EVENT}" >> "${GITHUB_ENV}"
+        run: echo "GITHUB_CI_EVENT=${GITHUB_CI_EVENT}" >> "${GITHUB_ENV}" && echo "GITHUB_CI_SHA=${GITHUB_CI_SHA}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
         run: cd source && ./build.sh -m ${{ matrix.model }}
@@ -88,7 +88,7 @@ jobs:
         env:
           GITHUB_CI_EVENT: ${{ github.event_name }}
           GITHUB_CI_SHA: ${{ github.event.pull_request.head.sha }}
-        run: echo "GITHUB_CI_EVENT=${GITHUB_CI_EVENT}" >> "${GITHUB_ENV}" && echo "GITHUB_CI_EVENT=${GITHUB_CI_EVENT}" >> "${GITHUB_ENV}"
+        run: echo "GITHUB_CI_EVENT=${GITHUB_CI_EVENT}" >> "${GITHUB_ENV}" && echo "GITHUB_CI_SHA=${GITHUB_CI_SHA}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
         run: make -C source/ -j$(nproc) model="${{ matrix.model }}" firmware-multi_compressed_European firmware-multi_compressed_Bulgarian+Russian+Serbian+Ukrainian firmware-multi_Chinese+Japanese

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,10 +29,8 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git meta info
-        env:
-          GITHUB_CI_EVENT: ${{ github.event_name }}
-          GITHUB_CI_SHA: ${{ github.event.pull_request.head.sha }}
-        run: echo "GITHUB_CI_EVENT=${GITHUB_CI_EVENT}" >> "${GITHUB_ENV}" && echo "GITHUB_CI_SHA=${GITHUB_CI_SHA}" >> "${GITHUB_ENV}"
+        env: GITHUB_CI_PR_SHA: ${{ github.event.pull_request.head.sha }}
+        run: echo "GITHUB_CI_PR_SHA=${GITHUB_CI_PR_SHA}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
         run: cd source && ./build.sh -m ${{ matrix.model }}
@@ -85,10 +83,8 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git meta info
-        env:
-          GITHUB_CI_EVENT: ${{ github.event_name }}
-          GITHUB_CI_SHA: ${{ github.event.pull_request.head.sha }}
-        run: echo "GITHUB_CI_EVENT=${GITHUB_CI_EVENT}" >> "${GITHUB_ENV}" && echo "GITHUB_CI_SHA=${GITHUB_CI_SHA}" >> "${GITHUB_ENV}"
+        env: GITHUB_CI_PR_SHA: ${{ github.event.pull_request.head.sha }}
+        run: echo "GITHUB_CI_PR_SHA=${GITHUB_CI_PR_SHA}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
         run: make -C source/ -j$(nproc) model="${{ matrix.model }}" firmware-multi_compressed_European firmware-multi_compressed_Bulgarian+Russian+Serbian+Ukrainian firmware-multi_Chinese+Japanese

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
 
+
   build:
     runs-on: ubuntu-20.04
     container:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -3,6 +3,7 @@ name: CI
 on: [push, pull_request]
 
 jobs:
+
   build:
     runs-on: ubuntu-20.04
     container:
@@ -27,13 +28,10 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git meta info
-        shell: bash
         env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
           GITHUB_CI_EVENT: ${{ github.event_name }}
           GITHUB_CI_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          echo "cmd echo gh_ctx: ${GITHUB_CONTEXT}" && echo "cmd echo gh_env: ${GITHUB_ENV}" && ./scripts/deploy.sh  gh_ci_id
+        run: ./scripts/deploy.sh  gh_ci_id
 
       - name: Build ${{ matrix.model }}
         run: cd source && ./build.sh -m ${{ matrix.model }}
@@ -86,13 +84,10 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git meta info
-        shell: bash
         env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
           GITHUB_CI_EVENT: ${{ github.event_name }}
           GITHUB_CI_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          echo "cmd echo gh_ctx: ${GITHUB_CONTEXT}" && echo "cmd echo gh_env: ${GITHUB_ENV}" && ./scripts/deploy.sh  gh_ci_id
+        run: ./scripts/deploy.sh  gh_ci_id
 
       - name: Build ${{ matrix.model }}
         run: make -C source/ -j$(nproc) model="${{ matrix.model }}" firmware-multi_compressed_European firmware-multi_compressed_Bulgarian+Russian+Serbian+Ukrainian firmware-multi_Chinese+Japanese

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,8 +29,6 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git meta info
-        env:
-          GITHUB_CI_PR: ${{ github.event.pull_request.head.sha }}
         run: echo "GITHUB_CI_PR_SHA=${{github.event_name}}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
@@ -84,9 +82,7 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git meta info
-        env:
-          GITHUB_CI_PR: ${{ github.event.pull_request.head.sha }}
-        run: echo "GITHUB_CI_PR_SHA=${{github.event_name}}" >> "${GITHUB_ENV}"
+        run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
         run: make -C source/ -j$(nproc) model="${{ matrix.model }}" firmware-multi_compressed_European firmware-multi_compressed_Bulgarian+Russian+Serbian+Ukrainian firmware-multi_Chinese+Japanese

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -27,6 +27,7 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git meta info
+        shell: bash
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "cmd echo gh_ctx: ${GITHUB_CONTEXT}"; echo ""; echo ""; echo "cmd echo gh_env: ${GITHUB_ENV}"; echo ""; echo ""; ./scripts/deploy.sh  gh_ci_id
@@ -82,6 +83,7 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git meta info
+        shell: bash
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "cmd echo gh_ctx: ${GITHUB_CONTEXT}"; echo ""; echo ""; echo "cmd echo gh_env: ${GITHUB_ENV}"; echo ""; echo ""; ./scripts/deploy.sh  gh_ci_id

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Git ownership exception
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
+      - name: Git meta info
+        env: GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "cmd echo gh_ctx: ${GITHUB_CONTEXT}"; echo ""; echo ""; echo "cmd echo gh_env: ${GITHUB_ENV}"; echo ""; echo ""; ./scripts/deploy.sh  gh_ci_id
+
       - name: Build ${{ matrix.model }}
         run: cd source && ./build.sh -m ${{ matrix.model }}
 
@@ -75,6 +79,10 @@ jobs:
 
       - name: Git ownership exception
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Git meta info
+        env: GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "cmd echo gh_ctx: ${GITHUB_CONTEXT}"; echo ""; echo ""; echo "cmd echo gh_env: ${GITHUB_ENV}"; echo ""; echo ""; ./scripts/deploy.sh  gh_ci_id
 
       - name: Build ${{ matrix.model }}
         run: make -C source/ -j$(nproc) model="${{ matrix.model }}" firmware-multi_compressed_European firmware-multi_compressed_Bulgarian+Russian+Serbian+Ukrainian firmware-multi_Chinese+Japanese

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,7 +31,6 @@ jobs:
         env:
           GITHUB_CI_EVENT: ${{ github.event_name }}
           GITHUB_CI_SHA: ${{ github.event.pull_request.head.sha }}
-        run: ./scripts/deploy.sh  gh_ci_id
 
       - name: Build ${{ matrix.model }}
         run: cd source && ./build.sh -m ${{ matrix.model }}
@@ -87,7 +86,6 @@ jobs:
         env:
           GITHUB_CI_EVENT: ${{ github.event_name }}
           GITHUB_CI_SHA: ${{ github.event.pull_request.head.sha }}
-        run: ./scripts/deploy.sh  gh_ci_id
 
       - name: Build ${{ matrix.model }}
         run: make -C source/ -j$(nproc) model="${{ matrix.model }}" firmware-multi_compressed_European firmware-multi_compressed_Bulgarian+Russian+Serbian+Ukrainian firmware-multi_Chinese+Japanese

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -29,7 +29,7 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git meta info
-        run: echo "GITHUB_CI_PR_SHA=${{github.event_name}}" >> "${GITHUB_ENV}"
+        run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
         run: cd source && ./build.sh -m ${{ matrix.model }}
@@ -82,7 +82,7 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git meta info
-        run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
+        run: echo "GITHUB_CI_PR_SHA=${{github.event_name}}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
         run: make -C source/ -j$(nproc) model="${{ matrix.model }}" firmware-multi_compressed_European firmware-multi_compressed_Bulgarian+Russian+Serbian+Ukrainian firmware-multi_Chinese+Japanese

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,6 +32,7 @@ jobs:
         env:
           GITHUB_CI_EVENT: ${{ github.event_name }}
           GITHUB_CI_SHA: ${{ github.event.pull_request.head.sha }}
+        run: true
 
       - name: Build ${{ matrix.model }}
         run: cd source && ./build.sh -m ${{ matrix.model }}
@@ -87,6 +88,7 @@ jobs:
         env:
           GITHUB_CI_EVENT: ${{ github.event_name }}
           GITHUB_CI_SHA: ${{ github.event.pull_request.head.sha }}
+        run: true
 
       - name: Build ${{ matrix.model }}
         run: make -C source/ -j$(nproc) model="${{ matrix.model }}" firmware-multi_compressed_European firmware-multi_compressed_Bulgarian+Russian+Serbian+Ukrainian firmware-multi_Chinese+Japanese

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -82,7 +82,7 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git meta info
-        run: echo "GITHUB_CI_PR_SHA=${{github.event_name}}" >> "${GITHUB_ENV}"
+        run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
         run: make -C source/ -j$(nproc) model="${{ matrix.model }}" firmware-multi_compressed_European firmware-multi_compressed_Bulgarian+Russian+Serbian+Ukrainian firmware-multi_Chinese+Japanese

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,7 +30,8 @@ jobs:
         shell: bash
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "cmd echo gh_ctx: ${GITHUB_CONTEXT}" && echo "cmd echo gh_env: ${GITHUB_ENV}" && ./scripts/deploy.sh  gh_ci_id
+        run: |
+          echo "cmd echo gh_ctx: ${GITHUB_CONTEXT}" && echo "cmd echo gh_env: ${GITHUB_ENV}" && ./scripts/deploy.sh  gh_ci_id
 
       - name: Build ${{ matrix.model }}
         run: cd source && ./build.sh -m ${{ matrix.model }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,6 +30,8 @@ jobs:
         shell: bash
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
+          GITHUB_CI_EVENT: ${{ github.event_name }}
+          GITHUB_CI_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           echo "cmd echo gh_ctx: ${GITHUB_CONTEXT}" && echo "cmd echo gh_env: ${GITHUB_ENV}" && ./scripts/deploy.sh  gh_ci_id
 
@@ -87,6 +89,8 @@ jobs:
         shell: bash
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
+          GITHUB_CI_EVENT: ${{ github.event_name }}
+          GITHUB_CI_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           echo "cmd echo gh_ctx: ${GITHUB_CONTEXT}" && echo "cmd echo gh_env: ${GITHUB_ENV}" && ./scripts/deploy.sh  gh_ci_id
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,7 +32,7 @@ jobs:
         env:
           GITHUB_CI_EVENT: ${{ github.event_name }}
           GITHUB_CI_SHA: ${{ github.event.pull_request.head.sha }}
-        run: true
+        run: echo "GITHUB_CI_EVENT=${GITHUB_CI_EVENT}" >> "${GITHUB_ENV}" && echo "GITHUB_CI_EVENT=${GITHUB_CI_EVENT}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
         run: cd source && ./build.sh -m ${{ matrix.model }}
@@ -88,7 +88,7 @@ jobs:
         env:
           GITHUB_CI_EVENT: ${{ github.event_name }}
           GITHUB_CI_SHA: ${{ github.event.pull_request.head.sha }}
-        run: true
+        run: echo "GITHUB_CI_EVENT=${GITHUB_CI_EVENT}" >> "${GITHUB_ENV}" && echo "GITHUB_CI_EVENT=${GITHUB_CI_EVENT}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
         run: make -C source/ -j$(nproc) model="${{ matrix.model }}" firmware-multi_compressed_European firmware-multi_compressed_Bulgarian+Russian+Serbian+Ukrainian firmware-multi_Chinese+Japanese

--- a/Documentation/DebugMenu.md
+++ b/Documentation/DebugMenu.md
@@ -23,7 +23,7 @@ There is a static line on top which is presented on every sub-screen and reflect
   - D - git-related **d**ev branch
   - B - git-related custom **b**ranch
   - G - neither above but **g**it-related
-  - C - build from github **C**I during _pull request_ status
+  - C - build from github **C**I during _pull request_
   - H - build outside of a git tree (i.e. release tarball or **h**omebrew customization without git)
   - S - something **s**pecial[^ERR]
   - V - something **v**ery special[^ERR]

--- a/Documentation/DebugMenu.md
+++ b/Documentation/DebugMenu.md
@@ -23,6 +23,7 @@ There is a static line on top which is presented on every sub-screen and reflect
   - D - git-related **d**ev branch
   - B - git-related custom **b**ranch
   - G - neither above but **g**it-related
+  - C - build from github **C**I during _pull request_ status
   - H - build outside of a git tree (i.e. release tarball or **h**omebrew customization without git)
   - S - something **s**pecial[^ERR]
   - V - something **v**ery special[^ERR]

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -1266,7 +1266,7 @@ def get_translation_sanity_checks_text(defs: dict) -> str:
 def get_version_suffix(ver) -> str:
     # Check env var from push.yml first:
     # - if it's pull request then use vX.YY + C.ID for version line as in *C*I with proper tag instead of merge tag for detached tree
-    if os.environ.get("GITHUB_CI_PR_SHA", None) is not None:
+    if os.environ.get("GITHUB_CI_PR_SHA", "") != "":
         return "C" + "." + os.environ["GITHUB_CI_PR_SHA"][:8].upper()
     # - no github PR SHA ID, hence keep checking
 

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -1267,11 +1267,9 @@ def get_version_suffix(ver) -> str:
     # Check env var from push.yml first:
     # - if it's pull request then use vX.YY + C.ID for version line as in *C*I with proper tag instead of merge tag for detached tree
     try:
-        print("====>>>> GITHUB_CI_PR_SHA:", os.environ["GITHUB_CI_PR_SHA"])
         if os.environ["GITHUB_CI_PR_SHA"] != "":
             return "C" + "." + os.environ["GITHUB_CI_PR_SHA"][:8].upper()
     except KeyError:
-        print("====>>>> GITHUB_CI_PR_SHA:", "FALSE")
         True
     # - no github PR SHA ID, hence keep checking
 

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -1311,9 +1311,11 @@ def get_version_suffix(ver) -> str:
     except OSError:
         # Something _special_?
         suffix = "S"
+
     if "" == suffix:
         # Something _very_ special!
         suffix = "V"
+
     return suffix
 
 

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -1265,15 +1265,15 @@ def get_translation_sanity_checks_text(defs: dict) -> str:
 
 def get_version_suffix(ver) -> str:
     # Check env var from push.yml first:
-    # if it's pull request then use vX.YY + C.ID for version line as in *C*I with proper tag instead of merge tag for detached tree
+    # - if it's pull request then use vX.YY + C.ID for version line as in *C*I with proper tag instead of merge tag for detached tree
     try:
         print("====>>>> GITHUB_CI_PR_SHA:", os.environ["GITHUB_CI_PR_SHA"])
         if os.environ["GITHUB_CI_PR_SHA"] != "":
-            return "C" + "." + os.environ["GITHUB_CI_PR_SHA"][:8]
+            return "C" + "." + os.environ["GITHUB_CI_PR_SHA"][:8].upper()
     except KeyError:
         print("====>>>> GITHUB_CI_PR_SHA:", "FALSE")
         True
-    # No github PR SHA ID, hence "normal" build
+    # - no github PR SHA ID, hence "normal" build
 
     suffix = str("")
 

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -1264,18 +1264,19 @@ def get_translation_sanity_checks_text(defs: dict) -> str:
 
 
 def get_version_suffix(ver) -> str:
-    print("====>>>>", os.environ["GITHUB_CI_EVENT"])
-    print("====>>>>", os.environ["GITHUB_CI_SHA"])
-    # Check env vars from push.yml first (sha id may be set but being empty)
-    if (
-        os.environ["GITHUB_CI_EVENT"]
-        and os.environ["GITHUB_CI_EVENT"] == "pull_request"
-        and os.environ["GITHUB_CI_SHA"]
-        and os.environ["GITHUB_CI_SHA"] != ""
-    ):
-        # if it's pull request then use vX.YY + C.ID for version line as in *C*I with proper tag instead of merge tag for detached tree'
-        return "C" + "." + os.environ["GITHUB_CI_SHA"][:8]
+    # Check env var from push.yml first:
+    # if it's pull request then use vX.YY + C.ID for version line as in *C*I with proper tag instead of merge tag for detached tree
+    try:
+        print("====>>>> GITHUB_CI_PR_SHA:", os.environ["GITHUB_CI_PR_SHA"])
+        if os.environ["GITHUB_CI_PR_SHA"] != "":
+            return "C" + "." + os.environ["GITHUB_CI_PR_SHA"][:8]
+    except KeyError:
+        print("====>>>> GITHUB_CI_PR_SHA:", "FALSE")
+        True
+    # No github PR SHA ID, hence "normal" build
+
     suffix = str("")
+
     try:
         # Use commands _hoping_ they won't be too new for one environments nor deprecated for another ones:
         ## - get commit id; --short=8 - the shorted hash with 8 digits (increase/decrease if needed!)

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -1264,6 +1264,10 @@ def get_translation_sanity_checks_text(defs: dict) -> str:
 
 
 def get_version_suffix(ver) -> str:
+    # Check env vars from push.yml first (sha id may be set but being empty)
+    if os.environ['GITHUB_CI_EVENT'] and os.environ['GITHUB_CI_EVENT'] == "pull_request" and os.environ['GITHUB_CI_SHA'] and os.environ['GITHUB_CI_SHA'] != "":
+        # if it's pull request then use vX.YY + C.ID for version line as in *C*I with proper tag instead of merge tag for detached tree'
+        return "C" + "." + os.environ['GITHUB_CI_SHA'][:8]
     suffix = str("")
     try:
         # Use commands _hoping_ they won't be too new for one environments nor deprecated for another ones:

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -1264,6 +1264,8 @@ def get_translation_sanity_checks_text(defs: dict) -> str:
 
 
 def get_version_suffix(ver) -> str:
+    print("====>>>>", os.environ['GITHUB_CI_EVENT'])
+    print("====>>>>", os.environ['GITHUB_CI_SHA'])
     # Check env vars from push.yml first (sha id may be set but being empty)
     if os.environ['GITHUB_CI_EVENT'] and os.environ['GITHUB_CI_EVENT'] == "pull_request" and os.environ['GITHUB_CI_SHA'] and os.environ['GITHUB_CI_SHA'] != "":
         # if it's pull request then use vX.YY + C.ID for version line as in *C*I with proper tag instead of merge tag for detached tree'

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -1266,11 +1266,8 @@ def get_translation_sanity_checks_text(defs: dict) -> str:
 def get_version_suffix(ver) -> str:
     # Check env var from push.yml first:
     # - if it's pull request then use vX.YY + C.ID for version line as in *C*I with proper tag instead of merge tag for detached tree
-    try:
-        if os.environ["GITHUB_CI_PR_SHA"] != "":
-            return "C" + "." + os.environ["GITHUB_CI_PR_SHA"][:8].upper()
-    except KeyError:
-        True
+    if os.environ.get("GITHUB_CI_PR_SHA", None) is not None:
+        return "C" + "." + os.environ["GITHUB_CI_PR_SHA"][:8].upper()
     # - no github PR SHA ID, hence keep checking
 
     suffix = str("")

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -1264,12 +1264,17 @@ def get_translation_sanity_checks_text(defs: dict) -> str:
 
 
 def get_version_suffix(ver) -> str:
-    print("====>>>>", os.environ['GITHUB_CI_EVENT'])
-    print("====>>>>", os.environ['GITHUB_CI_SHA'])
+    print("====>>>>", os.environ["GITHUB_CI_EVENT"])
+    print("====>>>>", os.environ["GITHUB_CI_SHA"])
     # Check env vars from push.yml first (sha id may be set but being empty)
-    if os.environ['GITHUB_CI_EVENT'] and os.environ['GITHUB_CI_EVENT'] == "pull_request" and os.environ['GITHUB_CI_SHA'] and os.environ['GITHUB_CI_SHA'] != "":
+    if (
+        os.environ["GITHUB_CI_EVENT"]
+        and os.environ["GITHUB_CI_EVENT"] == "pull_request"
+        and os.environ["GITHUB_CI_SHA"]
+        and os.environ["GITHUB_CI_SHA"] != ""
+    ):
         # if it's pull request then use vX.YY + C.ID for version line as in *C*I with proper tag instead of merge tag for detached tree'
-        return "C" + "." + os.environ['GITHUB_CI_SHA'][:8]
+        return "C" + "." + os.environ["GITHUB_CI_SHA"][:8]
     suffix = str("")
     try:
         # Use commands _hoping_ they won't be too new for one environments nor deprecated for another ones:

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -1273,7 +1273,7 @@ def get_version_suffix(ver) -> str:
     except KeyError:
         print("====>>>> GITHUB_CI_PR_SHA:", "FALSE")
         True
-    # - no github PR SHA ID, hence "normal" build
+    # - no github PR SHA ID, hence keep checking
 
     suffix = str("")
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -124,6 +124,8 @@ gh_ci_id()
 {
 	echo "GH_CTX: ${GITHUB_CONTEXT}"
 	echo "GH_ENV: ${GITHUB_ENV}"
+	echo "GITHUB_CI_EVENT: ${GITHUB_CI_EVENT}"
+	echo "GITHUB_CI_SHA: ${GITHUB_CI_SHA}"
 	return 0
 }
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,7 +5,7 @@
 # - generate full set of builds ("build" sub-command)
 # - probably doing some other routines (check source briefly before running undocumented commands!)
 
-set -x
+#set -x
 #set -e
 
 ### helper functions
@@ -122,8 +122,6 @@ check_style_log()
 # DO NOT RUN THIS LOCALLY! github ci can't provide reliable git meta info in some cases so some work must be done manually
 gh_ci_id()
 {
-	echo "GH_CTX: ${GITHUB_CONTEXT}"
-	echo "GH_ENV: ${GITHUB_ENV}"
 	echo "GITHUB_CI_EVENT: ${GITHUB_CI_EVENT}"
 	echo "GITHUB_CI_SHA: ${GITHUB_CI_SHA}"
 	return 0

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -5,7 +5,7 @@
 # - generate full set of builds ("build" sub-command)
 # - probably doing some other routines (check source briefly before running undocumented commands!)
 
-#set -x
+set -x
 #set -e
 
 ### helper functions
@@ -119,6 +119,14 @@ check_style_log()
 	return 0
 }
 
+# DO NOT RUN THIS LOCALLY! github ci can't provide reliable git meta info in some cases so some work must be done manually
+gh_ci_id()
+{
+	echo "GH_CTX: ${GITHUB_CONTEXT}"
+	echo "GH_ENV: ${GITHUB_ENV}"
+	return 0
+}
+
 ### main
 
 docker_conf="Env.yml"
@@ -176,6 +184,11 @@ fi;
 
 if [ "check_style_log" = "${cmd}" ]; then
 	check_style_log
+	exit "${?}"
+fi;
+
+if [ "gh_ci_id" = "${cmd}" ]; then
+	gh_ci_id
 	exit "${?}"
 fi;
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -119,14 +119,6 @@ check_style_log()
 	return 0
 }
 
-# DO NOT RUN THIS LOCALLY! github ci can't provide reliable git meta info in some cases so some work must be done manually
-gh_ci_id()
-{
-	echo "GITHUB_CI_EVENT: ${GITHUB_CI_EVENT}"
-	echo "GITHUB_CI_SHA: ${GITHUB_CI_SHA}"
-	return 0
-}
-
 ### main
 
 docker_conf="Env.yml"
@@ -184,11 +176,6 @@ fi;
 
 if [ "check_style_log" = "${cmd}" ]; then
 	check_style_log
-	exit "${?}"
-fi;
-
-if [ "gh_ci_id" = "${cmd}" ]; then
-	gh_ci_id
 	exit "${?}"
 fi;
 


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Implement proper git SHA ID marking for builds during pull-requests.

* **What is the current behavior?**
If a build has been produced on github CI **after creating pull request**, then git SHA ID doesn't equal to the latest git SHA ID in a user's branch.

* **What is the new behavior (if this is a feature change)?**
Retrieve proper git SHA ID for marking builds during pull-requests using github CI environment variables through `push.yml` features.

* **Other information**:
As far as I understand (according to some pieces of information), here is what github does on builds for pull-requests:
- `git checkout COMMIT-ID_from_user_branch` 
- `git merge UPSTREAM`
Therefore, getting COMMIT_ID using `git` command returns SHA ID for merge commit and not the latest commit to user branch. But with a couple of tricks there is a way to get original SHA ID. I tried to make as less changes as possible. Documentation updated as well. Debugging `print` in `make_translation` will be removed once I double-check the output after creating this PR.