### PR TITLE
metadata.py: update tagging considering github CI builds

### DIFF
--- a/source/metadata.py
+++ b/source/metadata.py
@@ -35,7 +35,10 @@ def load_json(filename: str):
         return json.loads(f.read())
 
 def read_git_tag():
-    return f"{subprocess.check_output(['git', 'rev-parse', '--short=7', 'HEAD']).strip().decode('ascii').upper()}"
+    if os.environ.get("GITHUB_CI_PR_SHA", "") != "":
+        return os.environ["GITHUB_CI_PR_SHA"][:7].upper()
+    else:
+        return f"{subprocess.check_output(['git', 'rev-parse', '--short=7', 'HEAD']).strip().decode('ascii').upper()}"
 
 def read_version():
     with open(HERE / "version.h") as version_file:


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Make commit SHA ID for JSON files equal to the latest commit if it's pull-request.

* **What is the current behavior?**
JSON files have commit ID which is not valid to the project tree in case of github CI builds during pull-requests.

* **What is the new behavior (if this is a feature change)?**
Put proper valid commit ID into JSON files on github CI builds.

* **Other information**:
Since now a proper SHA ID can be obtained during github CI builds using changes in `push.yml`, utilize this for proper JSON tagging.
