### PR TITLE
Update tagging for detached commit case & update docs

### DIFF
--- a/Documentation/DebugMenu.md
+++ b/Documentation/DebugMenu.md
@@ -22,6 +22,7 @@ There is a static line on top which is presented on every sub-screen and reflect
   - T - git-related release **t**ag but version is not vXX.YY !
   - D - git-related **d**ev branch
   - B - git-related custom **b**ranch
+  - E - git-related from d**e**tached commit
   - G - neither above but **g**it-related
   - C - build from github **C**I during _pull request_
   - H - build outside of a git tree (i.e. release tarball or **h**omebrew customization without git)

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -1278,8 +1278,14 @@ def get_version_suffix(ver) -> str:
         sha_id = f"{subprocess.check_output(['git', 'rev-parse', '--short=8', 'HEAD']).strip().decode('ascii').upper()}"
         ## - if the exact commit relates to tag, then this command should return one-line tag name:
         tag = f"{subprocess.check_output(['git', 'tag', '--points-at', '%s' % sha_id]).strip().decode('ascii')}"
-        ## - get short "traditional" branch name (as in `git branch` for that one with asterisk):
-        branch = f"{subprocess.check_output(['git', 'symbolic-ref', '--short', 'HEAD']).strip().decode('ascii')}"
+        if (
+            f"{subprocess.check_output(['git', 'rev-parse', '--symbolic-full-name', '--short', 'HEAD']).strip().decode('ascii')}"
+            == "HEAD"
+        ):
+            return "E" + "." + sha_id
+        else:
+            ## - get short "traditional" branch name (as in `git branch` for that one with asterisk):
+            branch = f"{subprocess.check_output(['git', 'symbolic-ref', '--short', 'HEAD']).strip().decode('ascii')}"
         if tag and "" != tag:
             # _Speculate_ on tag that it's Release...
             if ver == tag:


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Implement proper tagging for detached commit case.

* **What is the current behavior?**
If the project tree in a detached commit case, then tagging logic goes for "Homebrew" build which is not correct.

* **What is the new behavior (if this is a feature change)?**
Check if the tree is in a detached state and if it's the case then put SHA ID only instead of trying to get branch name.

* **Other information**:
I hope this is last commit in the series considering all major possible cases for proper tagging so if there is any commit ID it doesn't lead to nowhere but allowing to ID the source tree used for a build.