### PR TITLE
Make `make docker-clean` to remove docker build cache

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -17,7 +17,7 @@ usage()
 	echo "CMD (docker related):"
 	echo -e "\tshell - start docker container with shell inside to work on IronOS with all tools needed"
 	echo -e "\tbuild - compile builds of IronOS inside docker container for supported hardware"
-	echo -e "\tclean - delete created docker container (but not pre-downloaded data for it)\n"
+	echo -e "\tclean - delete created docker image for IronOS & its build cache objects\n"
 	echo "CMD (helper routines):"
 	echo -e "\tdocs_readme - generate & OVERWRITE(!) README.md inside Documentation/ based on nav section from mkdocs.yml if it changed\n"
 	echo -e "\tcheck_style_file SRC - run code style checks based on clang-format & custom parsers for source code file SRC\n"
@@ -194,6 +194,7 @@ elif [ "${cmd}" = "build" ]; then
 	docker_cmd="run  --rm  builder  make  build-all  OUT=${OUT}"
 elif [ "${cmd}" = "clean" ]; then
 	docker  rmi  ironos-builder:latest
+	docker  system  prune  --filter label=ironos-builder:latest  --force
 	exit "${?}"
 else
 	usage


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Add `docker-clean` sub-targets `docker-clean-image` & `docker-clean-cache` into `Makefile` to remove not only image but cache.

* **What is the current behavior?**
After doing a lot of `make docker-shell` / `make docker-build`, `make clean-full` / `make docker-clean` may remove only docker image with IronOS env but not its build cache objects.

* **What is the new behavior (if this is a feature change)?**
`make clean-full` / `make docker-clean` / `./scripts/deploy.sh clean` removes **all** docker data related to IronOS env container.

* **Other information**:
I personally use docker very rarely & sporadically. And I know that the modern tendency is not to care about resources (especially disk space) much. But even for me it was surprising to discover that after about a month of working with IronOS image, docker ate ~30 GB of rootfs. So, since there is a way to clean up docker image, this patch adds cleaning up image's cache as well for the convenience of its users.

Also while I was testing this to make sure that it doesn't delete what it shouldn't, "today I learned" that _it seems_ if you run `docker rmi ...` for image which was created by `docker  compose` then it deletes build cache as well, BUT if you run `docker rmi ...` for image which was created by **`docker-compose`** then it deletes **only image itself**. Yes, I know that there is an option "--no-cache" but _it seems_ it's not supported by `docker-compose` and such `docker` subcommands as `compose` / `compose run`. So, this patch allows to clean up docker cache in a more easy & straightforward way. And it's possible to clean up cache without touching image like that:
```
make docker-shell
...
exit
make docker-clean-cache
```
So on the next `make docker-shell` you go into pre-downloaded & pre-allocated container but with cache & space cleaned.