### PR TITLE
Revert "Remove 0.5 ohm increase to resistance"

### DIFF
--- a/source/Core/Drivers/USBPD.cpp
+++ b/source/Core/Drivers/USBPD.cpp
@@ -123,7 +123,8 @@ bool parseCapabilitiesArray(const uint8_t numCaps, uint8_t *bestIndex, uint16_t 
   *bestIndex   = 0xFF; // Mark unselected
   *bestVoltage = 5000; // Default 5V
 
-  uint8_t tipResistance = getTipResistanceX10();
+  // Fudge of 0.5 ohms to round up a little to account for us always having off periods in PWM
+  uint8_t tipResistance = getTipResistanceX10() + 5;
 #ifdef MODEL_HAS_DCDC
   // If this device has step down DC/DC inductor to smooth out current spikes
   // We can instead ignore resistance and go for max voltage we can accept; and rely on the DC/DC regulation to keep under current limit


### PR DESCRIPTION
Reverts Ralim/IronOS#1728
Reverting this as it appears to maybe sorta help _one_ specific PSU out of lots that have been tested.
So given it helps approximately 1 charger out of 100's-100k's it has been decided in chat that this is not really worth it.