### PR TITLE
Add python packages required by `mkdocs` into docker container

### DIFF
--- a/scripts/IronOS.Dockerfile
+++ b/scripts/IronOS.Dockerfile
@@ -14,14 +14,13 @@ WORKDIR /build/ironos
 ## - clang (required for clang-format to check C++ code formatting)
 ## - shellcheck (to check sh scripts)
 
-ARG APK_COMPS="gcc-riscv-none-elf gcc-arm-none-eabi newlib-riscv-none-elf \
-               newlib-arm-none-eabi"
+ARG APK_COMPS="gcc-riscv-none-elf gcc-arm-none-eabi newlib-riscv-none-elf newlib-arm-none-eabi"
 ARG APK_PYTHON="python3 py3-pip black"
 ARG APK_MISC="findutils make git diffutils zip"
 ARG APK_DEV="musl-dev clang bash clang-extra-tools shellcheck"
 
-# PIP packages to check & test Python code
-ARG PIP_PKGS='bdflib flake8'
+# PIP packages to check & test Python code, and generate docs
+ARG PIP_PKGS='bdflib flake8 pymdown-extensions mkdocs mkdocs-autolinks-plugin mkdocs-awesome-pages-plugin mkdocs-git-revision-date-plugin'
 
 # Install system packages using alpine package manager
 RUN apk add --no-cache ${APK_COMPS} ${APK_PYTHON} ${APK_MISC} ${APK_DEV}
@@ -32,4 +31,5 @@ RUN python3 -m pip install ${PIP_PKGS}
 # Git trust to avoid related warning
 RUN git config --global --add safe.directory /build/ironos
 
+# Copy the whole source tree working dir into container
 COPY  .  /build/ironos


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Add python packages required by `mkdocs` into docker container.

* **What is the current behavior?**
Set of commands:
`$ make docker-shell`
`# make docs`
returns error.

* **What is the new behavior (if this is a feature change)?**
`make docs` generates `site` directory with static html documentation inside of a container successfully.

* **Other information**:
