### PR TITLE
Include Bluetooth document to read-the-docs site generating

### DIFF
--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -22,6 +22,7 @@
   - [Startup Logo](../Documentation/Logo.md)
   - Hardware
       - [Hall Sensor (Pinecil)](../Documentation/HallSensor.md)
+      - [Bluetooth (Pinecil V2)](../Documentation/Bluetooth.md)
       - [Hardware Notes](../Documentation/Hardware.md)
       - [Troubleshooting](../Documentation/Troubleshooting.md)
       - [Known Hardware Issues](../Documentation/HardwareIssues.md)

--- a/scripts/IronOS-mkdocs.yml
+++ b/scripts/IronOS-mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - Startup Logo: Logo.md
   - Hardware:
       - Hall Sensor (Pinecil): HallSensor.md
+      - Bluetooth (Pinecil V2): Bluetooth.md
       - Hardware Notes: Hardware.md
       - Troubleshooting: Troubleshooting.md
       - Known Hardware Issues: HardwareIssues.md


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Include `Bluetooth.md` to read-the-docs site generating.

* **What is the current behavior?**
There is `Bluetooth.md` document but its content is not available in [online documentation](https://ralim.github.io/IronOS/Troubleshooting/).

* **What is the new behavior (if this is a feature change)?**
Make `Bluetooth.md` content being generated for online documentation by updating related `mkdocs` configuration file.

* **Other information**:
`README.md` inside of `Documentation` is updated as well.
