### PR TITLE
Update links to the original Miniware firmware [#1840]

### DIFF
--- a/Documentation/Flashing/MHP30.md
+++ b/Documentation/Flashing/MHP30.md
@@ -26,7 +26,7 @@ Then this works the same as a production release (use the correct file).
 
 # MHP30
 
-This is completely safe, but if it goes wrong just put the `.hex` file from the official website ([MHP30](https://www.minidso.com/forum.php?mod=viewthread&tid=4385&extra=page%3D1) onto the unit and you're back to the old firmware. Downloads for the `.hex` files to flash are available on the [releases page.](https://github.com/Ralim/IronOS/releases) The file you want is called MHP30.zip. Inside the zip file (make sure to extract the file before flashing with it) will be a file called `MHP30_{Language-Code}.hex`.
+This is completely safe, but if it goes wrong just put the corresponding `.hex` file from [the official website](https://e-design.com.cn/en/NewsDetail/4203645.html) onto the unit and you're back to the old firmware. Downloads for the `.hex` files to flash are available on the [releases page.](https://github.com/Ralim/IronOS/releases) The file you want is called MHP30.zip. Inside the zip file (make sure to extract the file before flashing with it) will be a file called `MHP30_{Language-Code}.hex`.
 
 Officially the bootloader on the devices only works under Windows (use the built-in File Explorer, as alternative file managers or copy handlers like Teracopy will fail). However, users have reported that it does work under Mac, and can be made to work under Linux _sometimes_. Details over on the [wiki page](https://github.com/Ralim/IronOS/wiki/Upgrading-Firmware).
 

--- a/Documentation/Flashing/TS100.md
+++ b/Documentation/Flashing/TS100.md
@@ -26,7 +26,7 @@ Then this works the same as a production release (use the correct file).
 
 # TS100
 
-This is completely safe, but if it goes wrong just put the `.hex` file from the official website ([TS100](https://www.minidso.com/forum.php?mod=viewthread&tid=868&extra=page%3D1) onto the unit and you're back to the old firmware. Downloads for the `.hex` files to flash are available on the [releases page.](https://github.com/Ralim/IronOS/releases) The file you want is called TS100.zip. Inside the zip file (make sure to extract the file before flashing with it) will be a file called `TS100_{Language-Code}.hex`.
+This is completely safe, but if it goes wrong just put the corresponding `.hex` file from [the official website](https://e-design.com.cn/en/NewsDetail/4203645.html) onto the unit and you're back to the old firmware. Downloads for the `.hex` files to flash are available on the [releases page.](https://github.com/Ralim/IronOS/releases) The file you want is called TS100.zip. Inside the zip file (make sure to extract the file before flashing with it) will be a file called `TS100_{Language-Code}.hex`.
 
 Officially the bootloader on the devices only works under Windows (use the built-in File Explorer, as alternative file managers or copy handlers like Teracopy will fail). However, users have reported that it does work under Mac, and can be made to work under Linux _sometimes_. Details over on the [wiki page](https://github.com/Ralim/IronOS/wiki/Upgrading-Firmware).
 

--- a/Documentation/Flashing/TS80(P).md
+++ b/Documentation/Flashing/TS80(P).md
@@ -26,7 +26,7 @@ Then this works the same as a production release (use the correct file).
 
 # TS80 / TS80P
 
-This is completely safe, but if it goes wrong just put the `.hex` file from the official website ([TS80](https://www.minidso.com/forum.php?mod=viewthread&tid=868&extra=page%3D1)/[TS80P](https://www.minidso.com/forum.php?mod=viewthread&tid=4070&extra=page%3D1) onto the unit and you're back to the old firmware. Downloads for the `.hex` files to flash are available on the [releases page.](https://github.com/Ralim/IronOS/releases) The file you want is called TS80.zip or TS80P.zip. Inside the zip file (make sure to extract the file before flashing with it) will be a file called `TS80_{Language-Code}.hex`/`TS80P_{Language-Code}.hex`.
+This is completely safe, but if it goes wrong just put the corresponding `.hex` file from [the official website](https://e-design.com.cn/en/NewsDetail/4203645.html) onto the unit and you're back to the old firmware. Downloads for the `.hex` files to flash are available on the [releases page.](https://github.com/Ralim/IronOS/releases) The file you want is called TS80.zip or TS80P.zip. Inside the zip file (make sure to extract the file before flashing with it) will be a file called `TS80_{Language-Code}.hex`/`TS80P_{Language-Code}.hex`.
 
 Officially the bootloader on the devices only works under Windows (use the built-in File Explorer, as alternative file managers or copy handlers like Teracopy will fail). However, users have reported that it does work under Mac, and can be made to work under Linux _sometimes_. Details over on the [wiki page](https://github.com/Ralim/TS80/wiki/Upgrading-Firmware).
 

--- a/Documentation/Hardware.md
+++ b/Documentation/Hardware.md
@@ -8,7 +8,7 @@ TS100\* is a neat soldering iron:
 - can run from 9-25V DC;
 - provides a power range that is determined by the input voltage;
 - voltages below 12V don't overly work well for any substantial mass;
-- the default firmware can be found [here](https://www.minidso.com/forum.php?mod=viewthread&tid=892&extra=page%3D1).
+- the original firmware can be found [here](https://e-design.com.cn/en/NewsDetail/4203645.html).
 
 ![](https://brushlesswhoop.com/images/ts100-og.jpg)
 
@@ -19,7 +19,7 @@ TS80\* is a successor to TS100:
 
 - uses _Quick Charge 3.0_ / _QC3_ capable charger only (18W max);
 - doesn't support PD as it is not designed on the hardware level;
-- the default firmware can be found [here](https://www.minidso.com/forum.php?mod=viewthread&tid=3208&extra=page%3D1).
+- the original firmware can be found [here](https://e-design.com.cn/en/NewsDetail/4203645.html).
 
 ![](https://core-electronics.com.au/media/catalog/product/4/2/4244-01.jpg)
 
@@ -30,7 +30,7 @@ TS80P\* is a successor to TS80:
 
 - supports _Quick Charge 3.0_ (_QC3_: 9V/3A, 18W max);
 - supports _Power Delivery_ (_PD_: 9V/3A & 12V/3A, 30W max)\*\*;
-- the default firmware can be found [here](https://www.minidso.com/forum.php?mod=viewthread&tid=4085&extra=page%3D1).
+- the original firmware can be found [here](https://e-design.com.cn/en/NewsDetail/4203645.html).
 
 \*\*: use valid PD device that supports 12V/3A as power source to get full 30W potential, otherwise the iron will fall back to 9V/18W power mode.
 
@@ -44,7 +44,8 @@ MHP30 is a **M**ini **H**ot **P**late:
 - accelerometer is the MSA301, this is mounted roughly in the middle of the unit;
 - USB-PD is using the FUSB302;
 - the hardware I2C bus on PB6/7 is used for the MSA301 and FUSB302;
-- the OLED is the same SSD1306 as everything else, but it’s on a bit-banged bus.
+- the OLED is the same SSD1306 as everything else, but it’s on a bit-banged bus;
+- the original firmware can be found [here](https://e-design.com.cn/en/NewsDetail/4203645.html).
 
 
 ### Pinecil


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Update links to the official Miniware firmware since the original forum links are dead.

* **What is the current behavior?**
For the purpose of restoring functionality in case if something went wrong with flashing IronOS, documentation suggests to download official firmware and flash it. However, the minidso forum links are dead by now.

* **What is the new behavior (if this is a feature change)?**
Hence, this update replaces dead links to new official download firmware hub-like single page by Miniware.

* **Other information**:
If [related commit to meta repo](https://github.com/Ralim/IronOS-Meta/pull/41) will be approved, before approving this PR I would like to add links to firmware from meta repo into this commit as well as _mirror_ links.