### PR TITLE
Settings: disable Bluetooth LE by default (for PinecilV2) #1856

### DIFF
--- a/source/Core/Src/Settings.cpp
+++ b/source/Core/Src/Settings.cpp
@@ -88,7 +88,7 @@ static const SettingConstants settingsConstants[(int)SettingsOptions::SettingsOp
     {MIN_BRIGHTNESS, MAX_BRIGHTNESS, BRIGHTNESS_STEP, DEFAULT_BRIGHTNESS}, // OLEDBrightness
     {0, 6, 1, 1},                                                          // LOGOTime
     {0, 1, 1, 0},                                                          // CalibrateCJC
-    {0, 1, 1, 1},                                                          // BluetoothLE
+    {0, 1, 1, 0},                                                          // BluetoothLE
     {0, 1, 1, 1},                                                          // PDVpdo
     {1, 5, 1, 4},                                                          // ProfilePhases
     {MIN_TEMP_C, MAX_TEMP_F, 5, 90},                                       // ProfilePreheatTemp


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [ ] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Turning off Bluetooth LE on PinecilV2 by default.

* **What is the current behavior?**
Bluetooth LE on PinecilV2 is turned on by default.

* **What is the new behavior (if this is a feature change)?**
Bluetooth LE on PinecilV2 is turned off by default.

* **Other information**:
[Report](https://github.com/Ralim/IronOS/issues/1856).