### PR TITLE
Update translation_RU.json. Fixed a phrase that was too long causing …

### DIFF
--- a/Translations/translation_RU.json
+++ b/Translations/translation_RU.json
@@ -52,7 +52,7 @@
             "message": "Питание(В):\n"
         },
         "SleepingSimpleString": {
-            "message": "Хххррп"
+            "message": "Zzzz"
         },
         "SleepingAdvancedString": {
             "message": "Сон...\n"


### PR DESCRIPTION
…temperature values to not fit on the sleep screen.

The sleep indication phrase in simple mode is too long "Хххррп". The temperature value does not fit on the screen. Replaced it with the original phrase "Zzzz", understandable in all languages.


<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [] The changes have been tested locally
- [] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->



* **What is the current behavior?**
<!-- (You can also just link to an open issue here) -->

* **What is the new behavior (if this is a feature change)?**

* **Other information**:
