### PR TITLE
Translations/: set "Zzz " as SleepingSimpleString in all translations & revert maxLen value

### DIFF
--- a/Translations/translation_BE.json
+++ b/Translations/translation_BE.json
@@ -52,7 +52,7 @@
             "message": "Сілкаванне В: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Чаканне...\n"

--- a/Translations/translation_BG.json
+++ b/Translations/translation_BG.json
@@ -52,7 +52,7 @@
             "message": "Входно V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Сън...\n"

--- a/Translations/translation_CS.json
+++ b/Translations/translation_CS.json
@@ -52,7 +52,7 @@
             "message": "Napětí: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Režim spánku...\n"

--- a/Translations/translation_DA.json
+++ b/Translations/translation_DA.json
@@ -52,7 +52,7 @@
             "message": "Input V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Dvale...\n"

--- a/Translations/translation_DE.json
+++ b/Translations/translation_DE.json
@@ -52,7 +52,7 @@
             "message": "V Eingang: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Ruhemodus...\n"

--- a/Translations/translation_EL.json
+++ b/Translations/translation_EL.json
@@ -52,7 +52,7 @@
             "message": "Είσοδος V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Υπνος...\n"

--- a/Translations/translation_EN.json
+++ b/Translations/translation_EN.json
@@ -52,7 +52,7 @@
             "message": "Input V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Sleeping...\n"

--- a/Translations/translation_ES.json
+++ b/Translations/translation_ES.json
@@ -52,7 +52,7 @@
             "message": "Voltaje: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "En reposo...\n"

--- a/Translations/translation_ET.json
+++ b/Translations/translation_ET.json
@@ -52,7 +52,7 @@
             "message": "Sisend V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Unerežiim...\n"

--- a/Translations/translation_FI.json
+++ b/Translations/translation_FI.json
@@ -52,7 +52,7 @@
             "message": "Jännite: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Lepotila...\n"

--- a/Translations/translation_FR.json
+++ b/Translations/translation_FR.json
@@ -52,7 +52,7 @@
             "message": "V d'entrée: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "En veille...\n"

--- a/Translations/translation_HR.json
+++ b/Translations/translation_HR.json
@@ -52,7 +52,7 @@
             "message": "Napon V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "SPAVAM...\n"

--- a/Translations/translation_HU.json
+++ b/Translations/translation_HU.json
@@ -52,7 +52,7 @@
             "message": "Bemenet V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Alvás...\n"

--- a/Translations/translation_IT.json
+++ b/Translations/translation_IT.json
@@ -52,7 +52,7 @@
             "message": "V in: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Riposo\n"

--- a/Translations/translation_JA_JP.json
+++ b/Translations/translation_JA_JP.json
@@ -52,7 +52,7 @@
             "message": "Input V: "
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Sleeping..."

--- a/Translations/translation_LT.json
+++ b/Translations/translation_LT.json
@@ -52,7 +52,7 @@
             "message": "Įvestis V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Miegu...\n"

--- a/Translations/translation_NB.json
+++ b/Translations/translation_NB.json
@@ -52,7 +52,7 @@
             "message": "Innspenn.: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Dvale...\n"

--- a/Translations/translation_NL.json
+++ b/Translations/translation_NL.json
@@ -52,7 +52,7 @@
             "message": "Ingangs spanning: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Slaapt...\n"

--- a/Translations/translation_NL_BE.json
+++ b/Translations/translation_NL_BE.json
@@ -52,7 +52,7 @@
             "message": "Voedingsspanning: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Slaapstand...\n"

--- a/Translations/translation_PL.json
+++ b/Translations/translation_PL.json
@@ -52,7 +52,7 @@
             "message": "Nap. wej.: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Tr. uśpienia\n"

--- a/Translations/translation_PT.json
+++ b/Translations/translation_PT.json
@@ -52,7 +52,7 @@
             "message": "Tensão: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Repouso...\n"

--- a/Translations/translation_RO.json
+++ b/Translations/translation_RO.json
@@ -52,7 +52,7 @@
             "message": "Intrare V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Adormit...\n"

--- a/Translations/translation_RU.json
+++ b/Translations/translation_RU.json
@@ -52,7 +52,7 @@
             "message": "Питание(В):\n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Сон...\n"

--- a/Translations/translation_SK.json
+++ b/Translations/translation_SK.json
@@ -52,7 +52,7 @@
             "message": "Vstupné U: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Pokojový režim.\n"

--- a/Translations/translation_SL.json
+++ b/Translations/translation_SL.json
@@ -52,7 +52,7 @@
             "message": "Vhodna U: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Spim...\n"

--- a/Translations/translation_SR_CYRL.json
+++ b/Translations/translation_SR_CYRL.json
@@ -52,7 +52,7 @@
             "message": "Ул. напон: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Спавање...\n"

--- a/Translations/translation_SR_LATN.json
+++ b/Translations/translation_SR_LATN.json
@@ -52,7 +52,7 @@
             "message": "Ul. napon: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Spavanje...\n"

--- a/Translations/translation_SV.json
+++ b/Translations/translation_SV.json
@@ -52,7 +52,7 @@
             "message": "Inspän. V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Viloläge...\n"

--- a/Translations/translation_TR.json
+++ b/Translations/translation_TR.json
@@ -52,7 +52,7 @@
             "message": "Giriş V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Bekleme Modu...\n"

--- a/Translations/translation_UK.json
+++ b/Translations/translation_UK.json
@@ -52,7 +52,7 @@
             "message": "Жив.(B): \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Очікування...\n"

--- a/Translations/translation_VI.json
+++ b/Translations/translation_VI.json
@@ -52,7 +52,7 @@
             "message": "Đau vào V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Đang ngu...\n"

--- a/Translations/translation_YUE_HK.json
+++ b/Translations/translation_YUE_HK.json
@@ -52,7 +52,7 @@
             "message": "Input V: "
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Sleeping..."

--- a/Translations/translation_ZH_CN.json
+++ b/Translations/translation_ZH_CN.json
@@ -52,7 +52,7 @@
             "message": "VIN: "
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Zzzz..."

--- a/Translations/translation_ZH_TW.json
+++ b/Translations/translation_ZH_TW.json
@@ -52,7 +52,7 @@
             "message": "Input V: "
         },
         "SleepingSimpleString": {
-            "message": "Zzz"
+            "message": "Zzz "
         },
         "SleepingAdvancedString": {
             "message": "Sleeping..."

--- a/Translations/translations_definitions.json
+++ b/Translations/translations_definitions.json
@@ -97,7 +97,7 @@
         },
         {
             "id": "SleepingSimpleString",
-            "maxLen": 3,
+            "maxLen": 4,
             "exclude": [
                 "NO_SLEEP_MODE"
             ],


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Set "`Zzz `" as `SleepingSimpleString` in all translations.

* **What is the current behavior?**
In _simple sleep screen_ mode the line on display looks like `Zzzz174`.

* **What is the new behavior (if this is a feature change)?**
The line on display looks like `Zzz 174` which is better for "readability".

* **Other information**:
This is a follow-up for [the previous related commit](https://github.com/Ralim/IronOS/pull/1866). This change I've tested & double-checked locally with _EN_.