### PR TITLE
Makefile: add S60P to MODELS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ DOCKER_CMD=$(DOCKER_BIN)  -f $(DOCKER_YML)  run  --rm  builder
 MKDOCS_YML=$(CURDIR)/scripts/IronOS-mkdocs.yml
 
 # supported models
-MODELS=TS100 TS80 TS80P Pinecil MHP30 Pinecilv2 S60 TS101 # target names & dir names
+MODELS=TS100 TS80 TS80P Pinecil MHP30 Pinecilv2 S60 TS101 S60P # target names & dir names
 MODELS_ML=Pinecil  Pinecilv2 # target names
 MODELS_MULTILANG=Pinecil_multi-lang  Pinecilv2_multi-lang # dir names
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Tiny update for top-level `Makefile`.

* **What is the current behavior?**
`S60P` is officially supported now but it's missing in top-level `Makefile`.

* **What is the new behavior (if this is a feature change)?**
Now `S60P` is added to top-level `Makefile` so `S60P` target can be used right from the root directory.

* **Other information**:
By the way, much appreciated and deeply honored for _collaborator_ status in this incredible project, being right next to wonderful and amazing people.

P.S. I took some liberty to update and unify labels a bit, hope no one's mind.