### PR TITLE
Localization of `SleepingSimpleString` in Translations

### DIFF
--- a/Translations/translation_BE.json
+++ b/Translations/translation_BE.json
@@ -52,7 +52,7 @@
             "message": "Сілкаванне В: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Чаканне...\n"

--- a/Translations/translation_BG.json
+++ b/Translations/translation_BG.json
@@ -52,7 +52,7 @@
             "message": "Входно V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "Хрр "
         },
         "SleepingAdvancedString": {
             "message": "Сън...\n"

--- a/Translations/translation_CS.json
+++ b/Translations/translation_CS.json
@@ -52,7 +52,7 @@
             "message": "Napětí: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Režim spánku...\n"

--- a/Translations/translation_DA.json
+++ b/Translations/translation_DA.json
@@ -52,7 +52,7 @@
             "message": "Input V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Dvale...\n"

--- a/Translations/translation_DE.json
+++ b/Translations/translation_DE.json
@@ -52,7 +52,7 @@
             "message": "V Eingang: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Ruhemodus...\n"

--- a/Translations/translation_EL.json
+++ b/Translations/translation_EL.json
@@ -52,7 +52,7 @@
             "message": "Είσοδος V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Υπνος...\n"

--- a/Translations/translation_ES.json
+++ b/Translations/translation_ES.json
@@ -52,7 +52,7 @@
             "message": "Voltaje: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "En reposo...\n"

--- a/Translations/translation_ET.json
+++ b/Translations/translation_ET.json
@@ -52,7 +52,7 @@
             "message": "Sisend V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Unerežiim...\n"

--- a/Translations/translation_FI.json
+++ b/Translations/translation_FI.json
@@ -52,7 +52,7 @@
             "message": "Jännite: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Lepotila...\n"

--- a/Translations/translation_FR.json
+++ b/Translations/translation_FR.json
@@ -52,7 +52,7 @@
             "message": "V d'entrée: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "En veille...\n"

--- a/Translations/translation_HR.json
+++ b/Translations/translation_HR.json
@@ -52,7 +52,7 @@
             "message": "Napon V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "SPAVAM...\n"

--- a/Translations/translation_HU.json
+++ b/Translations/translation_HU.json
@@ -52,7 +52,7 @@
             "message": "Bemenet V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Alvás...\n"

--- a/Translations/translation_IT.json
+++ b/Translations/translation_IT.json
@@ -52,7 +52,7 @@
             "message": "V in: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Riposo\n"

--- a/Translations/translation_JA_JP.json
+++ b/Translations/translation_JA_JP.json
@@ -52,7 +52,7 @@
             "message": "Input V: "
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Sleeping..."

--- a/Translations/translation_LT.json
+++ b/Translations/translation_LT.json
@@ -52,7 +52,7 @@
             "message": "Įvestis V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Miegu...\n"

--- a/Translations/translation_NB.json
+++ b/Translations/translation_NB.json
@@ -52,7 +52,7 @@
             "message": "Innspenn.: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Dvale...\n"

--- a/Translations/translation_NL.json
+++ b/Translations/translation_NL.json
@@ -52,7 +52,7 @@
             "message": "Ingangs spanning: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Slaapt...\n"

--- a/Translations/translation_NL_BE.json
+++ b/Translations/translation_NL_BE.json
@@ -52,7 +52,7 @@
             "message": "Voedingsspanning: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Slaapstand...\n"

--- a/Translations/translation_PL.json
+++ b/Translations/translation_PL.json
@@ -52,7 +52,7 @@
             "message": "Nap. wej.: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Tr. uśpienia\n"

--- a/Translations/translation_PT.json
+++ b/Translations/translation_PT.json
@@ -52,7 +52,7 @@
             "message": "Tensão: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Repouso...\n"

--- a/Translations/translation_RO.json
+++ b/Translations/translation_RO.json
@@ -52,7 +52,7 @@
             "message": "Intrare V: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "SLP "
         },
         "SleepingAdvancedString": {
             "message": "Adormit...\n"

--- a/Translations/translation_RU.json
+++ b/Translations/translation_RU.json
@@ -52,7 +52,7 @@
             "message": "Питание(В):\n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "Хрр "
         },
         "SleepingAdvancedString": {
             "message": "Сон...\n"

--- a/Translations/translation_SK.json
+++ b/Translations/translation_SK.json
@@ -52,7 +52,7 @@
             "message": "Vstupné U: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "Chr "
         },
         "SleepingAdvancedString": {
             "message": "Pokojový režim.\n"

--- a/Translations/translation_SR_CYRL.json
+++ b/Translations/translation_SR_CYRL.json
@@ -52,7 +52,7 @@
             "message": "Ул. напон: \n"
         },
         "SleepingSimpleString": {
-            "message": "Zzz "
+            "message": "Сан "
         },
         "SleepingAdvancedString": {
             "message": "Спавање...\n"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Localization of `SleepingSimpleString` in Translations.

* **What is the current behavior?**
`Translation_LANG.json` files has `SleepingSimpleString` set as `Zzz ` universal string.

* **What is the new behavior (if this is a feature change)?**
- for `EN`, traditional `Zzz `;
- for languages, where local version have been added before and if it fits to 3 chars + space, then revert it;
- for other cases set it as `SLP ` as more international (than Zzz, in my opinion), and as indication that it's not localized [yet].

* **Other information**:
Not a big deal but decided to give a second chance to localization of `SleepingSimpleString`, because I think that it's even funny that there may be _"local flavor"_ in that, so to speak. Let me know what you think. :)