### PR TITLE
Add description of fix for around common error under Windows section...

### DIFF
--- a/Documentation/Flashing/TS80(P).md
+++ b/Documentation/Flashing/TS80(P).md
@@ -39,6 +39,8 @@ Officially the bootloader on the devices only works under Windows (use the built
 7. If it didn't work the first time, try copying the file again without disconnecting the device, often it will work on the second shot.
 8. Disconnect the USB and power up the device. You're good to go.
 
+If you get a message when copying: "Are you sure you want to move this file without its properties?" then this can cause an issue where the iron thinks that the file has finished copying before it actually has and can cause a .ERR file. Since this dialog prompt is caused by copying a file from NTFS to FAT (the iron's filesystem) in windows, you can fix this by formatting a thumbdrive as FAT32 and then storing the hex file on that before copying the file to the iron. As there will be no NTFS properties on the file when stored on a FAT32 filesystem, there will be no prompt, and the copy will then proceed normally.
+
 For the more adventurous out there, you can also load this firmware onto the device using an SWD programmer, for easier installation follow the guide at the end of this document.
 
 On the USB port, `USB_D+` is shorted to `SWDIO` and `USB_D-` is shorted to `SWCLK` so debugging works without disassembly (attach while staying in the bootloader). Installing [IronOS-dfu](https://github.com/Ralim/IronOS-dfu) is recommended as it allows reliable flashing of binary files with [dfu-util](http://dfu-util.sourceforge.net/).


### PR DESCRIPTION
...of installation guide

Added a message about how to get around windows dialog prompt that was causing the iron to prematurely reboot before user has a chance to click yes on the prompt to actually begin the copy when copying from NTFS filesystems (Most of what Windows users will be copying from) to the filesystem which the iron uses.

This is an extremely common problem for Windows users, and I'd like to put in a tested workaround in the guide as it would have saved me about 15 minutes on what would have been a 20 second install.

I believe this will be of similar benefit to most Windows users.

* **Please check if the PR fulfills these requirements**
- [X] The changes have been tested locally
- [X] There are no breaking changes

* **What kind of change does this PR introduce?**
Docs update

* **What is the current behavior?**
Using the guide as it was, the iron was prematurely rebooting before I could click the confirmation on the windows dialog to actually begin the copy. 

I have not checked if there is a current open issue. This is something that I experienced personally and (As far as I know) something most Windows users will experience, since it is an issue for all file copies from NTFS to FAT filesystems. Under normal circumstances you can press yes, and the file will copy, the reason this doesn't work for the TS80p is there's some sort of trigger that something is copying that the iron sees and so by the time you press Yes on the dialog, the Iron is already trying to install from a file that hasn't fully copied yes, which disconnects the iron and so the copy cannot take place.

* **What is the new behavior (if this is a feature change)?**
The user can update the Iron to the IronOS firmware properly now with this addendum. 

* **Other information**:
