### PR TITLE
Expand USB-PD mode option

### DIFF
--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -1215,7 +1215,7 @@ def get_translation_strings_and_indices_text(
         translation_indices_text += (
             f"    .{record['id']} = {start_index}, // {escape(lang_data)}\n"
         )
-    
+
     for _, record in enumerate(defs["menuValues"]):
         # Add to translations the menu text and the description
         lang_data = lang["menuValues"][record["id"]]
@@ -1260,7 +1260,7 @@ def get_translation_strings_and_indices_text(
     translation_indices_text = write_grouped_indexes(
         translation_indices_text, "SettingsShortNames", "menuOptions", "displayText"
     )
-  
+
     translation_indices_text = write_grouped_indexes(
         translation_indices_text,
         "SettingsMenuEntriesDescriptions",

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -76,13 +76,13 @@ def filter_translation(lang: dict, defs: dict, macros: frozenset):
 
         return False
 
-    for category in ("menuOptions", "menuGroups"):
-        for index, record in enumerate(defs[category]):
+    for category in ("menuOptions", "menuGroups", "menuValues"):
+        for _, record in enumerate(defs[category]):
             if check_excluded(record):
                 lang[category][record["id"]]["displayText"] = ""
                 lang[category][record["id"]]["description"] = ""
 
-    for index, record in enumerate(defs["messagesWarn"]):
+    for _, record in enumerate(defs["messagesWarn"]):
         if check_excluded(record):
             lang["messagesWarn"][record["id"]]["message"] = ""
 
@@ -248,6 +248,15 @@ def get_letter_counts(defs: dict, lang: dict, build_version: str) -> Dict:
         eid = mod["id"]
         msg = obj[eid]["description"]
         big_font_messages.append(msg)
+
+    obj = lang["menuValues"]
+    for mod in defs["menuValues"]:
+        eid = mod["id"]
+        msg = obj[eid]["displayText"]
+        if test_is_small_font(msg):
+            small_font_messages.append(msg)
+        else:
+            big_font_messages.append(msg)
 
     obj = lang["menuGroups"]
     for mod in defs["menuGroups"]:
@@ -1114,6 +1123,12 @@ def get_translation_strings_and_indices_text(
         encode_string_and_add(
             lang_data["displayText"], "menuOptions" + record["id"] + "displayText"
         )
+    for index, record in enumerate(defs["menuValues"]):
+        lang_data = lang["menuValues"][record["id"]]
+        # Add to translations the menu text and the description
+        encode_string_and_add(
+            lang_data["displayText"], "menuValues" + record["id"] + "displayText"
+        )
 
     for index, record in enumerate(defs["menuGroups"]):
         lang_data = lang["menuGroups"][record["id"]]
@@ -1200,6 +1215,21 @@ def get_translation_strings_and_indices_text(
         translation_indices_text += (
             f"    .{record['id']} = {start_index}, // {escape(lang_data)}\n"
         )
+    
+    for _, record in enumerate(defs["menuValues"]):
+        # Add to translations the menu text and the description
+        lang_data = lang["menuValues"][record["id"]]
+        key = "menuValues" + record["id"] + "displayText"
+        translated_index = translated_string_lookups[key]
+        string_index = translated_index.byte_encoded_translation_index
+        start_index = (
+            string_index_commulative_lengths[string_index]
+            + translated_index.str_start_offset
+        )
+
+        translation_indices_text += (
+            f"    .{record['id']} = {start_index}, // {escape(lang_data)}\n"
+        )
 
     translation_indices_text += "\n"
 
@@ -1230,6 +1260,7 @@ def get_translation_strings_and_indices_text(
     translation_indices_text = write_grouped_indexes(
         translation_indices_text, "SettingsShortNames", "menuOptions", "displayText"
     )
+  
     translation_indices_text = write_grouped_indexes(
         translation_indices_text,
         "SettingsMenuEntriesDescriptions",

--- a/Translations/translation_BE.json
+++ b/Translations/translation_BE.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Крыніца\nсілкавання",
@@ -123,7 +134,7 @@
       "description": "Час чакання ўзгаднення PD з крокам 100 мс для сумяшчальнасці з некаторымі зараднымі зараднымі прыладамі QC (0: адключана)"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "Уключае рэжымы PPS & EPR."
     },
     "BoostTemperature": {

--- a/Translations/translation_BE.json
+++ b/Translations/translation_BE.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "BE",
-    "languageLocalName": "Беларуская",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Каліброўка\nзроблена!"
-        },
-        "ResetOKMessage": {
-            "message": "Скід OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Налады\nзкінуты!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Ня вызначаны\nакселерометр!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "Няма USB-PD IC\nвыяўлены!"
-        },
-        "LockingKeysString": {
-            "message": "ЗАМКНУТЫ"
-        },
-        "UnlockingKeysString": {
-            "message": "АДЫМКНУТЫ"
-        },
-        "WarningKeysLockedString": {
-            "message": "!ЗАМКНУТЫ!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Некантралюемае\nразаграванне"
-        },
-        "WarningTipShorted": {
-            "message": "!Кароткае замыканне на джале!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Пераканайцеся, што пры наступнай загрузцы наканечнік і ручка маюць пакаёвую тэмпературу!"
-        },
-        "CJCCalibrating": {
-            "message": "каліброўка\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Вы ўпэннены, што жадаеце зкінуць налады да першапачатковых значэнняў?"
-        },
-        "UVLOWarningString": {
-            "message": "НАПРУГА--"
-        },
-        "UndervoltageString": {
-            "message": "Нізкая напруга\n"
-        },
-        "InputVoltageString": {
-            "message": "Сілкаванне В: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Чаканне...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Джала: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Разагрэць\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Астудзіць\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Ваша прылада, хутчэй за ўсё, падробка!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Занадта горача\nкаб запусціць профіль"
-        }
+  "languageCode": "BE",
+  "languageLocalName": "Беларуская",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Каліброўка\nзроблена!"
     },
-    "characters": {
-        "SettingRightChar": "П",
-        "SettingLeftChar": "Л",
-        "SettingAutoChar": "А",
-        "SettingSlowChar": "М",
-        "SettingMediumChar": "С",
-        "SettingFastChar": "Х",
-        "SettingStartSolderingChar": "П",
-        "SettingStartSleepChar": "Ч",
-        "SettingStartSleepOffChar": "К",
-        "SettingLockBoostChar": "Т",
-        "SettingLockFullChar": "П"
+    "ResetOKMessage": {
+      "message": "Скід OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Налады\nсілкавання",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Налады\nпайкі",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Рэжымы\nсну",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Налады\nінтэрфейсу",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Дадатковыя\nналады",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Налады\nзкінуты!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Крыніца\nсілкавання",
-            "description": "Крыніца сілкавання. Усталюе напругу адсечкі. (DC 10В) (S 3,3В на ячэйку, без абмежавання магутнасці)"
-        },
-        "MinVolCell": {
-            "displayText": "Мін.\nнапр.",
-            "description": "Мінімальная дазволеная напруга на ячэйку (3S: 3 - 3,7V | 4S: 2,4 - 3,7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Магутнасць\nсілкавання",
-            "description": "Магутнасць выкарыстоўваемай крыніцы сілкавання"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\nпрыпынак",
-            "description": "Час чакання ўзгаднення PD з крокам 100 мс для сумяшчальнасці з некаторымі зараднымі зараднымі прыладамі QC (0: адключана)"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Уключае рэжымы PPS & EPR."
-        },
-        "BoostTemperature": {
-            "displayText": "t° турба\nрэжыму",
-            "description": "Тэмпература джала ў турба-рэжыме"
-        },
-        "AutoStart": {
-            "displayText": "Аўта\nстарт",
-            "description": "Рэжым, у якім запускаецца паяльнік пры падачы сілкавання (П=Пайка | Ч=Чаканне | К=Чаканне пры комн. тэмп.)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Крок тэмп.\nкар. нац.",
-            "description": "Крок вымярэння тэмпературы пры кароткім націску кнопак"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Крок тэмп.\nпад. нац.",
-            "description": "Крок вымярэння тэмпературы пры падоўжаным націску кнопак"
-        },
-        "LockingMode": {
-            "displayText": "Дазволіць\nблок. кнопак",
-            "description": "Пры рабоце падоўжаны націск дзьвух кнопак блакуе іх (Т=Толькі турба | П=Поўная блакіроўка)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Колькасць фаз у рэжыме профілю"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat\nTemp",
-            "description": "Разагрэйце да гэтай тэмпературы ў пачатку профільнага рэжыму"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat\nSpeed",
-            "description": "Разагрэйце з гэтай хуткасцю (градусы ў секунду)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemp",
-            "description": "Мэтавая тэмпература ў канцы гэтай фазы"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDuration",
-            "description": "Мэтавая працягласць гэтай фазы (секунды)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDuration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDuration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDuration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDuration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown\nSpeed",
-            "description": "Астуджаць з гэтай хуткасцю ў канцы профільнага рэжыму (градусы ў секунду)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Адчувальнасць\nакселерометра",
-            "description": "Адчувальнасць акселерометра (1=Мін. | ... | 9=Макс.)"
-        },
-        "SleepTemperature": {
-            "displayText": "Тэмп.\nчакання",
-            "description": "Тэмпература рэжыму чакання"
-        },
-        "SleepTimeout": {
-            "displayText": "Таймаўт\nчакання",
-            "description": "Час да пераходу ў рэжым чакання (Хвіліны | Секунды)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Таймаут\nвыключэння",
-            "description": "Час да адключэння паяльніка (Хвіліны)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Эфект Хола\nадчувальнасць",
-            "description": "Узровень адчувальнасці датчыка хола ў рэжыме сну (1=Мін. | ... | 9=Макс.)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Адзінкі\nтэмпературы",
-            "description": "Адзінкі вымярэння тэмпературы (C=Цэльcія | F=Фарэнгейта)"
-        },
-        "DisplayRotation": {
-            "displayText": "Арыентацыя\nэкрану",
-            "description": "Арыентацыя экрану (П=Правая рука | Л=Левая рука | А=Аўта)"
-        },
-        "CooldownBlink": {
-            "displayText": "Мігценне t°\nпры астуджэнні",
-            "description": "Міргаць тэмпературай на экране астуджэння, пакуль джала яшчэ гарачае"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Хуткацсь\nтексту",
-            "description": "Хуткасць гартання тэксту (М=марудна | Х=хутка)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Інвертаваць\nкнопкі",
-            "description": "Інвертаваць кнопкі вымярэння тэмпературы"
-        },
-        "AnimSpeed": {
-            "displayText": "Хуткасць\nанімацыі",
-            "description": "Хуткасць анімацыі гузікаў у галоўным меню (Мілісекунды) (Н=Нізкая | С=Сярэдняя | В=Высокая)"
-        },
-        "AnimLoop": {
-            "displayText": "Зацыкленая\nанімацыя",
-            "description": "Зацыкленая анімацыя гузікаў у галоўным меню"
-        },
-        "Brightness": {
-            "displayText": "Экран\nЯркасць",
-            "description": "Адрэгулюйце кантраснасць / яркасць OLED-экрана"
-        },
-        "ColourInversion": {
-            "displayText": "Экран\nІнвертаваць",
-            "description": "Інвертаваць колеры OLED-экрана"
-        },
-        "LOGOTime": {
-            "displayText": "Лагатып загрузкі\nпрацягласць",
-            "description": "Усталяваць працягласць лагатыпа загрузкі (s=Секунды)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Падрабязны\nрэжым чакання",
-            "description": "Адлюстроўваць дэталёвую инфармацыю паменьшаным шрыфтом на экране чакання"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Падрабязны\nэкран пайкі",
-            "description": "Паказваць дэталёвую інформацыю на экране пайкі"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Уключыць BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Межы\nмагутнасці",
-            "description": "Максімальная магутнасць, якую можа выкарыстоўваць паяльнік (Ватт)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Каліброўка тэмпературы\nпры наступнай загрузцы",
-            "description": "Каліброўка тэмпературы пры наступным уключэнні (не патрабуецца, калі розніца тэмператур меньш за 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Каліброўка\nнапругі",
-            "description": "Каліброўка ўваходнай напругі (падоўжаны націск для выхаду)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Сіла імп.\nсілкав. Вт",
-            "description": "Моц імпульса ўтрымливаючага ад сну павербанку ці іншай крыніцы сілкавання"
-        },
-        "PowerPulseWait": {
-            "displayText": "Імпульс магутнасці\nчас чакання",
-            "description": "Час чакання перад запускам кожнага імпульсу няспання (x 2.5 с)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Імпульс магутнасці\nпрацягласць",
-            "description": "Працягласць імпульсу няспання (x 250 мс)"
-        },
-        "SettingsReset": {
-            "displayText": "Скід\nналадаў",
-            "description": "Скід наладаў да першапачатковых значэнняў"
-        },
-        "LanguageSwitch": {
-            "displayText": "Мова:\n BY  Беларуская",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Ня вызначаны\nакселерометр!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "Няма USB-PD IC\nвыяўлены!"
+    },
+    "LockingKeysString": {
+      "message": "ЗАМКНУТЫ"
+    },
+    "UnlockingKeysString": {
+      "message": "АДЫМКНУТЫ"
+    },
+    "WarningKeysLockedString": {
+      "message": "!ЗАМКНУТЫ!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Некантралюемае\nразаграванне"
+    },
+    "WarningTipShorted": {
+      "message": "!Кароткае замыканне на джале!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Пераканайцеся, што пры наступнай загрузцы наканечнік і ручка маюць пакаёвую тэмпературу!"
+    },
+    "CJCCalibrating": {
+      "message": "каліброўка\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Вы ўпэннены, што жадаеце зкінуць налады да першапачатковых значэнняў?"
+    },
+    "UVLOWarningString": {
+      "message": "НАПРУГА--"
+    },
+    "UndervoltageString": {
+      "message": "Нізкая напруга\n"
+    },
+    "InputVoltageString": {
+      "message": "Сілкаванне В: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Чаканне...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Джала: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Разагрэць\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Астудзіць\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Ваша прылада, хутчэй за ўсё, падробка!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Занадта горача\nкаб запусціць профіль"
     }
+  },
+  "characters": {
+    "SettingRightChar": "П",
+    "SettingLeftChar": "Л",
+    "SettingAutoChar": "А",
+    "SettingSlowChar": "М",
+    "SettingMediumChar": "С",
+    "SettingFastChar": "Х",
+    "SettingStartSolderingChar": "П",
+    "SettingStartSleepChar": "Ч",
+    "SettingStartSleepOffChar": "К",
+    "SettingLockBoostChar": "Т",
+    "SettingLockFullChar": "П"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Налады\nсілкавання",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Налады\nпайкі",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Рэжымы\nсну",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Налады\nінтэрфейсу",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Дадатковыя\nналады",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Крыніца\nсілкавання",
+      "description": "Крыніца сілкавання. Усталюе напругу адсечкі. (DC 10В) (S 3,3В на ячэйку, без абмежавання магутнасці)"
+    },
+    "MinVolCell": {
+      "displayText": "Мін.\nнапр.",
+      "description": "Мінімальная дазволеная напруга на ячэйку (3S: 3 - 3,7V | 4S: 2,4 - 3,7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Магутнасць\nсілкавання",
+      "description": "Магутнасць выкарыстоўваемай крыніцы сілкавання"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\nпрыпынак",
+      "description": "Час чакання ўзгаднення PD з крокам 100 мс для сумяшчальнасці з некаторымі зараднымі зараднымі прыладамі QC (0: адключана)"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Уключае рэжымы PPS & EPR."
+    },
+    "BoostTemperature": {
+      "displayText": "t° турба\nрэжыму",
+      "description": "Тэмпература джала ў турба-рэжыме"
+    },
+    "AutoStart": {
+      "displayText": "Аўта\nстарт",
+      "description": "Рэжым, у якім запускаецца паяльнік пры падачы сілкавання (П=Пайка | Ч=Чаканне | К=Чаканне пры комн. тэмп.)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Крок тэмп.\nкар. нац.",
+      "description": "Крок вымярэння тэмпературы пры кароткім націску кнопак"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Крок тэмп.\nпад. нац.",
+      "description": "Крок вымярэння тэмпературы пры падоўжаным націску кнопак"
+    },
+    "LockingMode": {
+      "displayText": "Дазволіць\nблок. кнопак",
+      "description": "Пры рабоце падоўжаны націск дзьвух кнопак блакуе іх (Т=Толькі турба | П=Поўная блакіроўка)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Колькасць фаз у рэжыме профілю"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat\nTemp",
+      "description": "Разагрэйце да гэтай тэмпературы ў пачатку профільнага рэжыму"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat\nSpeed",
+      "description": "Разагрэйце з гэтай хуткасцю (градусы ў секунду)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemp",
+      "description": "Мэтавая тэмпература ў канцы гэтай фазы"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDuration",
+      "description": "Мэтавая працягласць гэтай фазы (секунды)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDuration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDuration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDuration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDuration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown\nSpeed",
+      "description": "Астуджаць з гэтай хуткасцю ў канцы профільнага рэжыму (градусы ў секунду)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Адчувальнасць\nакселерометра",
+      "description": "Адчувальнасць акселерометра (1=Мін. | ... | 9=Макс.)"
+    },
+    "SleepTemperature": {
+      "displayText": "Тэмп.\nчакання",
+      "description": "Тэмпература рэжыму чакання"
+    },
+    "SleepTimeout": {
+      "displayText": "Таймаўт\nчакання",
+      "description": "Час да пераходу ў рэжым чакання (Хвіліны | Секунды)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Таймаут\nвыключэння",
+      "description": "Час да адключэння паяльніка (Хвіліны)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Эфект Хола\nадчувальнасць",
+      "description": "Узровень адчувальнасці датчыка хола ў рэжыме сну (1=Мін. | ... | 9=Макс.)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Адзінкі\nтэмпературы",
+      "description": "Адзінкі вымярэння тэмпературы (C=Цэльcія | F=Фарэнгейта)"
+    },
+    "DisplayRotation": {
+      "displayText": "Арыентацыя\nэкрану",
+      "description": "Арыентацыя экрану (П=Правая рука | Л=Левая рука | А=Аўта)"
+    },
+    "CooldownBlink": {
+      "displayText": "Мігценне t°\nпры астуджэнні",
+      "description": "Міргаць тэмпературай на экране астуджэння, пакуль джала яшчэ гарачае"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Хуткацсь\nтексту",
+      "description": "Хуткасць гартання тэксту (М=марудна | Х=хутка)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Інвертаваць\nкнопкі",
+      "description": "Інвертаваць кнопкі вымярэння тэмпературы"
+    },
+    "AnimSpeed": {
+      "displayText": "Хуткасць\nанімацыі",
+      "description": "Хуткасць анімацыі гузікаў у галоўным меню (Мілісекунды) (Н=Нізкая | С=Сярэдняя | В=Высокая)"
+    },
+    "AnimLoop": {
+      "displayText": "Зацыкленая\nанімацыя",
+      "description": "Зацыкленая анімацыя гузікаў у галоўным меню"
+    },
+    "Brightness": {
+      "displayText": "Экран\nЯркасць",
+      "description": "Адрэгулюйце кантраснасць / яркасць OLED-экрана"
+    },
+    "ColourInversion": {
+      "displayText": "Экран\nІнвертаваць",
+      "description": "Інвертаваць колеры OLED-экрана"
+    },
+    "LOGOTime": {
+      "displayText": "Лагатып загрузкі\nпрацягласць",
+      "description": "Усталяваць працягласць лагатыпа загрузкі (s=Секунды)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Падрабязны\nрэжым чакання",
+      "description": "Адлюстроўваць дэталёвую инфармацыю паменьшаным шрыфтом на экране чакання"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Падрабязны\nэкран пайкі",
+      "description": "Паказваць дэталёвую інформацыю на экране пайкі"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Уключыць BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Межы\nмагутнасці",
+      "description": "Максімальная магутнасць, якую можа выкарыстоўваць паяльнік (Ватт)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Каліброўка тэмпературы\nпры наступнай загрузцы",
+      "description": "Каліброўка тэмпературы пры наступным уключэнні (не патрабуецца, калі розніца тэмператур меньш за 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Каліброўка\nнапругі",
+      "description": "Каліброўка ўваходнай напругі (падоўжаны націск для выхаду)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Сіла імп.\nсілкав. Вт",
+      "description": "Моц імпульса ўтрымливаючага ад сну павербанку ці іншай крыніцы сілкавання"
+    },
+    "PowerPulseWait": {
+      "displayText": "Імпульс магутнасці\nчас чакання",
+      "description": "Час чакання перад запускам кожнага імпульсу няспання (x 2.5 с)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Імпульс магутнасці\nпрацягласць",
+      "description": "Працягласць імпульсу няспання (x 250 мс)"
+    },
+    "SettingsReset": {
+      "displayText": "Скід\nналадаў",
+      "description": "Скід наладаў да першапачатковых значэнняў"
+    },
+    "LanguageSwitch": {
+      "displayText": "Мова:\n BY  Беларуская",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_BG.json
+++ b/Translations/translation_BG.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Гранично\nнапрежение",
@@ -123,7 +134,7 @@
       "description": "PD интервал за договаряне на захранването на стъпки от 100 мс за съвместимост с някои QC захранвания (0=Изкл.)"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "Включи PPS & EPR"
     },
     "BoostTemperature": {

--- a/Translations/translation_BG.json
+++ b/Translations/translation_BG.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "BG",
-    "languageLocalName": "Български",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Калибрирането\nе завършено!"
-        },
-        "ResetOKMessage": {
-            "message": "Нулиране"
-        },
-        "SettingsResetMessage": {
-            "message": "Настройките бяха\nнулирани!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Не е открит\nакселерометър!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "Не е открито\nUSB-PD захранване!"
-        },
-        "LockingKeysString": {
-            "message": "ЗАКЛЮЧ"
-        },
-        "UnlockingKeysString": {
-            "message": "ОТКЛЮЧ"
-        },
-        "WarningKeysLockedString": {
-            "message": "!ЗАКЛЮЧ!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Неконтролируемо\nпрегряване"
-        },
-        "WarningTipShorted": {
-            "message": "!КС на човка!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Преди рестартиране се уверете, че човка и дръжката са на стайна температурата!"
-        },
-        "CJCCalibrating": {
-            "message": "калибриране\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Сигурни ли сте, че искате да върнете фабричните настройки?"
-        },
-        "UVLOWarningString": {
-            "message": "НИС.НАПР."
-        },
-        "UndervoltageString": {
-            "message": "Ниско напрежение\n"
-        },
-        "InputVoltageString": {
-            "message": "Входно V: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Сън...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Човка:\n"
-        },
-        "ProfilePreheatString": {
-            "message": "Загряване\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Охлаждане\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Вероятно, устройство е фалшификат!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Твърде горещо за\nстартиране на профила"
-        }
+  "languageCode": "BG",
+  "languageLocalName": "Български",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Калибрирането\nе завършено!"
     },
-    "characters": {
-        "SettingRightChar": "Д",
-        "SettingLeftChar": "Л",
-        "SettingAutoChar": "А",
-        "SettingSlowChar": "Н",
-        "SettingMediumChar": "С",
-        "SettingFastChar": "В",
-        "SettingStartSolderingChar": "З",
-        "SettingStartSleepChar": "С",
-        "SettingStartSleepOffChar": "П",
-        "SettingLockBoostChar": "Т",
-        "SettingLockFullChar": "П"
+    "ResetOKMessage": {
+      "message": "Нулиране"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Настройки на\nзахранването",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Настройки на\nзапояване",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Авто\nизключване",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Интерфейс\n",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Допълнителни\nнастройки",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Настройките бяха\nнулирани!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Гранично\nнапрежение",
-            "description": "Минимално напрежение, за да не се изтощи батерията (DC 10V) (S 3,3V за клетка)"
-        },
-        "MinVolCell": {
-            "displayText": "Мин.\nнапрежение",
-            "description": "Минимално допустимо напрежение на акумулаторна клетка (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Напреж.\nна QC",
-            "description": "Максимална напрежение с QC захранвания"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\nинтервал",
-            "description": "PD интервал за договаряне на захранването на стъпки от 100 мс за съвместимост с някои QC захранвания (0=Изкл.)"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Включи PPS & EPR"
-        },
-        "BoostTemperature": {
-            "displayText": "Турбо\nтемп.",
-            "description": "Температурата за \"турбо\" режим"
-        },
-        "AutoStart": {
-            "displayText": "Автоматичен\nработен режим",
-            "description": "Режим на поялника при включване на захранването (З=Запояване | С=Сън | П=Покой на стайна температурата)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Промяна T\nбързо",
-            "description": "Промяна на температурата при бързо натискане на бутон"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Промяна Т\nзадържане",
-            "description": "Промяна на температурата при задържане на бутон"
-        },
-        "LockingMode": {
-            "displayText": "Бутони за\nзаключване",
-            "description": "Докато запоявате, задръжте двата бутона, за да превключите заключването им (Т=Турбо режим | П=Пълно)"
-        },
-        "ProfilePhases": {
-            "displayText": "Брой\nетапи",
-            "description": "Броят на етапите в режим на термичен профил"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Температурата\nна загряване",
-            "description": "Температурата на загряване в началото на режим на термичен профил"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Скорост на\nзагряване",
-            "description": "Скорост на предварително загряване (градуси в секунда)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Етап 1\nТемпературата",
-            "description": "Температурата в края на този етап"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Етап 1\nПродължителност",
-            "description": "Продължителност на този етап (в секунди)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Етап 2\nТемпературата",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Етап 2\nПродължителност",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Етап 3\nТемпературата",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Етап 3\nПродължителност",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Етап 4\nТемпературата",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Етап 4\nПродължителност",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Етап 5\nТемпературата",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Етап 5\nПродължителност",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Скорост на\nохлаждане",
-            "description": "Скорост на охлаждане в края на режим на термичен профил (градуси в секунда)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Чувствител.\nна движение",
-            "description": "Чувствителност на движение на акселерометър (1=Слабо | ... | 9=Силно)"
-        },
-        "SleepTemperature": {
-            "displayText": "Темп.\nсън",
-            "description": "Температурата при режим \"сън\""
-        },
-        "SleepTimeout": {
-            "displayText": "Време\nсън",
-            "description": "Включване в режим \"сън\" (секунди | минути)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Време\nизкл.",
-            "description": "Изключване след (минути)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Датчик\nна Хол",
-            "description": "Чувствителност на сензора към магнитно поле (1=Слабо | ... | 9=Силно)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Единици за\nтемпературата",
-            "description": "Единици за температурата (C=Целзии | F=Фаренхайт)"
-        },
-        "DisplayRotation": {
-            "displayText": "Ориентация\nна дисплея",
-            "description": "Ориентация на дисплея (Д=Дясна ръка | Л=Лява ръка | А=Авто)"
-        },
-        "CooldownBlink": {
-            "displayText": "Мигай при\nтопъл поялник",
-            "description": "След изключване от работен режим, индикатора за температурата да мига докато човката на поялника все още е топла"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Скорост\nна текста",
-            "description": "Скорост на движение на този текст (Н=Ниска | B=Висока)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Размяна\nбутони +/-",
-            "description": "Обръщане на бутоните + и - за промяна на температурата на човка на поялника"
-        },
-        "AnimSpeed": {
-            "displayText": "Скорост на\nанимацията",
-            "description": "Скорост на анимация на иконата в главното меню (Н=Ниска | C=Средна | B=Висока)"
-        },
-        "AnimLoop": {
-            "displayText": "Анимац.\nцикъл",
-            "description": "Зациклена анимация на иконите в главното меню"
-        },
-        "Brightness": {
-            "displayText": "Яркост\nна екрана",
-            "description": "Регулирайте яркостта на екрана"
-        },
-        "ColourInversion": {
-            "displayText": "Инвертиране\nна екрана",
-            "description": "Инверсия на пикселите на екрана"
-        },
-        "LOGOTime": {
-            "displayText": "Продължит.\nлогото",
-            "description": "Продължителност на логото за стартиране (в секунди)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Детайлен\nекран в покой",
-            "description": "Покажи детайлна информация със ситен шрифт на екрана в режим на покой"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Детайлен\nработен екран",
-            "description": "Детайлна информация в работен режим при запояване"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Включи BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Лимит на\nмощност",
-            "description": "Максимална мощност на поялника (вати)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Калибриране\nна темп.",
-            "description": "Калибриране на температурата (CJC) при следващо включване (не се изисква, ако разликата е по-малка от 5 °С)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Калибриране\nнапрежение",
-            "description": "Калибриране на входното напрежение (задръжте бутонa за изход)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Захранващ\nимпулс",
-            "description": "Поддържане на интензивност на захранващия импулс (вати)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Закъснение\nна импулса",
-            "description": "Пауза между импулсите, които предпазват захранването от автоматично изключване (x 2,5 с)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Продължит.\nна импулса",
-            "description": "Дължината на импулса, който предпазва захранването от автоматично изключване (x 250 мс)"
-        },
-        "SettingsReset": {
-            "displayText": "Фабрични\nнастройки",
-            "description": "Връщане на фабрични настройки"
-        },
-        "LanguageSwitch": {
-            "displayText": "Език:\n BG   Български",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Не е открит\nакселерометър!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "Не е открито\nUSB-PD захранване!"
+    },
+    "LockingKeysString": {
+      "message": "ЗАКЛЮЧ"
+    },
+    "UnlockingKeysString": {
+      "message": "ОТКЛЮЧ"
+    },
+    "WarningKeysLockedString": {
+      "message": "!ЗАКЛЮЧ!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Неконтролируемо\nпрегряване"
+    },
+    "WarningTipShorted": {
+      "message": "!КС на човка!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Преди рестартиране се уверете, че човка и дръжката са на стайна температурата!"
+    },
+    "CJCCalibrating": {
+      "message": "калибриране\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Сигурни ли сте, че искате да върнете фабричните настройки?"
+    },
+    "UVLOWarningString": {
+      "message": "НИС.НАПР."
+    },
+    "UndervoltageString": {
+      "message": "Ниско напрежение\n"
+    },
+    "InputVoltageString": {
+      "message": "Входно V: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Сън...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Човка:\n"
+    },
+    "ProfilePreheatString": {
+      "message": "Загряване\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Охлаждане\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Вероятно, устройство е фалшификат!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Твърде горещо за\nстартиране на профила"
     }
+  },
+  "characters": {
+    "SettingRightChar": "Д",
+    "SettingLeftChar": "Л",
+    "SettingAutoChar": "А",
+    "SettingSlowChar": "Н",
+    "SettingMediumChar": "С",
+    "SettingFastChar": "В",
+    "SettingStartSolderingChar": "З",
+    "SettingStartSleepChar": "С",
+    "SettingStartSleepOffChar": "П",
+    "SettingLockBoostChar": "Т",
+    "SettingLockFullChar": "П"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Настройки на\nзахранването",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Настройки на\nзапояване",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Авто\nизключване",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Интерфейс\n",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Допълнителни\nнастройки",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Гранично\nнапрежение",
+      "description": "Минимално напрежение, за да не се изтощи батерията (DC 10V) (S 3,3V за клетка)"
+    },
+    "MinVolCell": {
+      "displayText": "Мин.\nнапрежение",
+      "description": "Минимално допустимо напрежение на акумулаторна клетка (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Напреж.\nна QC",
+      "description": "Максимална напрежение с QC захранвания"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\nинтервал",
+      "description": "PD интервал за договаряне на захранването на стъпки от 100 мс за съвместимост с някои QC захранвания (0=Изкл.)"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Включи PPS & EPR"
+    },
+    "BoostTemperature": {
+      "displayText": "Турбо\nтемп.",
+      "description": "Температурата за \"турбо\" режим"
+    },
+    "AutoStart": {
+      "displayText": "Автоматичен\nработен режим",
+      "description": "Режим на поялника при включване на захранването (З=Запояване | С=Сън | П=Покой на стайна температурата)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Промяна T\nбързо",
+      "description": "Промяна на температурата при бързо натискане на бутон"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Промяна Т\nзадържане",
+      "description": "Промяна на температурата при задържане на бутон"
+    },
+    "LockingMode": {
+      "displayText": "Бутони за\nзаключване",
+      "description": "Докато запоявате, задръжте двата бутона, за да превключите заключването им (Т=Турбо режим | П=Пълно)"
+    },
+    "ProfilePhases": {
+      "displayText": "Брой\nетапи",
+      "description": "Броят на етапите в режим на термичен профил"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Температурата\nна загряване",
+      "description": "Температурата на загряване в началото на режим на термичен профил"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Скорост на\nзагряване",
+      "description": "Скорост на предварително загряване (градуси в секунда)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Етап 1\nТемпературата",
+      "description": "Температурата в края на този етап"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Етап 1\nПродължителност",
+      "description": "Продължителност на този етап (в секунди)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Етап 2\nТемпературата",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Етап 2\nПродължителност",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Етап 3\nТемпературата",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Етап 3\nПродължителност",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Етап 4\nТемпературата",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Етап 4\nПродължителност",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Етап 5\nТемпературата",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Етап 5\nПродължителност",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Скорост на\nохлаждане",
+      "description": "Скорост на охлаждане в края на режим на термичен профил (градуси в секунда)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Чувствител.\nна движение",
+      "description": "Чувствителност на движение на акселерометър (1=Слабо | ... | 9=Силно)"
+    },
+    "SleepTemperature": {
+      "displayText": "Темп.\nсън",
+      "description": "Температурата при режим \"сън\""
+    },
+    "SleepTimeout": {
+      "displayText": "Време\nсън",
+      "description": "Включване в режим \"сън\" (секунди | минути)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Време\nизкл.",
+      "description": "Изключване след (минути)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Датчик\nна Хол",
+      "description": "Чувствителност на сензора към магнитно поле (1=Слабо | ... | 9=Силно)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Единици за\nтемпературата",
+      "description": "Единици за температурата (C=Целзии | F=Фаренхайт)"
+    },
+    "DisplayRotation": {
+      "displayText": "Ориентация\nна дисплея",
+      "description": "Ориентация на дисплея (Д=Дясна ръка | Л=Лява ръка | А=Авто)"
+    },
+    "CooldownBlink": {
+      "displayText": "Мигай при\nтопъл поялник",
+      "description": "След изключване от работен режим, индикатора за температурата да мига докато човката на поялника все още е топла"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Скорост\nна текста",
+      "description": "Скорост на движение на този текст (Н=Ниска | B=Висока)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Размяна\nбутони +/-",
+      "description": "Обръщане на бутоните + и - за промяна на температурата на човка на поялника"
+    },
+    "AnimSpeed": {
+      "displayText": "Скорост на\nанимацията",
+      "description": "Скорост на анимация на иконата в главното меню (Н=Ниска | C=Средна | B=Висока)"
+    },
+    "AnimLoop": {
+      "displayText": "Анимац.\nцикъл",
+      "description": "Зациклена анимация на иконите в главното меню"
+    },
+    "Brightness": {
+      "displayText": "Яркост\nна екрана",
+      "description": "Регулирайте яркостта на екрана"
+    },
+    "ColourInversion": {
+      "displayText": "Инвертиране\nна екрана",
+      "description": "Инверсия на пикселите на екрана"
+    },
+    "LOGOTime": {
+      "displayText": "Продължит.\nлогото",
+      "description": "Продължителност на логото за стартиране (в секунди)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Детайлен\nекран в покой",
+      "description": "Покажи детайлна информация със ситен шрифт на екрана в режим на покой"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Детайлен\nработен екран",
+      "description": "Детайлна информация в работен режим при запояване"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Включи BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Лимит на\nмощност",
+      "description": "Максимална мощност на поялника (вати)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Калибриране\nна темп.",
+      "description": "Калибриране на температурата (CJC) при следващо включване (не се изисква, ако разликата е по-малка от 5 °С)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Калибриране\nнапрежение",
+      "description": "Калибриране на входното напрежение (задръжте бутонa за изход)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Захранващ\nимпулс",
+      "description": "Поддържане на интензивност на захранващия импулс (вати)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Закъснение\nна импулса",
+      "description": "Пауза между импулсите, които предпазват захранването от автоматично изключване (x 2,5 с)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Продължит.\nна импулса",
+      "description": "Дължината на импулса, който предпазва захранването от автоматично изключване (x 250 мс)"
+    },
+    "SettingsReset": {
+      "displayText": "Фабрични\nнастройки",
+      "description": "Връщане на фабрични настройки"
+    },
+    "LanguageSwitch": {
+      "displayText": "Език:\n BG   Български",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_CS.json
+++ b/Translations/translation_CS.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "CS",
-    "languageLocalName": "Český",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Kalibrace\ndokončena!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Nějaká nastavení\nbyla změněna!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Akcelerometr\nnebyl detekován!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "Žádný IO USB-PD\nnebyl detekován!"
-        },
-        "LockingKeysString": {
-            "message": "ZAMČENO"
-        },
-        "UnlockingKeysString": {
-            "message": "ODEMČENO"
-        },
-        "WarningKeysLockedString": {
-            "message": "ZAMČENO!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Teplotní\nOchrana"
-        },
-        "WarningTipShorted": {
-            "message": "!Zkrat na hrotu!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Před restartem se ujistěte, že hrot a držák mají pokojovou teplotu!"
-        },
-        "CJCCalibrating": {
-            "message": "kalibrování\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Opravdu chcete resetovat zařízení do továrního nastavení?"
-        },
-        "UVLOWarningString": {
-            "message": "Nízké DC"
-        },
-        "UndervoltageString": {
-            "message": "Nízké napětí\n"
-        },
-        "InputVoltageString": {
-            "message": "Napětí: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Režim spánku...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Hrot: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Předehřívání\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Zchlazování\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Vaše zařízení je pravěpodobně padělek!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Teplota příliš vysoká pro start profilu"
-        }
+  "languageCode": "CS",
+  "languageLocalName": "Český",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Kalibrace\ndokončena!"
     },
-    "characters": {
-        "SettingRightChar": "P",
-        "SettingLeftChar": "L",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "P",
-        "SettingMediumChar": "S",
-        "SettingFastChar": "R",
-        "SettingStartSolderingChar": "P",
-        "SettingStartSleepChar": "S",
-        "SettingStartSleepOffChar": "M",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "U"
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Napájecí\nnastavení",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Pájecí\nnastavení",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Režim\nspánku",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Uživatelské\nrozhraní",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Pokročilá\nnastavení",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Nějaká nastavení\nbyla změněna!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Zdroj\nnapájení",
-            "description": "Při nižším napětí ukončit pájení (DC 10V)  (S 3,3V na článek, zakázat omezení napájení)."
-        },
-        "MinVolCell": {
-            "displayText": "Minimální\nnapětí",
-            "description": "Minimální dovolené napětí po článku (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Napětí\nQC",
-            "description": "Maximální napětí QC pro jednání páječkou"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\ntimeout",
-            "description": "Maximální prodleva při jednání PD ve 100ms krocích pro kompatibilitu s některými QC nabíječkami"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Povoluje režimy PPS & EPR"
-        },
-        "BoostTemperature": {
-            "displayText": "Teplota\nboostu",
-            "description": "Teplota hrotu v \"režimu boost\""
-        },
-        "AutoStart": {
-            "displayText": "Chování\npři startu",
-            "description": "P=pájecí teplota | S=spánková teplota | M=zahřát hrot po pohybu"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Krok teploty\nkrátký?",
-            "description": "Velikost přídavku při změně teploty krátkým stiskem tlačítka"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Krok teploty\ndlouhý?",
-            "description": "Velikost přídavku při změně teploty dlouhým stiskem tlačítka"
-        },
-        "LockingMode": {
-            "displayText": "Povolit zamč.\ntlačítek",
-            "description": "Při pájení podržte obě tlačítka pro jejich zamčení (B=pouze v režimu boost | U=úplné zamčení)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profilové\nFáze",
-            "description": "Počet fází v profilovém režimu"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Teplota\nPředehřátí",
-            "description": "Teplota na kterou předehřát na začátku profilového režimu"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Rychlost\nPředehřívání",
-            "description": "Rychlost předehřívání (stupně za sekundu)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Teplota\nFáze 1",
-            "description": "Cílová teplota na konci této fáze"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Trvání\nFáze 1",
-            "description": "Doba trvání této fáze (sekundy)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Teplota\nFáze 2",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Trvání\nFáze 2",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Teplota\nFáze 3",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Trvání\nFáze 3",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Teplota\nFáze 4",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Trvání\nFáze 4",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Teplota\nFáze 5",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Trvání\nFáze 5",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Rychlost\nochlazování",
-            "description": "Rychlost ochlazování na konci profilového režimu (stupně za sekundu)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Citlivost\nna pohyb",
-            "description": "1=nejméně citlivé | ... | 9=nejvíce citlivé"
-        },
-        "SleepTemperature": {
-            "displayText": "Teplota\nve spánku",
-            "description": "Teplota hrotu v režimu spánku."
-        },
-        "SleepTimeout": {
-            "displayText": "Čas\ndo spánku",
-            "description": "\"Režim spánku\" naběhne v (s=sekundách | m=minutách)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Čas do\nvypnutí",
-            "description": "Interval automatického vypnutí (m=minut)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Citlivost\nHall. čidla",
-            "description": "Citlivost Hallova čidla pro detekci spánku (1=nejméně citlivé | ... | 9=nejvíce citlivé)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Jednotka\nteploty",
-            "description": "C=Celsius | F=Fahrenheit"
-        },
-        "DisplayRotation": {
-            "displayText": "Orientace\nobrazovky",
-            "description": "P=pravák | L=levák | A=automaticky"
-        },
-        "CooldownBlink": {
-            "displayText": "Blikáni při\nchladnutí",
-            "description": "Blikat teplotou při chladnutí dokud je hrot horký"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Rychlost\nposouvání",
-            "description": "Rychlost posouvání popisků podobných tomuto (P=pomalu | R=rychle)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Prohodit\ntl. +-?",
-            "description": "Prohodit tlačítka pro změnu teploty"
-        },
-        "AnimSpeed": {
-            "displayText": "Anim.\nrychlost",
-            "description": "Tempo animace ikon v menu (P=pomalu | S=středně | R=rychle)"
-        },
-        "AnimLoop": {
-            "displayText": "Anim.\nsmyčka",
-            "description": "Animovat ikony hlavního menu ve smyčce"
-        },
-        "Brightness": {
-            "displayText": "Jas\nobrazovky",
-            "description": "Upravit jas OLED"
-        },
-        "ColourInversion": {
-            "displayText": "Invertovat\nobrazovku",
-            "description": "Invertovat barvy na OLED"
-        },
-        "LOGOTime": {
-            "displayText": "Trvání\nboot loga",
-            "description": "Nastavení doby trvání boot loga (s=sekundy)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Podrobná obr.\nnečinnosti",
-            "description": "Zobrazit detailní informace malým fontem na obrazovce nečinnosti"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Podrobná obr.\npájení",
-            "description": "Zobrazit detailní informace malým fontem na obrazovce pájení"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Povoluje BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Omezení\nVýkonu",
-            "description": "Maximální příkon páječky (W=watt)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Kalibrovat CJC\npři příštím startu",
-            "description": "Při příštím startu bude kalibrována kompenzace studeného spoje (není třeba pokud Delta T je < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Kalibrovat\nvstupní napětí?",
-            "description": "Začít kalibraci vstupního napětí (dlouhý stisk pro ukončení)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Napájecí\npulz",
-            "description": "Intenzita výkonu pulzu pro udržení páječky vzhůru (watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Prodleva\nnapáj. pulzu",
-            "description": "Prodleva než je spuštěn pulz pro udržení páječky vzhůru pulzu pro udržení páječky vzhůru (x 2,5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Délka\nnapáj. pulzu",
-            "description": "Délka pulzu pro udržení páječky vzhůru (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Obnovit tovární\nnastavení?",
-            "description": "Obnovit všechna nastavení na výchozí"
-        },
-        "LanguageSwitch": {
-            "displayText": "Jazyk:\n CS       Český",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Akcelerometr\nnebyl detekován!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "Žádný IO USB-PD\nnebyl detekován!"
+    },
+    "LockingKeysString": {
+      "message": "ZAMČENO"
+    },
+    "UnlockingKeysString": {
+      "message": "ODEMČENO"
+    },
+    "WarningKeysLockedString": {
+      "message": "ZAMČENO!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Teplotní\nOchrana"
+    },
+    "WarningTipShorted": {
+      "message": "!Zkrat na hrotu!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Před restartem se ujistěte, že hrot a držák mají pokojovou teplotu!"
+    },
+    "CJCCalibrating": {
+      "message": "kalibrování\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Opravdu chcete resetovat zařízení do továrního nastavení?"
+    },
+    "UVLOWarningString": {
+      "message": "Nízké DC"
+    },
+    "UndervoltageString": {
+      "message": "Nízké napětí\n"
+    },
+    "InputVoltageString": {
+      "message": "Napětí: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Režim spánku...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Hrot: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Předehřívání\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Zchlazování\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Vaše zařízení je pravěpodobně padělek!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Teplota příliš vysoká pro start profilu"
     }
+  },
+  "characters": {
+    "SettingRightChar": "P",
+    "SettingLeftChar": "L",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "P",
+    "SettingMediumChar": "S",
+    "SettingFastChar": "R",
+    "SettingStartSolderingChar": "P",
+    "SettingStartSleepChar": "S",
+    "SettingStartSleepOffChar": "M",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "U"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Napájecí\nnastavení",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Pájecí\nnastavení",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Režim\nspánku",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Uživatelské\nrozhraní",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Pokročilá\nnastavení",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Zdroj\nnapájení",
+      "description": "Při nižším napětí ukončit pájení (DC 10V)  (S 3,3V na článek, zakázat omezení napájení)."
+    },
+    "MinVolCell": {
+      "displayText": "Minimální\nnapětí",
+      "description": "Minimální dovolené napětí po článku (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Napětí\nQC",
+      "description": "Maximální napětí QC pro jednání páječkou"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\ntimeout",
+      "description": "Maximální prodleva při jednání PD ve 100ms krocích pro kompatibilitu s některými QC nabíječkami"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Povoluje režimy PPS & EPR"
+    },
+    "BoostTemperature": {
+      "displayText": "Teplota\nboostu",
+      "description": "Teplota hrotu v \"režimu boost\""
+    },
+    "AutoStart": {
+      "displayText": "Chování\npři startu",
+      "description": "P=pájecí teplota | S=spánková teplota | M=zahřát hrot po pohybu"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Krok teploty\nkrátký?",
+      "description": "Velikost přídavku při změně teploty krátkým stiskem tlačítka"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Krok teploty\ndlouhý?",
+      "description": "Velikost přídavku při změně teploty dlouhým stiskem tlačítka"
+    },
+    "LockingMode": {
+      "displayText": "Povolit zamč.\ntlačítek",
+      "description": "Při pájení podržte obě tlačítka pro jejich zamčení (B=pouze v režimu boost | U=úplné zamčení)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profilové\nFáze",
+      "description": "Počet fází v profilovém režimu"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Teplota\nPředehřátí",
+      "description": "Teplota na kterou předehřát na začátku profilového režimu"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Rychlost\nPředehřívání",
+      "description": "Rychlost předehřívání (stupně za sekundu)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Teplota\nFáze 1",
+      "description": "Cílová teplota na konci této fáze"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Trvání\nFáze 1",
+      "description": "Doba trvání této fáze (sekundy)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Teplota\nFáze 2",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Trvání\nFáze 2",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Teplota\nFáze 3",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Trvání\nFáze 3",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Teplota\nFáze 4",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Trvání\nFáze 4",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Teplota\nFáze 5",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Trvání\nFáze 5",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Rychlost\nochlazování",
+      "description": "Rychlost ochlazování na konci profilového režimu (stupně za sekundu)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Citlivost\nna pohyb",
+      "description": "1=nejméně citlivé | ... | 9=nejvíce citlivé"
+    },
+    "SleepTemperature": {
+      "displayText": "Teplota\nve spánku",
+      "description": "Teplota hrotu v režimu spánku."
+    },
+    "SleepTimeout": {
+      "displayText": "Čas\ndo spánku",
+      "description": "\"Režim spánku\" naběhne v (s=sekundách | m=minutách)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Čas do\nvypnutí",
+      "description": "Interval automatického vypnutí (m=minut)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Citlivost\nHall. čidla",
+      "description": "Citlivost Hallova čidla pro detekci spánku (1=nejméně citlivé | ... | 9=nejvíce citlivé)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Jednotka\nteploty",
+      "description": "C=Celsius | F=Fahrenheit"
+    },
+    "DisplayRotation": {
+      "displayText": "Orientace\nobrazovky",
+      "description": "P=pravák | L=levák | A=automaticky"
+    },
+    "CooldownBlink": {
+      "displayText": "Blikáni při\nchladnutí",
+      "description": "Blikat teplotou při chladnutí dokud je hrot horký"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Rychlost\nposouvání",
+      "description": "Rychlost posouvání popisků podobných tomuto (P=pomalu | R=rychle)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Prohodit\ntl. +-?",
+      "description": "Prohodit tlačítka pro změnu teploty"
+    },
+    "AnimSpeed": {
+      "displayText": "Anim.\nrychlost",
+      "description": "Tempo animace ikon v menu (P=pomalu | S=středně | R=rychle)"
+    },
+    "AnimLoop": {
+      "displayText": "Anim.\nsmyčka",
+      "description": "Animovat ikony hlavního menu ve smyčce"
+    },
+    "Brightness": {
+      "displayText": "Jas\nobrazovky",
+      "description": "Upravit jas OLED"
+    },
+    "ColourInversion": {
+      "displayText": "Invertovat\nobrazovku",
+      "description": "Invertovat barvy na OLED"
+    },
+    "LOGOTime": {
+      "displayText": "Trvání\nboot loga",
+      "description": "Nastavení doby trvání boot loga (s=sekundy)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Podrobná obr.\nnečinnosti",
+      "description": "Zobrazit detailní informace malým fontem na obrazovce nečinnosti"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Podrobná obr.\npájení",
+      "description": "Zobrazit detailní informace malým fontem na obrazovce pájení"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Povoluje BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Omezení\nVýkonu",
+      "description": "Maximální příkon páječky (W=watt)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Kalibrovat CJC\npři příštím startu",
+      "description": "Při příštím startu bude kalibrována kompenzace studeného spoje (není třeba pokud Delta T je < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Kalibrovat\nvstupní napětí?",
+      "description": "Začít kalibraci vstupního napětí (dlouhý stisk pro ukončení)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Napájecí\npulz",
+      "description": "Intenzita výkonu pulzu pro udržení páječky vzhůru (watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Prodleva\nnapáj. pulzu",
+      "description": "Prodleva než je spuštěn pulz pro udržení páječky vzhůru pulzu pro udržení páječky vzhůru (x 2,5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Délka\nnapáj. pulzu",
+      "description": "Délka pulzu pro udržení páječky vzhůru (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Obnovit tovární\nnastavení?",
+      "description": "Obnovit všechna nastavení na výchozí"
+    },
+    "LanguageSwitch": {
+      "displayText": "Jazyk:\n CS       Český",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_CS.json
+++ b/Translations/translation_CS.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Zdroj\nnapájení",
@@ -123,7 +134,7 @@
       "description": "Maximální prodleva při jednání PD ve 100ms krocích pro kompatibilitu s některými QC nabíječkami"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "Povoluje režimy PPS & EPR"
     },
     "BoostTemperature": {

--- a/Translations/translation_DA.json
+++ b/Translations/translation_DA.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "DA",
-    "languageLocalName": "Dansk",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Calibration\ndone!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Visse indstillinger\nEr blevet ændret!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "ingen accelerometer\nfundet!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "ingen USB-PD IC\nFundet!"
-        },
-        "LockingKeysString": {
-            "message": "LÅST"
-        },
-        "UnlockingKeysString": {
-            "message": "ULÅST"
-        },
-        "WarningKeysLockedString": {
-            "message": "!LÅST!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Thermal\nRunaway"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Before rebooting, make sure tip & handle are at room temperature!"
-        },
-        "CJCCalibrating": {
-            "message": "calibrating\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Er du sikker du vil resette indstillingerne til standard?"
-        },
-        "UVLOWarningString": {
-            "message": "Lav Volt"
-        },
-        "UndervoltageString": {
-            "message": "Undervolt\n"
-        },
-        "InputVoltageString": {
-            "message": "Input V: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Dvale...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Tip: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Din enhed er højst sandsyneligt en Kopivare!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to\nstart profile"
-        }
+  "languageCode": "DA",
+  "languageLocalName": "Dansk",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Calibration\ndone!"
     },
-    "characters": {
-        "SettingRightChar": "H",
-        "SettingLeftChar": "V",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "S",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "F",
-        "SettingStartSolderingChar": "L",
-        "SettingStartSleepChar": "D",
-        "SettingStartSleepOffChar": "R",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "F"
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Strøm\nIndstillinger",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Lodde\nIndstillinger",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Dvale\nmode",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Bruger\nGrændseflade",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Advancerede\nIndstillinger",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Visse indstillinger\nEr blevet ændret!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Strøm\nKilde",
-            "description": "Strømforsyning. Indstil Cutoff Spændingen. (DC 10V) (S 3,3V per celle)"
-        },
-        "MinVolCell": {
-            "displayText": "Minimum\nSpænding",
-            "description": "Minimum tilladt spænding pr. celle (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC\nSpænding",
-            "description": "Max QC spænding Loddekolben skal forhandle sig til"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\ntimeout",
-            "description": "PD-forhandlingstimeout i trin på 100 ms for kompatibilitet med nogle QC-opladere"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Enables PPS & EPR modes"
-        },
-        "BoostTemperature": {
-            "displayText": "Boost\ntemp",
-            "description": "Temperatur i \"boost mode\""
-        },
-        "AutoStart": {
-            "displayText": "Start-up\nOpførsel",
-            "description": "Start automatisk med lodning når strøm sættes til. (L=Lodning | D=Dvale tilstand | R=Dvale tilstand rumtemperatur)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Temp ændring\nkort",
-            "description": "Temperatur-ændring-stigning ved kort tryk på knappen"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Temp ændring\nlang",
-            "description": "Temperatur-ændring-stigning ved lang tryk på knappen"
-        },
-        "LockingMode": {
-            "displayText": "Tillad låsning\naf knapperne",
-            "description": "Hold begge knapper nede under lodning for at låse dem (B=kun boost-tilstand | F=fuld låsning)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat\nTemp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat\nSpeed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDuration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDuration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDuration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDuration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDuration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown\nSpeed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Bevægelses\nfølsomhed",
-            "description": "Bevægelsesfølsomhed (1=Mindst følsom | ... | 9=Mest følsom)"
-        },
-        "SleepTemperature": {
-            "displayText": "Dvale\ntemp",
-            "description": "Dvale Temperatur (C)"
-        },
-        "SleepTimeout": {
-            "displayText": "Dvale\ntimeout",
-            "description": "Dvale Timeout (Minutter | Sekunder)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Sluknings\ntimeout",
-            "description": "sluknings Timeout (Minutter)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Hall sensor\nfølsomhed",
-            "description": "følsomhed overfor magneten (1=Mindst følsom | ... | 9=Mest følsom)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Temperatur\nEnhed",
-            "description": "Temperatur Enhed (C=Celsius | F=Fahrenheit)"
-        },
-        "DisplayRotation": {
-            "displayText": "Skærm\nOrientering",
-            "description": "Skærm Orientering (H=Højre Håndet | V=Venstre Håndet | A=Automatisk)"
-        },
-        "CooldownBlink": {
-            "displayText": "Køl ned\nBlinkning",
-            "description": "Blink temperaturen på skærmen, mens spidsen stadig er varm."
-        },
-        "ScrollingSpeed": {
-            "displayText": "Scrolling\nHastighed",
-            "description": "Hastigheden infotekst ruller forbi med (S=Langsom | F=Hurtigt)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Skift\n+ - tasterne",
-            "description": "Skift tildeling af knapper til temperaturjustering"
-        },
-        "AnimSpeed": {
-            "displayText": "Anim.\nHastighed",
-            "description": "Hastigheden for ikonanimationer i menuen (S=langsomt | M=medium | F=hurtigt)"
-        },
-        "AnimLoop": {
-            "displayText": "Anim.\nsløfe",
-            "description": "ikonanimation sløfe i hovedmenuen"
-        },
-        "Brightness": {
-            "displayText": "Skærm\nlysstyrke",
-            "description": "Juster lysstyrken på OLED-skærmen"
-        },
-        "ColourInversion": {
-            "displayText": "spejlvende\nskærm",
-            "description": "spejlvende farverne på OLED-skærmen"
-        },
-        "LOGOTime": {
-            "displayText": "opstartslogo\nvarighed",
-            "description": "Indstiller varigheden for opstartslogoet (s=sekunder)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Detaljeret\nStandby skærm",
-            "description": "Vis detialieret information med en mindre skriftstørrelse på standby skærmen."
-        },
-        "AdvancedSoldering": {
-            "displayText": "Detaljeret\nloddeskærm",
-            "description": "Vis detaljeret information mens der loddes"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Enables BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Strøm\nbegrænsning",
-            "description": "Maksimal effekt Loddekolben kan bruge (W=watt)"
-        },
-        "CalibrateCJC": {
-            "displayText": "kalibrere CJK\nunder næste opstart",
-            "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Kalibrere\ninput spændingen?",
-            "description": "VIN kalibrering. Knapperne justere, Lang tryk for at gå ud"
-        },
-        "PowerPulsePower": {
-            "displayText": "Strøm\npuls",
-            "description": "Intensiteten af strøm for hold-vågen-puls (watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Strøm puls\nForsinkelse",
-            "description": "Forsinkelse før hold-vågen-puls udløses (x 2,5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Strøm puls\nvarighed",
-            "description": "Hold-vågen-pulsvarighed (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Gendan fabriks\nIndstillinger",
-            "description": "Gendan alle indstillinger"
-        },
-        "LanguageSwitch": {
-            "displayText": "Sprog:\n DA       Dansk",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "ingen accelerometer\nfundet!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "ingen USB-PD IC\nFundet!"
+    },
+    "LockingKeysString": {
+      "message": "LÅST"
+    },
+    "UnlockingKeysString": {
+      "message": "ULÅST"
+    },
+    "WarningKeysLockedString": {
+      "message": "!LÅST!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Thermal\nRunaway"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Before rebooting, make sure tip & handle are at room temperature!"
+    },
+    "CJCCalibrating": {
+      "message": "calibrating\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Er du sikker du vil resette indstillingerne til standard?"
+    },
+    "UVLOWarningString": {
+      "message": "Lav Volt"
+    },
+    "UndervoltageString": {
+      "message": "Undervolt\n"
+    },
+    "InputVoltageString": {
+      "message": "Input V: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Dvale...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Tip: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Din enhed er højst sandsyneligt en Kopivare!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to\nstart profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "H",
+    "SettingLeftChar": "V",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "S",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "F",
+    "SettingStartSolderingChar": "L",
+    "SettingStartSleepChar": "D",
+    "SettingStartSleepOffChar": "R",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "F"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Strøm\nIndstillinger",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Lodde\nIndstillinger",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Dvale\nmode",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Bruger\nGrændseflade",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Advancerede\nIndstillinger",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Strøm\nKilde",
+      "description": "Strømforsyning. Indstil Cutoff Spændingen. (DC 10V) (S 3,3V per celle)"
+    },
+    "MinVolCell": {
+      "displayText": "Minimum\nSpænding",
+      "description": "Minimum tilladt spænding pr. celle (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC\nSpænding",
+      "description": "Max QC spænding Loddekolben skal forhandle sig til"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\ntimeout",
+      "description": "PD-forhandlingstimeout i trin på 100 ms for kompatibilitet med nogle QC-opladere"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Enables PPS & EPR modes"
+    },
+    "BoostTemperature": {
+      "displayText": "Boost\ntemp",
+      "description": "Temperatur i \"boost mode\""
+    },
+    "AutoStart": {
+      "displayText": "Start-up\nOpførsel",
+      "description": "Start automatisk med lodning når strøm sættes til. (L=Lodning | D=Dvale tilstand | R=Dvale tilstand rumtemperatur)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Temp ændring\nkort",
+      "description": "Temperatur-ændring-stigning ved kort tryk på knappen"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Temp ændring\nlang",
+      "description": "Temperatur-ændring-stigning ved lang tryk på knappen"
+    },
+    "LockingMode": {
+      "displayText": "Tillad låsning\naf knapperne",
+      "description": "Hold begge knapper nede under lodning for at låse dem (B=kun boost-tilstand | F=fuld låsning)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat\nTemp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat\nSpeed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDuration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDuration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDuration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDuration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDuration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown\nSpeed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Bevægelses\nfølsomhed",
+      "description": "Bevægelsesfølsomhed (1=Mindst følsom | ... | 9=Mest følsom)"
+    },
+    "SleepTemperature": {
+      "displayText": "Dvale\ntemp",
+      "description": "Dvale Temperatur (C)"
+    },
+    "SleepTimeout": {
+      "displayText": "Dvale\ntimeout",
+      "description": "Dvale Timeout (Minutter | Sekunder)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Sluknings\ntimeout",
+      "description": "sluknings Timeout (Minutter)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Hall sensor\nfølsomhed",
+      "description": "følsomhed overfor magneten (1=Mindst følsom | ... | 9=Mest følsom)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Temperatur\nEnhed",
+      "description": "Temperatur Enhed (C=Celsius | F=Fahrenheit)"
+    },
+    "DisplayRotation": {
+      "displayText": "Skærm\nOrientering",
+      "description": "Skærm Orientering (H=Højre Håndet | V=Venstre Håndet | A=Automatisk)"
+    },
+    "CooldownBlink": {
+      "displayText": "Køl ned\nBlinkning",
+      "description": "Blink temperaturen på skærmen, mens spidsen stadig er varm."
+    },
+    "ScrollingSpeed": {
+      "displayText": "Scrolling\nHastighed",
+      "description": "Hastigheden infotekst ruller forbi med (S=Langsom | F=Hurtigt)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Skift\n+ - tasterne",
+      "description": "Skift tildeling af knapper til temperaturjustering"
+    },
+    "AnimSpeed": {
+      "displayText": "Anim.\nHastighed",
+      "description": "Hastigheden for ikonanimationer i menuen (S=langsomt | M=medium | F=hurtigt)"
+    },
+    "AnimLoop": {
+      "displayText": "Anim.\nsløfe",
+      "description": "ikonanimation sløfe i hovedmenuen"
+    },
+    "Brightness": {
+      "displayText": "Skærm\nlysstyrke",
+      "description": "Juster lysstyrken på OLED-skærmen"
+    },
+    "ColourInversion": {
+      "displayText": "spejlvende\nskærm",
+      "description": "spejlvende farverne på OLED-skærmen"
+    },
+    "LOGOTime": {
+      "displayText": "opstartslogo\nvarighed",
+      "description": "Indstiller varigheden for opstartslogoet (s=sekunder)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Detaljeret\nStandby skærm",
+      "description": "Vis detialieret information med en mindre skriftstørrelse på standby skærmen."
+    },
+    "AdvancedSoldering": {
+      "displayText": "Detaljeret\nloddeskærm",
+      "description": "Vis detaljeret information mens der loddes"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Enables BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Strøm\nbegrænsning",
+      "description": "Maksimal effekt Loddekolben kan bruge (W=watt)"
+    },
+    "CalibrateCJC": {
+      "displayText": "kalibrere CJK\nunder næste opstart",
+      "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Kalibrere\ninput spændingen?",
+      "description": "VIN kalibrering. Knapperne justere, Lang tryk for at gå ud"
+    },
+    "PowerPulsePower": {
+      "displayText": "Strøm\npuls",
+      "description": "Intensiteten af strøm for hold-vågen-puls (watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Strøm puls\nForsinkelse",
+      "description": "Forsinkelse før hold-vågen-puls udløses (x 2,5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Strøm puls\nvarighed",
+      "description": "Hold-vågen-pulsvarighed (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Gendan fabriks\nIndstillinger",
+      "description": "Gendan alle indstillinger"
+    },
+    "LanguageSwitch": {
+      "displayText": "Sprog:\n DA       Dansk",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_DA.json
+++ b/Translations/translation_DA.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Strøm\nKilde",
@@ -123,8 +134,8 @@
       "description": "PD-forhandlingstimeout i trin på 100 ms for kompatibilitet med nogle QC-opladere"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
-      "description": "Enables PPS & EPR modes"
+      "displayText": "PD\nMode",
+      "description": "No Dynamic disables EPR & PPS, Safe mode does not use padding resistance"
     },
     "BoostTemperature": {
       "displayText": "Boost\ntemp",

--- a/Translations/translation_DE.json
+++ b/Translations/translation_DE.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Spannungs-\nquelle",
@@ -123,7 +134,7 @@
       "description": "PD Abfragedauer in 100ms Schritten (Kompatibilität mit best. QC-Ladegeräten)"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "Aktiviert PPS & EPR"
     },
     "BoostTemperature": {

--- a/Translations/translation_DE.json
+++ b/Translations/translation_DE.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "DE",
-    "languageLocalName": "Deutsch",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Erfolgreich\nkalibriert!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Einstellungen\nzurückgesetzt!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Bewegungssensor\nnicht erkannt!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "USB-PD IC\nnicht erkannt!"
-        },
-        "LockingKeysString": {
-            "message": "GESPERRT"
-        },
-        "UnlockingKeysString": {
-            "message": "ENTSPERRT"
-        },
-        "WarningKeysLockedString": {
-            "message": "!GESPERRT!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Thermal\nRunaway"
-        },
-        "WarningTipShorted": {
-            "message": "!Lötspitze\nkurzgeschlossen!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Vor dem Neustart bitte sicherstellen, dass Lötspitze & Gerät Raumtemperatur haben!"
-        },
-        "CJCCalibrating": {
-            "message": "kalibriere\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Sicher, dass alle Werte zurückgesetzt werden sollen?"
-        },
-        "UVLOWarningString": {
-            "message": "V niedr."
-        },
-        "UndervoltageString": {
-            "message": "Unterspannung\n"
-        },
-        "InputVoltageString": {
-            "message": "V Eingang: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Ruhemodus...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Temp: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Vorwärmen\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Abkühlen\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Höchstwahrscheinlich ist das Gerät eine Fälschung!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Zu heiß für\nProfilstart!"
-        }
+  "languageCode": "DE",
+  "languageLocalName": "Deutsch",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Erfolgreich\nkalibriert!"
     },
-    "characters": {
-        "SettingRightChar": "R",
-        "SettingLeftChar": "L",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "L",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "S",
-        "SettingStartSolderingChar": "L",
-        "SettingStartSleepChar": "R",
-        "SettingStartSleepOffChar": "K",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "V"
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Energie-\neinstellungen",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Löt-\neinstellungen",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Ruhe-\nmodus",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Anzeige-\neinstellungen",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Erweiterte\nEinstellungen",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Einstellungen\nzurückgesetzt!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Spannungs-\nquelle",
-            "description": "Spannungsquelle (Abschaltspannung) (DC=10V | nS=n*3.3V für n LiIon-Zellen)"
-        },
-        "MinVolCell": {
-            "displayText": "Minimale\nSpannung",
-            "description": "Minimal zulässige Spannung pro Zelle (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Spannungs-\nmaximum",
-            "description": "Maximal zulässige Spannung der verwendeten Spannungsversorgung (V=Volt)"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\ntimeout",
-            "description": "PD Abfragedauer in 100ms Schritten (Kompatibilität mit best. QC-Ladegeräten)"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Aktiviert PPS & EPR"
-        },
-        "BoostTemperature": {
-            "displayText": "Boost-\ntemperatur",
-            "description": "Temperatur der Lötspitze im Boostmodus"
-        },
-        "AutoStart": {
-            "displayText": "Start im\nLötmodus",
-            "description": "Heizverhalten beim Einschalten der Spannungsversorgung (L=Lötmodus | R=Ruhemodus | K=Ruhemodus mit kalter Spitze)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Temp-Schritt\nDruck kurz",
-            "description": "Schrittweite für Temperaturänderung bei kurzem Tastendruck"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Temp-Schritt\nDruck lang",
-            "description": "Schrittweite für Temperaturänderung bei langem Tastendruck"
-        },
-        "LockingMode": {
-            "displayText": "Tasten-\nsperre",
-            "description": "Langes Drücken beider Tasten im Lötmodus sperrt diese (B=nur Boost | V=vollständig)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhasen",
-            "description": "Anzahl an Phasen im Profilmodus"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Vorheiz-\ntemperatur",
-            "description": "Zu Beginn des Profilmodus auf diese Temperatur vorheizen"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Vorheiz-\nrate",
-            "description": "Mit dieser Geschwindigkeit vorheizen (Grad pro Sekunde)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemperatur",
-            "description": "Zieltemperatur zum Ende dieser Phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDauer",
-            "description": "Dauer dieser Phase (Sekunden)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemperatur",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDauer",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemperatur",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDauer",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemperatur",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDauer",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemperatur",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDauer",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Abkühl-\nrate",
-            "description": "Am Ende des Profilmodus mit dieser Geschwindigkeit abkühlen (Grad pro Sekunde)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Bewegungs-\nempfindlichk.",
-            "description": "1=minimal | ... | 9=maximal"
-        },
-        "SleepTemperature": {
-            "displayText": "Ruhe-\ntemperatur",
-            "description": "Ruhetemperatur der Lötspitze"
-        },
-        "SleepTimeout": {
-            "displayText": "Ruhever-\nzögerung",
-            "description": "Dauer vor Übergang in den Ruhemodus (s=Sekunden | m=Minuten)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Abschalt-\nverzög.",
-            "description": "Dauer vor automatischer Abschaltung (m=Minuten)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Empfindlichkeit\nder Hall-Sonde",
-            "description": "Empfindlichkeit der Hall-Sonde um den Ruhemodus auszulösen (1=minimal | ... | 9=maximal)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Temperatur-\neinheit",
-            "description": "C=°Celsius | F=°Fahrenheit"
-        },
-        "DisplayRotation": {
-            "displayText": "Anzeige-\nausrichtung",
-            "description": "R=rechtshändig | L=linkshändig | A=automatisch"
-        },
-        "CooldownBlink": {
-            "displayText": "Abkühl-\nblinken",
-            "description": "Temperaturanzeige blinkt beim Abkühlen, solange Spitze heiß ist"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Scroll-\ngeschw.",
-            "description": "Scrollgeschwindigkeit der Erläuterungen (L=langsam | S=schnell)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "+- Tasten\numkehren",
-            "description": "Tastenbelegung zur Temperaturänderung umkehren"
-        },
-        "AnimSpeed": {
-            "displayText": "Anim.\nGeschw.",
-            "description": "Geschwindigkeit der Icon-Animationen im Menü (L=langsam | M=mittel | S=schnell)"
-        },
-        "AnimLoop": {
-            "displayText": "Anim.\nSchleife",
-            "description": "Icon-Animationen im Hauptmenü wiederholen"
-        },
-        "Brightness": {
-            "displayText": "Bildschirm-\nhelligkeit",
-            "description": "Verändert die Helligkeit des OLED-Displays"
-        },
-        "ColourInversion": {
-            "displayText": "Farben\numkehren",
-            "description": "Invertiert die Farben des OLED-Displays"
-        },
-        "LOGOTime": {
-            "displayText": "Startlogo-\ndauer",
-            "description": "Legt die Dauer der Anzeige des Startlogos fest (s=Sekunden)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Detaillierte\nRuheansicht",
-            "description": "Detaillierte Anzeige im Ruhemodus"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Detaillierte\nLötansicht",
-            "description": "Detaillierte Anzeige im Lötmodus"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Aktiviert Bluetooth LE"
-        },
-        "PowerLimit": {
-            "displayText": "Leistungs-\nmaximum",
-            "description": "Durchschnittliche maximal zulässige Leistungsaufnahme des Lötkolbens (W=Watt)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Temperatur\nkalibrieren",
-            "description": "Beim nächsten Start wird die Kaltstellenkompensation kalibriert (nicht nötig wenn Delta T < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Eingangsspannung\nkalibrieren",
-            "description": "Kalibrierung der Eingangsspannung (Langer Tastendruck zum Verlassen)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Leistungs-\nimpuls",
-            "description": "Powerbank mit einem Impuls wach halten (Watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Impuls-\nverzögerung",
-            "description": "Dauer vor Abgabe von Wachhalteimpulsen (x 2,5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Impuls-\ndauer",
-            "description": "Dauer des Wachhalteimpulses (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Einstellungen\nzurücksetzen",
-            "description": "Werte auf Werkseinstellungen zurücksetzen"
-        },
-        "LanguageSwitch": {
-            "displayText": "Sprache:\n DE     Deutsch",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Bewegungssensor\nnicht erkannt!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "USB-PD IC\nnicht erkannt!"
+    },
+    "LockingKeysString": {
+      "message": "GESPERRT"
+    },
+    "UnlockingKeysString": {
+      "message": "ENTSPERRT"
+    },
+    "WarningKeysLockedString": {
+      "message": "!GESPERRT!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Thermal\nRunaway"
+    },
+    "WarningTipShorted": {
+      "message": "!Lötspitze\nkurzgeschlossen!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Vor dem Neustart bitte sicherstellen, dass Lötspitze & Gerät Raumtemperatur haben!"
+    },
+    "CJCCalibrating": {
+      "message": "kalibriere\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Sicher, dass alle Werte zurückgesetzt werden sollen?"
+    },
+    "UVLOWarningString": {
+      "message": "V niedr."
+    },
+    "UndervoltageString": {
+      "message": "Unterspannung\n"
+    },
+    "InputVoltageString": {
+      "message": "V Eingang: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Ruhemodus...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Temp: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Vorwärmen\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Abkühlen\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Höchstwahrscheinlich ist das Gerät eine Fälschung!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Zu heiß für\nProfilstart!"
     }
+  },
+  "characters": {
+    "SettingRightChar": "R",
+    "SettingLeftChar": "L",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "L",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "S",
+    "SettingStartSolderingChar": "L",
+    "SettingStartSleepChar": "R",
+    "SettingStartSleepOffChar": "K",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "V"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Energie-\neinstellungen",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Löt-\neinstellungen",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Ruhe-\nmodus",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Anzeige-\neinstellungen",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Erweiterte\nEinstellungen",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Spannungs-\nquelle",
+      "description": "Spannungsquelle (Abschaltspannung) (DC=10V | nS=n*3.3V für n LiIon-Zellen)"
+    },
+    "MinVolCell": {
+      "displayText": "Minimale\nSpannung",
+      "description": "Minimal zulässige Spannung pro Zelle (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Spannungs-\nmaximum",
+      "description": "Maximal zulässige Spannung der verwendeten Spannungsversorgung (V=Volt)"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\ntimeout",
+      "description": "PD Abfragedauer in 100ms Schritten (Kompatibilität mit best. QC-Ladegeräten)"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Aktiviert PPS & EPR"
+    },
+    "BoostTemperature": {
+      "displayText": "Boost-\ntemperatur",
+      "description": "Temperatur der Lötspitze im Boostmodus"
+    },
+    "AutoStart": {
+      "displayText": "Start im\nLötmodus",
+      "description": "Heizverhalten beim Einschalten der Spannungsversorgung (L=Lötmodus | R=Ruhemodus | K=Ruhemodus mit kalter Spitze)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Temp-Schritt\nDruck kurz",
+      "description": "Schrittweite für Temperaturänderung bei kurzem Tastendruck"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Temp-Schritt\nDruck lang",
+      "description": "Schrittweite für Temperaturänderung bei langem Tastendruck"
+    },
+    "LockingMode": {
+      "displayText": "Tasten-\nsperre",
+      "description": "Langes Drücken beider Tasten im Lötmodus sperrt diese (B=nur Boost | V=vollständig)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhasen",
+      "description": "Anzahl an Phasen im Profilmodus"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Vorheiz-\ntemperatur",
+      "description": "Zu Beginn des Profilmodus auf diese Temperatur vorheizen"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Vorheiz-\nrate",
+      "description": "Mit dieser Geschwindigkeit vorheizen (Grad pro Sekunde)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemperatur",
+      "description": "Zieltemperatur zum Ende dieser Phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDauer",
+      "description": "Dauer dieser Phase (Sekunden)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemperatur",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDauer",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemperatur",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDauer",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemperatur",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDauer",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemperatur",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDauer",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Abkühl-\nrate",
+      "description": "Am Ende des Profilmodus mit dieser Geschwindigkeit abkühlen (Grad pro Sekunde)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Bewegungs-\nempfindlichk.",
+      "description": "1=minimal | ... | 9=maximal"
+    },
+    "SleepTemperature": {
+      "displayText": "Ruhe-\ntemperatur",
+      "description": "Ruhetemperatur der Lötspitze"
+    },
+    "SleepTimeout": {
+      "displayText": "Ruhever-\nzögerung",
+      "description": "Dauer vor Übergang in den Ruhemodus (s=Sekunden | m=Minuten)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Abschalt-\nverzög.",
+      "description": "Dauer vor automatischer Abschaltung (m=Minuten)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Empfindlichkeit\nder Hall-Sonde",
+      "description": "Empfindlichkeit der Hall-Sonde um den Ruhemodus auszulösen (1=minimal | ... | 9=maximal)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Temperatur-\neinheit",
+      "description": "C=°Celsius | F=°Fahrenheit"
+    },
+    "DisplayRotation": {
+      "displayText": "Anzeige-\nausrichtung",
+      "description": "R=rechtshändig | L=linkshändig | A=automatisch"
+    },
+    "CooldownBlink": {
+      "displayText": "Abkühl-\nblinken",
+      "description": "Temperaturanzeige blinkt beim Abkühlen, solange Spitze heiß ist"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Scroll-\ngeschw.",
+      "description": "Scrollgeschwindigkeit der Erläuterungen (L=langsam | S=schnell)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "+- Tasten\numkehren",
+      "description": "Tastenbelegung zur Temperaturänderung umkehren"
+    },
+    "AnimSpeed": {
+      "displayText": "Anim.\nGeschw.",
+      "description": "Geschwindigkeit der Icon-Animationen im Menü (L=langsam | M=mittel | S=schnell)"
+    },
+    "AnimLoop": {
+      "displayText": "Anim.\nSchleife",
+      "description": "Icon-Animationen im Hauptmenü wiederholen"
+    },
+    "Brightness": {
+      "displayText": "Bildschirm-\nhelligkeit",
+      "description": "Verändert die Helligkeit des OLED-Displays"
+    },
+    "ColourInversion": {
+      "displayText": "Farben\numkehren",
+      "description": "Invertiert die Farben des OLED-Displays"
+    },
+    "LOGOTime": {
+      "displayText": "Startlogo-\ndauer",
+      "description": "Legt die Dauer der Anzeige des Startlogos fest (s=Sekunden)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Detaillierte\nRuheansicht",
+      "description": "Detaillierte Anzeige im Ruhemodus"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Detaillierte\nLötansicht",
+      "description": "Detaillierte Anzeige im Lötmodus"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Aktiviert Bluetooth LE"
+    },
+    "PowerLimit": {
+      "displayText": "Leistungs-\nmaximum",
+      "description": "Durchschnittliche maximal zulässige Leistungsaufnahme des Lötkolbens (W=Watt)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Temperatur\nkalibrieren",
+      "description": "Beim nächsten Start wird die Kaltstellenkompensation kalibriert (nicht nötig wenn Delta T < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Eingangsspannung\nkalibrieren",
+      "description": "Kalibrierung der Eingangsspannung (Langer Tastendruck zum Verlassen)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Leistungs-\nimpuls",
+      "description": "Powerbank mit einem Impuls wach halten (Watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Impuls-\nverzögerung",
+      "description": "Dauer vor Abgabe von Wachhalteimpulsen (x 2,5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Impuls-\ndauer",
+      "description": "Dauer des Wachhalteimpulses (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Einstellungen\nzurücksetzen",
+      "description": "Werte auf Werkseinstellungen zurücksetzen"
+    },
+    "LanguageSwitch": {
+      "displayText": "Sprache:\n DE     Deutsch",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_EL.json
+++ b/Translations/translation_EL.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Πηγή\nενέργειας",
@@ -123,7 +134,7 @@
       "description": "Χρονικό όριο διαπραγμάτευσης PD σε βήματα 100ms για συμβατότητα με κάποιους φορτιστές QC"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "Ενεργοποιεί λειτουργίες PPS & EPR."
     },
     "BoostTemperature": {

--- a/Translations/translation_EL.json
+++ b/Translations/translation_EL.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "EL",
-    "languageLocalName": "Greek",
-    "tempUnitFahrenheit": true,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Βαθμονόμηση\nολοκληρώθηκε!"
-        },
-        "ResetOKMessage": {
-            "message": "Επαν. OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Κάποιες ρυθμ.\nάλλαξαν"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Δεν εντοπίστηκε\nεπιταχυνσιόμετρο"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "Δεν εντοπίστηκε\nκύκλωμα USB-PD"
-        },
-        "LockingKeysString": {
-            "message": "ΚΛΕΙΔ."
-        },
-        "UnlockingKeysString": {
-            "message": "ΞΕΚΛΕΙΔ."
-        },
-        "WarningKeysLockedString": {
-            "message": "ΚΛΕΙΔΩΜΕΝΑ\nΠΛΗΚΤΡΑ!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Θερμική\nΦυγή"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Πριν την επανεκκίνηση, βεβαιωθείτε ότι η μύτη και η συσκ. είναι σε θερμ. δωματίου!"
-        },
-        "CJCCalibrating": {
-            "message": "βαθμονόμηση\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Σίγουρα θέλετε επαναφορά αρχικών ρυθμίσεων;"
-        },
-        "UVLOWarningString": {
-            "message": "Χαμηλ DC"
-        },
-        "UndervoltageString": {
-            "message": "Υπόταση\n"
-        },
-        "InputVoltageString": {
-            "message": "Είσοδος V: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Υπνος...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Μύτη: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Η συσκευή σας ίσως να μην είναι αυθεντική!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to\nstart profile"
-        }
+  "languageCode": "EL",
+  "languageLocalName": "Greek",
+  "tempUnitFahrenheit": true,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Βαθμονόμηση\nολοκληρώθηκε!"
     },
-    "characters": {
-        "SettingRightChar": "R",
-        "SettingLeftChar": "L",
-        "SettingAutoChar": "Α",
-        "SettingSlowChar": "Α",
-        "SettingMediumChar": "Μ",
-        "SettingFastChar": "Γ",
-        "SettingStartSolderingChar": "Κ",
-        "SettingStartSleepChar": "Ζ",
-        "SettingStartSleepOffChar": "Υ",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "Π"
+    "ResetOKMessage": {
+      "message": "Επαν. OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Ρυθμίσεις\nενέργειας",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Ρυθμίσεις\nκόλλησης",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Λειτουργία\nύπνου",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Διεπαφή\nχρήστη",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Προηγμένες\nρυθμίσεις",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Κάποιες ρυθμ.\nάλλαξαν"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Πηγή\nενέργειας",
-            "description": "Πηγή ενέργειας. Oρισμός τάσης απενεργοποίησης. (DC 10V) (S 3.3V ανα μπαταρία, απενεργοποίηση ενεργειακού ορίου)"
-        },
-        "MinVolCell": {
-            "displayText": "Ελάχιστη\nτάση",
-            "description": "Ελάχιστη επιτρεπτή τάση ανα μπαταρία (3 σε σειρά: 3 - 3.7V | 4-6 σε σειρά: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Τάση\nQC",
-            "description": "Μέγιστη τάση QC που να ζητείται από το τροφοδοτικό"
-        },
-        "PDNegTimeout": {
-            "displayText": "χρονικό όριο\nPD",
-            "description": "Χρονικό όριο διαπραγμάτευσης PD σε βήματα 100ms για συμβατότητα με κάποιους φορτιστές QC"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Ενεργοποιεί λειτουργίες PPS & EPR."
-        },
-        "BoostTemperature": {
-            "displayText": "Θερμοκ.\nboost",
-            "description": "Θερμοκρασία στη \"λειτουργία boost\""
-        },
-        "AutoStart": {
-            "displayText": "Ζέσταμα\nκατά την εν.",
-            "description": "Κ=θερμ. κόλλησης | Z=αναμονή σε θερμοκρασία ύπνου μέχρι την κίνηση | Υ=αναμονή χωρίς ζέσταμα μέχρι την κίνηση"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Αλλαγή θερμοκ.\nστιγμιαίο",
-            "description": "Βήμα αλλαγής θερμοκρασίας σε στιγμιαίο πάτημα πλήκτρου"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Αλλαγή θερμοκ.\nπαρατεταμένο",
-            "description": "Βήμα αλλαγής θερμοκρασίας σε παρατεταμένο πάτημα πλήκτρου"
-        },
-        "LockingMode": {
-            "displayText": "Κλείδωμα\nπλήκτρων",
-            "description": "Κατά την κόλληση, κρατήστε και τα δύο πλήκτρα για κλείδωμα (B=μόνο λειτ. boost | Π=πλήρες κλείδωμα)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat\nTemp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat\nSpeed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDuration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDuration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDuration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDuration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDuration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown\nSpeed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Ευαισθησία\nκίνησης",
-            "description": "1=λιγότερο ευαίσθητο | ... | 9=περισσότερο ευαίσθητο"
-        },
-        "SleepTemperature": {
-            "displayText": "Θερμοκρ.\nύπνου",
-            "description": "Θερμοκρασία μύτης σε λειτ. ύπνου"
-        },
-        "SleepTimeout": {
-            "displayText": "Έναρξη\nύπνου",
-            "description": "Χρονικό διάστημα πρίν την ενεργοποίηση λειτουργίας ύπνου (Δ=δευτ. | Λ=λεπτά)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Έναρξη\nαπενεργ.",
-            "description": "Χρονικό διάστημα πρίν την απενεργοποίηση του κολλητηριού (Λ=λεπτά)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Ευαισθ. αισθ. \nφαιν. Hall",
-            "description": "Ευαισθησία του αισθητήρα φαινομένου Hall για εντοπισμό αδράνειας (1=λιγότερο ευαίσθητο | ... | 9=περισσότερο ευαίσθητο)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Μονάδες\nθερμοκρασίας",
-            "description": "C=Κελσίου | F=Φαρενάιτ"
-        },
-        "DisplayRotation": {
-            "displayText": "Διάταξη\nοθόνης",
-            "description": "R=δεξιόχειρες | L=αριστερόχειρες | Α=αυτόματο"
-        },
-        "CooldownBlink": {
-            "displayText": "Αναβοσβήσιμο\nψύξης",
-            "description": "Αναβοσβήσιμο της ενδειξης θερμοκρασίας κατά την παύση θέρμανσης όταν η μύτη είναι ακόμα καυτή"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Ταχύτητα\nκύλισης",
-            "description": "Ταχύτητα κύλισης κειμένου (Α=αργά | Γ=γρήγορα)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Αντιστροφή\nπλήκτρων + -",
-            "description": "Αντιστροφή διάταξης πλήκτρων στη ρύθμιση θερμοκρασίας"
-        },
-        "AnimSpeed": {
-            "displayText": "Ταχύτητα\nκιν. εικονιδ.",
-            "description": "Ρυθμός κίνησης εικονιδίων στο μενού (Α=αργός | Μ=μέτριος | Γ=γρήγορος)"
-        },
-        "AnimLoop": {
-            "displayText": "Επανάληψη\nκιν. εικονιδ.",
-            "description": "Επανάληψη κίνησης εικονιδίων στο αρχικό μενού"
-        },
-        "Brightness": {
-            "displayText": "Αντίθεση\nοθόνης",
-            "description": "Ρύθμιση φωτεινότητας οθόνης OLED"
-        },
-        "ColourInversion": {
-            "displayText": "Αντιστροφή\nχρωμάτων",
-            "description": "Αντιστροφή χρωμάτων οθόνης OLED"
-        },
-        "LOGOTime": {
-            "displayText": "Διάρκεια\nlogo εκκίνησης",
-            "description": "Διάρκεια εμφάνισης της εικόνας εκκίνησης (s=seconds)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Λεπτομερής\nοθ. αδράνειας",
-            "description": "Προβολή λεπτομερών πληροφοριών σε μικρότερη γραμματοσειρά στην οθόνη αδράνειας"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Λεπτομερής\nοθ. κόλλησης",
-            "description": "Προβολή λεπτομερών πληροφοριών σε μικρότερη γραμματοσειρά στην οθόνη κόλλησης"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Enables BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Ενεργειακό\nόριο",
-            "description": "Μέγιστη ενέργεια που μπορεί να χρησιμοποιεί το κολλητήρι (W=watt)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Βαθμονόμηση CJC\nσε επόμενη έναρξη",
-            "description": "Στην επόμενη εκκίνηση θα γίνει βαθμονόμηση θερμοκρασίας (δεν απαιτείται αν Δθερμ < 5 C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Βαθμονόμηση\nτάσης εισόδου;",
-            "description": "Έναρξη βαθμονόμησης τάσης εισόδου (κράτημα για έξοδο)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Παλμός\nενέργειας",
-            "description": "Ένταση ενέργειας παλμού διατήρησης λειτουργίας (W=watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Καθυστέρηση\nπαλμού ενέργ.",
-            "description": "Καθυστέρηση πριν την ενεργοποίση παλμού διατήρησης λειτουργίας (x 2.5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Διάρκεια\nπαλμού ενέργ.",
-            "description": "Διάρκεια παλμού διατήρησης ενέργειας (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Επαναφορά\nεργ. ρυθμίσεων;",
-            "description": "Επαναφορά στις προεπιλεγμένες ρυθμίσεις"
-        },
-        "LanguageSwitch": {
-            "displayText": "Γλώσσα:\n EL    Ελληνικά",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Δεν εντοπίστηκε\nεπιταχυνσιόμετρο"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "Δεν εντοπίστηκε\nκύκλωμα USB-PD"
+    },
+    "LockingKeysString": {
+      "message": "ΚΛΕΙΔ."
+    },
+    "UnlockingKeysString": {
+      "message": "ΞΕΚΛΕΙΔ."
+    },
+    "WarningKeysLockedString": {
+      "message": "ΚΛΕΙΔΩΜΕΝΑ\nΠΛΗΚΤΡΑ!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Θερμική\nΦυγή"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Πριν την επανεκκίνηση, βεβαιωθείτε ότι η μύτη και η συσκ. είναι σε θερμ. δωματίου!"
+    },
+    "CJCCalibrating": {
+      "message": "βαθμονόμηση\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Σίγουρα θέλετε επαναφορά αρχικών ρυθμίσεων;"
+    },
+    "UVLOWarningString": {
+      "message": "Χαμηλ DC"
+    },
+    "UndervoltageString": {
+      "message": "Υπόταση\n"
+    },
+    "InputVoltageString": {
+      "message": "Είσοδος V: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Υπνος...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Μύτη: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Η συσκευή σας ίσως να μην είναι αυθεντική!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to\nstart profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "R",
+    "SettingLeftChar": "L",
+    "SettingAutoChar": "Α",
+    "SettingSlowChar": "Α",
+    "SettingMediumChar": "Μ",
+    "SettingFastChar": "Γ",
+    "SettingStartSolderingChar": "Κ",
+    "SettingStartSleepChar": "Ζ",
+    "SettingStartSleepOffChar": "Υ",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "Π"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Ρυθμίσεις\nενέργειας",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Ρυθμίσεις\nκόλλησης",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Λειτουργία\nύπνου",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Διεπαφή\nχρήστη",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Προηγμένες\nρυθμίσεις",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Πηγή\nενέργειας",
+      "description": "Πηγή ενέργειας. Oρισμός τάσης απενεργοποίησης. (DC 10V) (S 3.3V ανα μπαταρία, απενεργοποίηση ενεργειακού ορίου)"
+    },
+    "MinVolCell": {
+      "displayText": "Ελάχιστη\nτάση",
+      "description": "Ελάχιστη επιτρεπτή τάση ανα μπαταρία (3 σε σειρά: 3 - 3.7V | 4-6 σε σειρά: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Τάση\nQC",
+      "description": "Μέγιστη τάση QC που να ζητείται από το τροφοδοτικό"
+    },
+    "PDNegTimeout": {
+      "displayText": "χρονικό όριο\nPD",
+      "description": "Χρονικό όριο διαπραγμάτευσης PD σε βήματα 100ms για συμβατότητα με κάποιους φορτιστές QC"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Ενεργοποιεί λειτουργίες PPS & EPR."
+    },
+    "BoostTemperature": {
+      "displayText": "Θερμοκ.\nboost",
+      "description": "Θερμοκρασία στη \"λειτουργία boost\""
+    },
+    "AutoStart": {
+      "displayText": "Ζέσταμα\nκατά την εν.",
+      "description": "Κ=θερμ. κόλλησης | Z=αναμονή σε θερμοκρασία ύπνου μέχρι την κίνηση | Υ=αναμονή χωρίς ζέσταμα μέχρι την κίνηση"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Αλλαγή θερμοκ.\nστιγμιαίο",
+      "description": "Βήμα αλλαγής θερμοκρασίας σε στιγμιαίο πάτημα πλήκτρου"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Αλλαγή θερμοκ.\nπαρατεταμένο",
+      "description": "Βήμα αλλαγής θερμοκρασίας σε παρατεταμένο πάτημα πλήκτρου"
+    },
+    "LockingMode": {
+      "displayText": "Κλείδωμα\nπλήκτρων",
+      "description": "Κατά την κόλληση, κρατήστε και τα δύο πλήκτρα για κλείδωμα (B=μόνο λειτ. boost | Π=πλήρες κλείδωμα)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat\nTemp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat\nSpeed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDuration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDuration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDuration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDuration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDuration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown\nSpeed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Ευαισθησία\nκίνησης",
+      "description": "1=λιγότερο ευαίσθητο | ... | 9=περισσότερο ευαίσθητο"
+    },
+    "SleepTemperature": {
+      "displayText": "Θερμοκρ.\nύπνου",
+      "description": "Θερμοκρασία μύτης σε λειτ. ύπνου"
+    },
+    "SleepTimeout": {
+      "displayText": "Έναρξη\nύπνου",
+      "description": "Χρονικό διάστημα πρίν την ενεργοποίηση λειτουργίας ύπνου (Δ=δευτ. | Λ=λεπτά)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Έναρξη\nαπενεργ.",
+      "description": "Χρονικό διάστημα πρίν την απενεργοποίηση του κολλητηριού (Λ=λεπτά)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Ευαισθ. αισθ. \nφαιν. Hall",
+      "description": "Ευαισθησία του αισθητήρα φαινομένου Hall για εντοπισμό αδράνειας (1=λιγότερο ευαίσθητο | ... | 9=περισσότερο ευαίσθητο)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Μονάδες\nθερμοκρασίας",
+      "description": "C=Κελσίου | F=Φαρενάιτ"
+    },
+    "DisplayRotation": {
+      "displayText": "Διάταξη\nοθόνης",
+      "description": "R=δεξιόχειρες | L=αριστερόχειρες | Α=αυτόματο"
+    },
+    "CooldownBlink": {
+      "displayText": "Αναβοσβήσιμο\nψύξης",
+      "description": "Αναβοσβήσιμο της ενδειξης θερμοκρασίας κατά την παύση θέρμανσης όταν η μύτη είναι ακόμα καυτή"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Ταχύτητα\nκύλισης",
+      "description": "Ταχύτητα κύλισης κειμένου (Α=αργά | Γ=γρήγορα)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Αντιστροφή\nπλήκτρων + -",
+      "description": "Αντιστροφή διάταξης πλήκτρων στη ρύθμιση θερμοκρασίας"
+    },
+    "AnimSpeed": {
+      "displayText": "Ταχύτητα\nκιν. εικονιδ.",
+      "description": "Ρυθμός κίνησης εικονιδίων στο μενού (Α=αργός | Μ=μέτριος | Γ=γρήγορος)"
+    },
+    "AnimLoop": {
+      "displayText": "Επανάληψη\nκιν. εικονιδ.",
+      "description": "Επανάληψη κίνησης εικονιδίων στο αρχικό μενού"
+    },
+    "Brightness": {
+      "displayText": "Αντίθεση\nοθόνης",
+      "description": "Ρύθμιση φωτεινότητας οθόνης OLED"
+    },
+    "ColourInversion": {
+      "displayText": "Αντιστροφή\nχρωμάτων",
+      "description": "Αντιστροφή χρωμάτων οθόνης OLED"
+    },
+    "LOGOTime": {
+      "displayText": "Διάρκεια\nlogo εκκίνησης",
+      "description": "Διάρκεια εμφάνισης της εικόνας εκκίνησης (s=seconds)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Λεπτομερής\nοθ. αδράνειας",
+      "description": "Προβολή λεπτομερών πληροφοριών σε μικρότερη γραμματοσειρά στην οθόνη αδράνειας"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Λεπτομερής\nοθ. κόλλησης",
+      "description": "Προβολή λεπτομερών πληροφοριών σε μικρότερη γραμματοσειρά στην οθόνη κόλλησης"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Enables BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Ενεργειακό\nόριο",
+      "description": "Μέγιστη ενέργεια που μπορεί να χρησιμοποιεί το κολλητήρι (W=watt)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Βαθμονόμηση CJC\nσε επόμενη έναρξη",
+      "description": "Στην επόμενη εκκίνηση θα γίνει βαθμονόμηση θερμοκρασίας (δεν απαιτείται αν Δθερμ < 5 C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Βαθμονόμηση\nτάσης εισόδου;",
+      "description": "Έναρξη βαθμονόμησης τάσης εισόδου (κράτημα για έξοδο)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Παλμός\nενέργειας",
+      "description": "Ένταση ενέργειας παλμού διατήρησης λειτουργίας (W=watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Καθυστέρηση\nπαλμού ενέργ.",
+      "description": "Καθυστέρηση πριν την ενεργοποίση παλμού διατήρησης λειτουργίας (x 2.5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Διάρκεια\nπαλμού ενέργ.",
+      "description": "Διάρκεια παλμού διατήρησης ενέργειας (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Επαναφορά\nεργ. ρυθμίσεων;",
+      "description": "Επαναφορά στις προεπιλεγμένες ρυθμίσεις"
+    },
+    "LanguageSwitch": {
+      "displayText": "Γλώσσα:\n EL    Ελληνικά",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_EN.json
+++ b/Translations/translation_EN.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "EN",
-    "languageLocalName": "English",
-    "tempUnitFahrenheit": true,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Calibration\ndone!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Certain settings\nchanged!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "No accelerometer\ndetected!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "No USB-PD IC\ndetected!"
-        },
-        "LockingKeysString": {
-            "message": "LOCKED"
-        },
-        "UnlockingKeysString": {
-            "message": "UNLOCKED"
-        },
-        "WarningKeysLockedString": {
-            "message": "!LOCKED!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Thermal\nRunaway"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Before rebooting, make sure tip & handle are at room temperature!"
-        },
-        "CJCCalibrating": {
-            "message": "calibrating\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Are you sure you want to restore default settings?"
-        },
-        "UVLOWarningString": {
-            "message": "DC LOW"
-        },
-        "UndervoltageString": {
-            "message": "Undervoltage\n"
-        },
-        "InputVoltageString": {
-            "message": "Input V: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Sleeping...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Tip: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Your device is most likely a counterfeit!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to\nstart profile"
-        }
+  "languageCode": "EN",
+  "languageLocalName": "English",
+  "tempUnitFahrenheit": true,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Calibration\ndone!"
     },
-    "characters": {
-        "SettingRightChar": "R",
-        "SettingLeftChar": "L",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "S",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "F",
-        "SettingStartSolderingChar": "S",
-        "SettingStartSleepChar": "Z",
-        "SettingStartSleepOffChar": "R",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "F"
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Power\nsettings",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Soldering\nsettings",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Sleep\nmode",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "User\ninterface",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Advanced\nsettings",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Certain settings\nchanged!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Power\nsource",
-            "description": "Set cutoff voltage to prevent battery overdrainage (DC 10V) (S=3.3V per cell, disable PWR limit)"
-        },
-        "MinVolCell": {
-            "displayText": "Minimum\nvoltage",
-            "description": "Minimum allowed voltage per battery cell (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC\nvoltage",
-            "description": "Max QC voltage the iron should negotiate for"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\ntimeout",
-            "description": "PD negotiation timeout in 100ms steps for compatibility with some QC chargers"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Enables PPS & EPR modes"
-        },
-        "BoostTemperature": {
-            "displayText": "Boost\ntemp",
-            "description": "Tip temperature used in \"boost mode\""
-        },
-        "AutoStart": {
-            "displayText": "Start-up\nbehavior",
-            "description": "S=heat to soldering temp | Z=standby at sleep temp until moved | R=standby without heating until moved"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Temp change\nshort",
-            "description": "Temperature-change-increment on short button press"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Temp change\nlong",
-            "description": "Temperature-change-increment on long button press"
-        },
-        "LockingMode": {
-            "displayText": "Allow locking\nbuttons",
-            "description": "While soldering, hold down both buttons to toggle locking them (B=boost mode only | F=full locking)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat\nTemp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat\nSpeed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDuration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDuration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDuration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDuration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDuration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown\nSpeed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Motion\nsensitivity",
-            "description": "1=least sensitive | ... | 9=most sensitive"
-        },
-        "SleepTemperature": {
-            "displayText": "Sleep\ntemp",
-            "description": "Tip temperature while in \"sleep mode\""
-        },
-        "SleepTimeout": {
-            "displayText": "Sleep\ntimeout",
-            "description": "Interval before \"sleep mode\" starts (s=seconds | m=minutes)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Shutdown\ntimeout",
-            "description": "Interval before the iron shuts down (m=minutes)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Hall sensor\nsensitivity",
-            "description": "Sensitivity to magnets (1=least sensitive | ... | 9=most sensitive)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Temperature\nunit",
-            "description": "C=°Celsius | F=°Fahrenheit"
-        },
-        "DisplayRotation": {
-            "displayText": "Display\norientation",
-            "description": "R=right-handed | L=left-handed | A=automatic"
-        },
-        "CooldownBlink": {
-            "displayText": "Cooldown\nflashing",
-            "description": "Flash temp reading at idle while tip is hot"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Scrolling\nspeed",
-            "description": "Scrolling speed of info text (S=slow | F=fast)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Swap\n+ - keys",
-            "description": "Reverse assignment of buttons for temperature adjustment"
-        },
-        "AnimSpeed": {
-            "displayText": "Anim.\nspeed",
-            "description": "Pace of icon animations in menu (S=slow | M=medium | F=fast)"
-        },
-        "AnimLoop": {
-            "displayText": "Anim.\nloop",
-            "description": "Loop icon animations in main menu"
-        },
-        "Brightness": {
-            "displayText": "Screen\nbrightness",
-            "description": "Adjust the OLED screen brightness"
-        },
-        "ColourInversion": {
-            "displayText": "Invert\nscreen",
-            "description": "Invert the OLED screen colors"
-        },
-        "LOGOTime": {
-            "displayText": "Boot logo\nduration",
-            "description": "Set boot logo duration (s=seconds)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Detailed\nidle screen",
-            "description": "Display detailed info in a smaller font on idle screen"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Detailed\nsolder screen",
-            "description": "Display detailed info in a smaller font on soldering screen"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Enables BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Power\nlimit",
-            "description": "Average maximum power the iron can use (W=watt)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Calibrate CJC\nat next boot",
-            "description": "Calibrate Cold Junction Compensation at next boot (not required if Delta T is < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Calibrate\ninput voltage",
-            "description": "Start VIN calibration (long press to exit)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Power\npulse",
-            "description": "Intensity of power of keep-awake-pulse (W=watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Power pulse\ndelay",
-            "description": "Delay before keep-awake-pulse is triggered (x 2.5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Power pulse\nduration",
-            "description": "Keep-awake-pulse duration (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Restore default\nsettings",
-            "description": "Reset all settings to default"
-        },
-        "LanguageSwitch": {
-            "displayText": "Language:\n EN     English",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "No accelerometer\ndetected!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "No USB-PD IC\ndetected!"
+    },
+    "LockingKeysString": {
+      "message": "LOCKED"
+    },
+    "UnlockingKeysString": {
+      "message": "UNLOCKED"
+    },
+    "WarningKeysLockedString": {
+      "message": "!LOCKED!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Thermal\nRunaway"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Before rebooting, make sure tip & handle are at room temperature!"
+    },
+    "CJCCalibrating": {
+      "message": "calibrating\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Are you sure you want to restore default settings?"
+    },
+    "UVLOWarningString": {
+      "message": "DC LOW"
+    },
+    "UndervoltageString": {
+      "message": "Undervoltage\n"
+    },
+    "InputVoltageString": {
+      "message": "Input V: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Sleeping...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Tip: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Your device is most likely a counterfeit!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to\nstart profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "R",
+    "SettingLeftChar": "L",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "S",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "F",
+    "SettingStartSolderingChar": "S",
+    "SettingStartSleepChar": "Z",
+    "SettingStartSleepOffChar": "R",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "F"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Power\nsettings",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Soldering\nsettings",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Sleep\nmode",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "User\ninterface",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Advanced\nsettings",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Power\nsource",
+      "description": "Set cutoff voltage to prevent battery overdrainage (DC 10V) (S=3.3V per cell, disable PWR limit)"
+    },
+    "MinVolCell": {
+      "displayText": "Minimum\nvoltage",
+      "description": "Minimum allowed voltage per battery cell (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC\nvoltage",
+      "description": "Max QC voltage the iron should negotiate for"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\ntimeout",
+      "description": "PD negotiation timeout in 100ms steps for compatibility with some QC chargers"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Enables PPS & EPR modes"
+    },
+    "BoostTemperature": {
+      "displayText": "Boost\ntemp",
+      "description": "Tip temperature used in \"boost mode\""
+    },
+    "AutoStart": {
+      "displayText": "Start-up\nbehavior",
+      "description": "S=heat to soldering temp | Z=standby at sleep temp until moved | R=standby without heating until moved"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Temp change\nshort",
+      "description": "Temperature-change-increment on short button press"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Temp change\nlong",
+      "description": "Temperature-change-increment on long button press"
+    },
+    "LockingMode": {
+      "displayText": "Allow locking\nbuttons",
+      "description": "While soldering, hold down both buttons to toggle locking them (B=boost mode only | F=full locking)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat\nTemp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat\nSpeed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDuration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDuration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDuration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDuration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDuration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown\nSpeed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Motion\nsensitivity",
+      "description": "1=least sensitive | ... | 9=most sensitive"
+    },
+    "SleepTemperature": {
+      "displayText": "Sleep\ntemp",
+      "description": "Tip temperature while in \"sleep mode\""
+    },
+    "SleepTimeout": {
+      "displayText": "Sleep\ntimeout",
+      "description": "Interval before \"sleep mode\" starts (s=seconds | m=minutes)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Shutdown\ntimeout",
+      "description": "Interval before the iron shuts down (m=minutes)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Hall sensor\nsensitivity",
+      "description": "Sensitivity to magnets (1=least sensitive | ... | 9=most sensitive)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Temperature\nunit",
+      "description": "C=°Celsius | F=°Fahrenheit"
+    },
+    "DisplayRotation": {
+      "displayText": "Display\norientation",
+      "description": "R=right-handed | L=left-handed | A=automatic"
+    },
+    "CooldownBlink": {
+      "displayText": "Cooldown\nflashing",
+      "description": "Flash temp reading at idle while tip is hot"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Scrolling\nspeed",
+      "description": "Scrolling speed of info text (S=slow | F=fast)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Swap\n+ - keys",
+      "description": "Reverse assignment of buttons for temperature adjustment"
+    },
+    "AnimSpeed": {
+      "displayText": "Anim.\nspeed",
+      "description": "Pace of icon animations in menu (S=slow | M=medium | F=fast)"
+    },
+    "AnimLoop": {
+      "displayText": "Anim.\nloop",
+      "description": "Loop icon animations in main menu"
+    },
+    "Brightness": {
+      "displayText": "Screen\nbrightness",
+      "description": "Adjust the OLED screen brightness"
+    },
+    "ColourInversion": {
+      "displayText": "Invert\nscreen",
+      "description": "Invert the OLED screen colors"
+    },
+    "LOGOTime": {
+      "displayText": "Boot logo\nduration",
+      "description": "Set boot logo duration (s=seconds)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Detailed\nidle screen",
+      "description": "Display detailed info in a smaller font on idle screen"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Detailed\nsolder screen",
+      "description": "Display detailed info in a smaller font on soldering screen"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Enables BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Power\nlimit",
+      "description": "Average maximum power the iron can use (W=watt)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Calibrate CJC\nat next boot",
+      "description": "Calibrate Cold Junction Compensation at next boot (not required if Delta T is < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Calibrate\ninput voltage",
+      "description": "Start VIN calibration (long press to exit)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Power\npulse",
+      "description": "Intensity of power of keep-awake-pulse (W=watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Power pulse\ndelay",
+      "description": "Delay before keep-awake-pulse is triggered (x 2.5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Power pulse\nduration",
+      "description": "Keep-awake-pulse duration (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Restore default\nsettings",
+      "description": "Reset all settings to default"
+    },
+    "LanguageSwitch": {
+      "displayText": "Language:\n EN     English",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_EN.json
+++ b/Translations/translation_EN.json
@@ -105,10 +105,21 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Power\nsource",
-      "description": "Set cutoff voltage to prevent battery overdrainage (DC 10V) (S=3.3V per cell, disable PWR limit)"
+      "description": "Set cutoff voltage to prevent battery overdischarge (DC=10V) (S=3.3V per cell, disable PWR limit)"
     },
     "MinVolCell": {
       "displayText": "Minimum\nvoltage",
@@ -123,8 +134,8 @@
       "description": "PD negotiation timeout in 100ms steps for compatibility with some QC chargers"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
-      "description": "Enables PPS & EPR modes"
+      "displayText": "PD\nMode",
+      "description": "No Dynamic disables EPR & PPS, Safe mode does not use padding resistance"
     },
     "BoostTemperature": {
       "displayText": "Boost\ntemp",

--- a/Translations/translation_ES.json
+++ b/Translations/translation_ES.json
@@ -1,311 +1,310 @@
 {
-    "languageCode": "ES",
-    "languageLocalName": "Castellano",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "¡Calibracion\nlista!"
-        },
-        "ResetOKMessage": {
-            "message": "Listo"
-        },
-        "SettingsResetMessage": {
-            "message": "¡Ajustes\nReiniciados!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "¡Sin acelerómetro\nDetectado!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "¡Sin USB-PD IC\nDetectado!"
-        },
-        "LockingKeysString": {
-            "message": "BLOQUEADO"
-        },
-        "UnlockingKeysString": {
-            "message": "DESBLOQUEADO"
-        },
-        "WarningKeysLockedString": {
-            "message": "¡BLOQUEADO!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Térmico\nFuera de control"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "¡Antes de reiniciar, asegúrese de que la punta y el mango estén a temperatura ambiente!"
-        },
-        "CJCCalibrating": {
-            "message": "Calibrando\n"
-        },
-        "SettingsResetWarning": {
-            "message": "¿Quieres restablecer los ajustes?"
-        },
-        "UVLOWarningString": {
-            "message": "CC BAJA"
-        },
-        "UndervoltageString": {
-            "message": "Voltaje bajo\n"
-        },
-        "InputVoltageString": {
-            "message": "Voltaje: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "En reposo...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Punta: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Precalentado\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Enfriado\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "¡Es probable es que su dispositivo sea falso!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Muy caliente para \nempezar perfil"
-        }
+  "languageCode": "ES",
+  "languageLocalName": "Castellano",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "¡Calibracion\nlista!"
     },
-    "characters": {
-        "SettingRightChar": "D",
-        "SettingLeftChar": "I",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "L",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "R",
-        "SettingStartSolderingChar": "S",
-        "SettingStartSleepChar": "R",
-        "SettingStartSleepOffChar": "F",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "F"
+    "ResetOKMessage": {
+      "message": "Listo"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Potencia\najustes",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Soldadura\najustes",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Modos de\nreposo",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Interfaz\nde usuario",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Ajustes\navanzados",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "¡Ajustes\nReiniciados!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Fuente\nde energía",
-            "description": "Elige el tipo de fuente para limitar el voltaje (DC 10V) (S 3,3V por pila, ilimitado)"
-        },
-        "MinVolCell": {
-            "displayText": "Mínimo\nvoltaje",
-            "description": "Voltaje mínimo permitido por célula (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Potencia de\nentrada",
-            "description": "Potencia en Watts del adaptador de corriente utilizado"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\ntiempo de espera",
-            "description": "Timeout de negociación de PD en pasos de 100ms para compatibilidad con algunos cargadores QC (0: apagado)"
-            
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Permite modos PPS & EPR"
-        },
-        "BoostTemperature": {
-            "displayText": "Ajustar la\ntemp. extra",
-            "description": "Temperatura de la punta de \"modo boost\""
-        },
-        "AutoStart": {
-            "displayText": "Calentar\nal enchufar",
-            "description": "Calentado automático al iniciar (S=entrar en modo soldar | R=solo entrar en reposo | F=en reposo pero mantiene la punta fría)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Cambio temp.\npuls. cortas",
-            "description": "Aumento de la temperatura al pulsar brevemente un botón"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Cambio temp.\npuls. largas",
-            "description": "Aumento de la temperatura al pulsar prolongadamente un botón"
-        },
-        "LockingMode": {
-            "displayText": "Permitir botones\nbloqueo",
-            "description": "Mientras suelda, mantenga pulsados ambos botones para alternar su bloqueo (B=sólo modo boost | F=bloqueo total)"
-        },
-        "ProfilePhases": {
-            "displayText": "Fases de\nPerfil",
-            "description": "Numero de fases en modo perfil"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Temp de \n precalentado",
-            "description": "Precalentar a esta temperatura al inicio del modo perfil"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Velocidad de \nPrecalentado",
-            "description": "Precalentar a esta velocidad (grados por segundo)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Fase 1\nTemp",
-            "description": "Temperatura objetivo al final de esta fase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Fase 1\nDuración",
-            "description": "Duración objetivo de esta fase (segundos)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Fase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Fase 2\nDuración",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Fase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Fase 3\nDuración",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Fase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Fase 4\nDuración",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Fase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Fase 5\nDuración",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Velocidad de\nEnfriamineto",
-            "description": "Enfriar a esta velocidad al final del modo perfil (grados por segundo)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Detección de\nmovimiento",
-            "description": "Tiempo de reacción al agarrar (1=menos sensible | ... | 9=más sensible)"
-        },
-        "SleepTemperature": {
-            "displayText": "Temperatura\nen reposo",
-            "description": "Temperatura de la punta en \"reposo\""
-        },
-        "SleepTimeout": {
-            "displayText": "Entrar\nen reposo",
-            "description": "Tiempo de inactividad para entrar en reposo (min | seg)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Tiempo de\napagado",
-            "description": "Tiempo de inactividad para apagarse (en minutos)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Hall Eff\nSensibilidad",
-            "description": "Sensibilidad del sensor de efecto Hall en la detección de reposo (1=menos sensible | ... | 9=más sensible)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Unidad de\ntemperatura",
-            "description": "Unidad de temperatura (C=entígrados | F=Fahrenheit)"
-        },
-        "DisplayRotation": {
-            "displayText": "Orientación\nde pantalla",
-            "description": "Orientación de la pantalla (D=diestro | I=zurdo | A=automático)"
-        },
-        "CooldownBlink": {
-            "displayText": "Parpadear\nal enfriar",
-            "description": "Parpadear texto en inactivo cuando la punta este caliente"  
-        },
-        "ScrollingSpeed": {
-            "displayText": "Velocidad\ndel texto",
-            "description": "Velocidad de desplazamiento del texto (R=rápida | L=lenta)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Invertir\nbotones +/-",
-            "description": "Invertir botones de ajuste de temperatura"
-        },
-        "AnimSpeed": {
-            "displayText": "Anim.\nvelocidad",
-            "description": "Velocidad de animaciones de iconos en el menú (L=baja | M=media | R=alta)"
-        },
-        "AnimLoop": {
-            "displayText": "Anim.\nbucle",
-            "description": "Bucle de animaciones del menú principal"
-        },
-        "Brightness": {
-            "displayText": "Pantalla\nbrillo",
-            "description": "Ajusta el brillo de la pantalla OLED"
-        },
-        "ColourInversion": {
-            "displayText": "Invertir\npantalla",
-            "description": "Invertir la pantalla OLED"
-        },
-        "LOGOTime": {
-            "displayText": "Logo inicial\nduración",
-            "description": "Duración de la animación del logo inicial (s=segundos)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Info extra en\nmodo reposo",
-            "description": "Mostrar información detallada en tamaño pequeño en la pantalla de reposo"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Info extra\nal soldar",
-            "description": "Mostrar información detallada en tamaño pequeño en la pantalla de soldadura"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Habilitar BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Potencia\nlímite",
-            "description": "Elige el límite de potencia máxima del soldador (en Watts)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Calibrar CJC\nen el próximo inicio",
-            "description": "Al siguinte inicio el Cold Junction Compensation sera calibrado (no requerido si el Delta T es < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Calibrar voltaje\nde entrada",
-            "description": "Iniciar calibración VIN (pulsación larga para salir)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Pulsos bat.\nconstantes",
-            "description": "Intensidad de la potencia del pulso para mantener encendido (W=Watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Tiempor entre\n pulso de energia",
-            "description": "Tiempo de espera del pulso para mantener encendido (x 2,5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Duración de\n pulso de energia",
-            "description": "Duración del pulso para mantener encendido (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Volver a ajustes\nde fábrica",
-            "description": "Restablecer todos los ajustes por defecto"
-        },
-        "LanguageSwitch": {
-            "displayText": "Idioma:\n ES  Castellano",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "¡Sin acelerómetro\nDetectado!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "¡Sin USB-PD IC\nDetectado!"
+    },
+    "LockingKeysString": {
+      "message": "BLOQUEADO"
+    },
+    "UnlockingKeysString": {
+      "message": "DESBLOQUEADO"
+    },
+    "WarningKeysLockedString": {
+      "message": "¡BLOQUEADO!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Térmico\nFuera de control"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "¡Antes de reiniciar, asegúrese de que la punta y el mango estén a temperatura ambiente!"
+    },
+    "CJCCalibrating": {
+      "message": "Calibrando\n"
+    },
+    "SettingsResetWarning": {
+      "message": "¿Quieres restablecer los ajustes?"
+    },
+    "UVLOWarningString": {
+      "message": "CC BAJA"
+    },
+    "UndervoltageString": {
+      "message": "Voltaje bajo\n"
+    },
+    "InputVoltageString": {
+      "message": "Voltaje: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "En reposo...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Punta: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Precalentado\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Enfriado\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "¡Es probable es que su dispositivo sea falso!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Muy caliente para \nempezar perfil"
     }
+  },
+  "characters": {
+    "SettingRightChar": "D",
+    "SettingLeftChar": "I",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "L",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "R",
+    "SettingStartSolderingChar": "S",
+    "SettingStartSleepChar": "R",
+    "SettingStartSleepOffChar": "F",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "F"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Potencia\najustes",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Soldadura\najustes",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Modos de\nreposo",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Interfaz\nde usuario",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Ajustes\navanzados",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Fuente\nde energía",
+      "description": "Elige el tipo de fuente para limitar el voltaje (DC 10V) (S 3,3V por pila, ilimitado)"
+    },
+    "MinVolCell": {
+      "displayText": "Mínimo\nvoltaje",
+      "description": "Voltaje mínimo permitido por célula (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Potencia de\nentrada",
+      "description": "Potencia en Watts del adaptador de corriente utilizado"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\ntiempo de espera",
+      "description": "Timeout de negociación de PD en pasos de 100ms para compatibilidad con algunos cargadores QC (0: apagado)"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Permite modos PPS & EPR"
+    },
+    "BoostTemperature": {
+      "displayText": "Ajustar la\ntemp. extra",
+      "description": "Temperatura de la punta de \"modo boost\""
+    },
+    "AutoStart": {
+      "displayText": "Calentar\nal enchufar",
+      "description": "Calentado automático al iniciar (S=entrar en modo soldar | R=solo entrar en reposo | F=en reposo pero mantiene la punta fría)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Cambio temp.\npuls. cortas",
+      "description": "Aumento de la temperatura al pulsar brevemente un botón"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Cambio temp.\npuls. largas",
+      "description": "Aumento de la temperatura al pulsar prolongadamente un botón"
+    },
+    "LockingMode": {
+      "displayText": "Permitir botones\nbloqueo",
+      "description": "Mientras suelda, mantenga pulsados ambos botones para alternar su bloqueo (B=sólo modo boost | F=bloqueo total)"
+    },
+    "ProfilePhases": {
+      "displayText": "Fases de\nPerfil",
+      "description": "Numero de fases en modo perfil"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Temp de \n precalentado",
+      "description": "Precalentar a esta temperatura al inicio del modo perfil"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Velocidad de \nPrecalentado",
+      "description": "Precalentar a esta velocidad (grados por segundo)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Fase 1\nTemp",
+      "description": "Temperatura objetivo al final de esta fase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Fase 1\nDuración",
+      "description": "Duración objetivo de esta fase (segundos)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Fase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Fase 2\nDuración",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Fase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Fase 3\nDuración",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Fase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Fase 4\nDuración",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Fase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Fase 5\nDuración",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Velocidad de\nEnfriamineto",
+      "description": "Enfriar a esta velocidad al final del modo perfil (grados por segundo)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Detección de\nmovimiento",
+      "description": "Tiempo de reacción al agarrar (1=menos sensible | ... | 9=más sensible)"
+    },
+    "SleepTemperature": {
+      "displayText": "Temperatura\nen reposo",
+      "description": "Temperatura de la punta en \"reposo\""
+    },
+    "SleepTimeout": {
+      "displayText": "Entrar\nen reposo",
+      "description": "Tiempo de inactividad para entrar en reposo (min | seg)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Tiempo de\napagado",
+      "description": "Tiempo de inactividad para apagarse (en minutos)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Hall Eff\nSensibilidad",
+      "description": "Sensibilidad del sensor de efecto Hall en la detección de reposo (1=menos sensible | ... | 9=más sensible)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Unidad de\ntemperatura",
+      "description": "Unidad de temperatura (C=entígrados | F=Fahrenheit)"
+    },
+    "DisplayRotation": {
+      "displayText": "Orientación\nde pantalla",
+      "description": "Orientación de la pantalla (D=diestro | I=zurdo | A=automático)"
+    },
+    "CooldownBlink": {
+      "displayText": "Parpadear\nal enfriar",
+      "description": "Parpadear texto en inactivo cuando la punta este caliente"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Velocidad\ndel texto",
+      "description": "Velocidad de desplazamiento del texto (R=rápida | L=lenta)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Invertir\nbotones +/-",
+      "description": "Invertir botones de ajuste de temperatura"
+    },
+    "AnimSpeed": {
+      "displayText": "Anim.\nvelocidad",
+      "description": "Velocidad de animaciones de iconos en el menú (L=baja | M=media | R=alta)"
+    },
+    "AnimLoop": {
+      "displayText": "Anim.\nbucle",
+      "description": "Bucle de animaciones del menú principal"
+    },
+    "Brightness": {
+      "displayText": "Pantalla\nbrillo",
+      "description": "Ajusta el brillo de la pantalla OLED"
+    },
+    "ColourInversion": {
+      "displayText": "Invertir\npantalla",
+      "description": "Invertir la pantalla OLED"
+    },
+    "LOGOTime": {
+      "displayText": "Logo inicial\nduración",
+      "description": "Duración de la animación del logo inicial (s=segundos)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Info extra en\nmodo reposo",
+      "description": "Mostrar información detallada en tamaño pequeño en la pantalla de reposo"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Info extra\nal soldar",
+      "description": "Mostrar información detallada en tamaño pequeño en la pantalla de soldadura"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Habilitar BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Potencia\nlímite",
+      "description": "Elige el límite de potencia máxima del soldador (en Watts)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Calibrar CJC\nen el próximo inicio",
+      "description": "Al siguinte inicio el Cold Junction Compensation sera calibrado (no requerido si el Delta T es < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Calibrar voltaje\nde entrada",
+      "description": "Iniciar calibración VIN (pulsación larga para salir)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Pulsos bat.\nconstantes",
+      "description": "Intensidad de la potencia del pulso para mantener encendido (W=Watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Tiempor entre\n pulso de energia",
+      "description": "Tiempo de espera del pulso para mantener encendido (x 2,5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Duración de\n pulso de energia",
+      "description": "Duración del pulso para mantener encendido (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Volver a ajustes\nde fábrica",
+      "description": "Restablecer todos los ajustes por defecto"
+    },
+    "LanguageSwitch": {
+      "displayText": "Idioma:\n ES  Castellano",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_ES.json
+++ b/Translations/translation_ES.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Fuente\nde energía",
@@ -123,7 +134,7 @@
       "description": "Timeout de negociación de PD en pasos de 100ms para compatibilidad con algunos cargadores QC (0: apagado)"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "Permite modos PPS & EPR"
     },
     "BoostTemperature": {

--- a/Translations/translation_ET.json
+++ b/Translations/translation_ET.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Toiteallikas\nDC",
@@ -123,7 +134,7 @@
       "description": "PD läbirääkimise aegumine 100ms sammudena, et tagada ühilduvus osade QC laadijatega"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "Võimaldab PPS- ja EPR-režiimi"
     },
     "BoostTemperature": {

--- a/Translations/translation_ET.json
+++ b/Translations/translation_ET.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "ET",
-    "languageLocalName": "Eesti",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Kalibreerimine\ntehtud!"
-        },
-        "ResetOKMessage": {
-            "message": "Vaikesätted\ntaastatud"
-        },
-        "SettingsResetMessage": {
-            "message": "Osad seadistused\non muutunud!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Kiirendusandurit\nei tuvastatud!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "USB-PD IC\nei tuvastatud!"
-        },
-        "LockingKeysString": {
-            "message": "LUKUS"
-        },
-        "UnlockingKeysString": {
-            "message": "AVATUD"
-        },
-        "WarningKeysLockedString": {
-            "message": "!LUKUS!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Termiline\närajooks"
-        },
-        "WarningTipShorted": {
-            "message": "!Otsik lühises!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Enne taaskäivitamist veenduge, et otsik ja käepide on toatemperatuuril!"
-        },
-        "CJCCalibrating": {
-            "message": "kalibreerimine\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Kas olete kindel, et soovite taastada vaikesätted?"
-        },
-        "UVLOWarningString": {
-            "message": "DC MADAL"
-        },
-        "UndervoltageString": {
-            "message": "Alapinge\n"
-        },
-        "InputVoltageString": {
-            "message": "Sisend V: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Unerežiim...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Otsik: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Eelkuumutus\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Jahtumine\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Teie seade on tõenäoliselt võltsing!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Liiga kuum,\net alustada profiili"
-        }
+  "languageCode": "ET",
+  "languageLocalName": "Eesti",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Kalibreerimine\ntehtud!"
     },
-    "characters": {
-        "SettingRightChar": "P",
-        "SettingLeftChar": "V",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "A",
-        "SettingMediumChar": "K",
-        "SettingFastChar": "T",
-        "SettingStartSolderingChar": "J",
-        "SettingStartSleepChar": "Z",
-        "SettingStartSleepOffChar": "P",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "T"
+    "ResetOKMessage": {
+      "message": "Vaikesätted\ntaastatud"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Toiteseaded\n",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Jootmise\nseaded",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Unerežiimi\nseaded",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Kasutaja-\nliides",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Täpsemad\nseaded",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Osad seadistused\non muutunud!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Toiteallikas\nDC",
-            "description": "Määrab katkestuspinge, et vältida aku liigset tühjenemist. (DC 10V) (S=3,3V elemendi kohta, eemaldab voolupiirangud)"
-        },
-        "MinVolCell": {
-            "displayText": "Minimaalne\npinge",
-            "description": "Minimaalne lubatud pinge akuelemendi kohta (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC\npinge",
-            "description": "Maks. QC pinge, mida jootekolb läbirääkima peaks"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\naegumine",
-            "description": "PD läbirääkimise aegumine 100ms sammudena, et tagada ühilduvus osade QC laadijatega"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Võimaldab PPS- ja EPR-režiimi"
-        },
-        "BoostTemperature": {
-            "displayText": "Boost\ntemp",
-            "description": "Kolviotsiku temperatuur \"boost režiimis\""
-        },
-        "AutoStart": {
-            "displayText": "Käitumine\nkäivitusel",
-            "description": "J=kuumuta jootmistemperatuurini | Z=unerežiim, kuni seadet liigutatakse | P=unerežiim toatemperatuuril, kuni seadet liigutatakse"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Temp. muut\nlühike",
-            "description": "Temperatuuri muutmine lühikese vajutusega"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Temp. muut\npikk",
-            "description": "Temperatuuri muutmine pika vajutusega"
-        },
-        "LockingMode": {
-            "displayText": "Luba nuppude\nlukustamine",
-            "description": "Hoidke jootmise ajal mõlemad nupud all, et lülitada nende lukustamist (B=ainult boostrežiimis | T=täielik lukustamine)."
-        },
-        "ProfilePhases": {
-            "displayText": "Profiil\nfaasid",
-            "description": "Faaside arv profiilirežiimis"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Eelkuumutus\ntemp.",
-            "description": "Eelkuumuta sellele temperatuurile profiilirežiimi alguses"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Eelkuumutus\nkiirus",
-            "description": "Eelkuumuta sellise kiirusega (kraadi sekundis)."
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Faas 1\ntemp.",
-            "description": "Selle faasi lõpu sihttemperatuur"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Faas 1\nkestus",
-            "description": "Selle faasi sihtkestus (sekundites)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Faas 2\ntemp.",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Faas 2\nkestus",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Faas 3\ntemp.",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Faas 3\nkestus",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Faas 4\ntemp.",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Faas 4\nkestus",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Faas 5\ntemp.",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Faas 5\nkestus",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Jahtumise\nkiirus",
-            "description": "Jahtumine selle kiirusega profiilirežiimi lõpus (kraadi sekundis)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Liikumise\ntundlikkus",
-            "description": "1=vähetundlikuim | ... | 9=kõige tundlikum"
-        },
-        "SleepTemperature": {
-            "displayText": "Unerežiimi\ntemp",
-            "description": "Kolviotsiku temperatuur \"unerežiimis\""
-        },
-        "SleepTimeout": {
-            "displayText": "Unerežiimi\nviide",
-            "description": "Aeg enne \"unerežiimi\" algust (s=sekundid | m=minutid)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Seiskumise\nviide",
-            "description": "Aeg enne jootekolvi välja lülitamist (m=minutid)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Halli anduri\ntundlikkus",
-            "description": "Tundlikkus magnetite suhtes (1=vähetundlikum | ... | 9=kõige tundlikum)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Temperatuuri\nühik",
-            "description": "C=°Celsius | F=°Fahrenheit"
-        },
-        "DisplayRotation": {
-            "displayText": "Ekraani\norienteeritus",
-            "description": "P=paremakäeline | V=vasakukäeline | A=automaatne"
-        },
-        "CooldownBlink": {
-            "displayText": "Jahtumisel\nvilkumine",
-            "description": "Vilguta otsiku temperatuuri, kui see jahtub ja on veel ohtlikult kuum"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Kerimise\nkiirus",
-            "description": "Infoteksti kerimise kiirus (A = aeglane | K = kiire)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Vaheta\n+ - nupud",
-            "description": "Temperatuurinuppude asukohtade vahetus"
-        },
-        "AnimSpeed": {
-            "displayText": "Anim.\nkiirus",
-            "description": "Menüüikoonide animatsiooni kiirus (A=aeglane | K=keskmine | T=tempokas)"
-        },
-        "AnimLoop": {
-            "displayText": "Pidevad\nanim.",
-            "description": "Esitage menüüs pidevalt animatsioone"
-        },
-        "Brightness": {
-            "displayText": "Ekraani\nheledus",
-            "description": "Seadista OLED ekraani heledust"
-        },
-        "ColourInversion": {
-            "displayText": "Ekraani\ninverteerimine",
-            "description": "Inverteeri OLED ekraani värvid"
-        },
-        "LOGOTime": {
-            "displayText": "Alguslogo\nkestus",
-            "description": "Aeg, mille jooksul näidatakse logo peale kolvi käivitamist (s=sekundites)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Andmed\npuhkeolekus",
-            "description": "Näita unerežiimis üksikasjalikumat teavet väiksemas kirjas"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Andmed\njootmisel",
-            "description": "Näita jootmisel üksikasjalikumat teavet väiksemas kirjas"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Luba BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Võimsus-\npiirang",
-            "description": "Suurim lubatud võimsus mida kolb võib kasutada (W=vatti)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Kalibr. CJC\ntuleval käivit.",
-            "description": "Kalibreeri külmaühenduse kompensatsioon (CJC) järgmisel käivitamisel (ei ole vajalik, kui Delta T on < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Kalibreeri\nsisendpinge",
-            "description": "Sisendpinge (VIN) kalibreerimine (väljumiseks vajutage pikalt)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Impulsi\ntugevus",
-            "description": "Ärkvelolekuimpulsi tugevus (vattides). Vajalik, vältimaks akupanga uinumist."
-        },
-        "PowerPulseWait": {
-            "displayText": "Impulsi\nviivitus",
-            "description": "Viivitus enne ärkvelolekuimpulsi käivitumist (x 2,5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Impulsi\nkestus",
-            "description": "Ärkvelolekuimpulsi kestus (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Taasta\nvaikesätted",
-            "description": "Nulli kõik seadistused vaikesätetele"
-        },
-        "LanguageSwitch": {
-            "displayText": "Keel:\n ET     Eesti",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Kiirendusandurit\nei tuvastatud!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "USB-PD IC\nei tuvastatud!"
+    },
+    "LockingKeysString": {
+      "message": "LUKUS"
+    },
+    "UnlockingKeysString": {
+      "message": "AVATUD"
+    },
+    "WarningKeysLockedString": {
+      "message": "!LUKUS!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Termiline\närajooks"
+    },
+    "WarningTipShorted": {
+      "message": "!Otsik lühises!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Enne taaskäivitamist veenduge, et otsik ja käepide on toatemperatuuril!"
+    },
+    "CJCCalibrating": {
+      "message": "kalibreerimine\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Kas olete kindel, et soovite taastada vaikesätted?"
+    },
+    "UVLOWarningString": {
+      "message": "DC MADAL"
+    },
+    "UndervoltageString": {
+      "message": "Alapinge\n"
+    },
+    "InputVoltageString": {
+      "message": "Sisend V: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Unerežiim...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Otsik: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Eelkuumutus\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Jahtumine\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Teie seade on tõenäoliselt võltsing!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Liiga kuum,\net alustada profiili"
     }
+  },
+  "characters": {
+    "SettingRightChar": "P",
+    "SettingLeftChar": "V",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "A",
+    "SettingMediumChar": "K",
+    "SettingFastChar": "T",
+    "SettingStartSolderingChar": "J",
+    "SettingStartSleepChar": "Z",
+    "SettingStartSleepOffChar": "P",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "T"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Toiteseaded\n",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Jootmise\nseaded",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Unerežiimi\nseaded",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Kasutaja-\nliides",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Täpsemad\nseaded",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Toiteallikas\nDC",
+      "description": "Määrab katkestuspinge, et vältida aku liigset tühjenemist. (DC 10V) (S=3,3V elemendi kohta, eemaldab voolupiirangud)"
+    },
+    "MinVolCell": {
+      "displayText": "Minimaalne\npinge",
+      "description": "Minimaalne lubatud pinge akuelemendi kohta (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC\npinge",
+      "description": "Maks. QC pinge, mida jootekolb läbirääkima peaks"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\naegumine",
+      "description": "PD läbirääkimise aegumine 100ms sammudena, et tagada ühilduvus osade QC laadijatega"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Võimaldab PPS- ja EPR-režiimi"
+    },
+    "BoostTemperature": {
+      "displayText": "Boost\ntemp",
+      "description": "Kolviotsiku temperatuur \"boost režiimis\""
+    },
+    "AutoStart": {
+      "displayText": "Käitumine\nkäivitusel",
+      "description": "J=kuumuta jootmistemperatuurini | Z=unerežiim, kuni seadet liigutatakse | P=unerežiim toatemperatuuril, kuni seadet liigutatakse"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Temp. muut\nlühike",
+      "description": "Temperatuuri muutmine lühikese vajutusega"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Temp. muut\npikk",
+      "description": "Temperatuuri muutmine pika vajutusega"
+    },
+    "LockingMode": {
+      "displayText": "Luba nuppude\nlukustamine",
+      "description": "Hoidke jootmise ajal mõlemad nupud all, et lülitada nende lukustamist (B=ainult boostrežiimis | T=täielik lukustamine)."
+    },
+    "ProfilePhases": {
+      "displayText": "Profiil\nfaasid",
+      "description": "Faaside arv profiilirežiimis"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Eelkuumutus\ntemp.",
+      "description": "Eelkuumuta sellele temperatuurile profiilirežiimi alguses"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Eelkuumutus\nkiirus",
+      "description": "Eelkuumuta sellise kiirusega (kraadi sekundis)."
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Faas 1\ntemp.",
+      "description": "Selle faasi lõpu sihttemperatuur"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Faas 1\nkestus",
+      "description": "Selle faasi sihtkestus (sekundites)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Faas 2\ntemp.",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Faas 2\nkestus",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Faas 3\ntemp.",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Faas 3\nkestus",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Faas 4\ntemp.",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Faas 4\nkestus",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Faas 5\ntemp.",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Faas 5\nkestus",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Jahtumise\nkiirus",
+      "description": "Jahtumine selle kiirusega profiilirežiimi lõpus (kraadi sekundis)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Liikumise\ntundlikkus",
+      "description": "1=vähetundlikuim | ... | 9=kõige tundlikum"
+    },
+    "SleepTemperature": {
+      "displayText": "Unerežiimi\ntemp",
+      "description": "Kolviotsiku temperatuur \"unerežiimis\""
+    },
+    "SleepTimeout": {
+      "displayText": "Unerežiimi\nviide",
+      "description": "Aeg enne \"unerežiimi\" algust (s=sekundid | m=minutid)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Seiskumise\nviide",
+      "description": "Aeg enne jootekolvi välja lülitamist (m=minutid)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Halli anduri\ntundlikkus",
+      "description": "Tundlikkus magnetite suhtes (1=vähetundlikum | ... | 9=kõige tundlikum)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Temperatuuri\nühik",
+      "description": "C=°Celsius | F=°Fahrenheit"
+    },
+    "DisplayRotation": {
+      "displayText": "Ekraani\norienteeritus",
+      "description": "P=paremakäeline | V=vasakukäeline | A=automaatne"
+    },
+    "CooldownBlink": {
+      "displayText": "Jahtumisel\nvilkumine",
+      "description": "Vilguta otsiku temperatuuri, kui see jahtub ja on veel ohtlikult kuum"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Kerimise\nkiirus",
+      "description": "Infoteksti kerimise kiirus (A = aeglane | K = kiire)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Vaheta\n+ - nupud",
+      "description": "Temperatuurinuppude asukohtade vahetus"
+    },
+    "AnimSpeed": {
+      "displayText": "Anim.\nkiirus",
+      "description": "Menüüikoonide animatsiooni kiirus (A=aeglane | K=keskmine | T=tempokas)"
+    },
+    "AnimLoop": {
+      "displayText": "Pidevad\nanim.",
+      "description": "Esitage menüüs pidevalt animatsioone"
+    },
+    "Brightness": {
+      "displayText": "Ekraani\nheledus",
+      "description": "Seadista OLED ekraani heledust"
+    },
+    "ColourInversion": {
+      "displayText": "Ekraani\ninverteerimine",
+      "description": "Inverteeri OLED ekraani värvid"
+    },
+    "LOGOTime": {
+      "displayText": "Alguslogo\nkestus",
+      "description": "Aeg, mille jooksul näidatakse logo peale kolvi käivitamist (s=sekundites)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Andmed\npuhkeolekus",
+      "description": "Näita unerežiimis üksikasjalikumat teavet väiksemas kirjas"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Andmed\njootmisel",
+      "description": "Näita jootmisel üksikasjalikumat teavet väiksemas kirjas"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Luba BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Võimsus-\npiirang",
+      "description": "Suurim lubatud võimsus mida kolb võib kasutada (W=vatti)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Kalibr. CJC\ntuleval käivit.",
+      "description": "Kalibreeri külmaühenduse kompensatsioon (CJC) järgmisel käivitamisel (ei ole vajalik, kui Delta T on < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Kalibreeri\nsisendpinge",
+      "description": "Sisendpinge (VIN) kalibreerimine (väljumiseks vajutage pikalt)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Impulsi\ntugevus",
+      "description": "Ärkvelolekuimpulsi tugevus (vattides). Vajalik, vältimaks akupanga uinumist."
+    },
+    "PowerPulseWait": {
+      "displayText": "Impulsi\nviivitus",
+      "description": "Viivitus enne ärkvelolekuimpulsi käivitumist (x 2,5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Impulsi\nkestus",
+      "description": "Ärkvelolekuimpulsi kestus (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Taasta\nvaikesätted",
+      "description": "Nulli kõik seadistused vaikesätetele"
+    },
+    "LanguageSwitch": {
+      "displayText": "Keel:\n ET     Eesti",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_FI.json
+++ b/Translations/translation_FI.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "FI",
-    "languageLocalName": "Suomi",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Calibration\ndone!"
-        },
-        "ResetOKMessage": {
-            "message": "Palautus"
-        },
-        "SettingsResetMessage": {
-            "message": "Asetukset\npalautettu!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Kiihtyvyysanturi\npuuttuu!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "USB-PD IC\npuuttuu!"
-        },
-        "LockingKeysString": {
-            "message": " LUKITTU"
-        },
-        "UnlockingKeysString": {
-            "message": "AUKI"
-        },
-        "WarningKeysLockedString": {
-            "message": "!LUKKO!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Thermal\nRunaway"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Before rebooting, make sure tip & handle are at room temperature!"
-        },
-        "CJCCalibrating": {
-            "message": "calibrating\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Haluatko varmasti palauttaa oletusarvot?"
-        },
-        "UVLOWarningString": {
-            "message": "DC ALH."
-        },
-        "UndervoltageString": {
-            "message": "Alijännite\n"
-        },
-        "InputVoltageString": {
-            "message": "Jännite: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Lepotila...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Kärki: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Your device is most likely a counterfeit!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to\nstart profile"
-        }
+  "languageCode": "FI",
+  "languageLocalName": "Suomi",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Calibration\ndone!"
     },
-    "characters": {
-        "SettingRightChar": "O",
-        "SettingLeftChar": "V",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "A",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "S",
-        "SettingStartSolderingChar": "J",
-        "SettingStartSleepChar": "L",
-        "SettingStartSleepOffChar": "H",
-        "SettingLockBoostChar": "V",
-        "SettingLockFullChar": "K"
+    "ResetOKMessage": {
+      "message": "Palautus"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Virta-\nasetukset",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Juotos-\nasetukset",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Lepotilan\nasetukset",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Käyttö-\nliittymä",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Lisä-\nasetukset",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Asetukset\npalautettu!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Virtalähde\nDC",
-            "description": "Virtalähde. Asettaa katkaisujännitteen. (DC 10V) (S 3.3V per kenno, poistaa virtarajoitukset)"
-        },
-        "MinVolCell": {
-            "displayText": "Pienin\njännite",
-            "description": "Pienin sallittu jännite per kenno (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC\njännite",
-            "description": "Ensisijainen maksimi QC jännite"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\ntimeout",
-            "description": "PD negotiation timeout in 100ms steps for compatibility with some QC chargers"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Enables PPS & EPR modes"
-        },
-        "BoostTemperature": {
-            "displayText": "Tehostus-\nlämpötila",
-            "description": "Tehostustilan lämpötila"
-        },
-        "AutoStart": {
-            "displayText": "Autom.\nkäynnistys",
-            "description": "Käynnistää virrat kytkettäessä juotostilan automaattisesti. (J=juotostila | L=Lepotila | H=Lepotila huoneenlämpö)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Lämmön muutos\nlyhyt painal.",
-            "description": "Lämpötilan muutos lyhyellä painalluksella"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Lämmön muutos\npitkä painal.",
-            "description": "Lämpötilan muutos pitkällä painalluksella"
-        },
-        "LockingMode": {
-            "displayText": "Salli nappien\nlukitus",
-            "description": "Kolvatessa paina molempia näppäimiä lukitaksesi ne (V=vain tehostus | K=kaikki)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat\nTemp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat\nSpeed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDuration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDuration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDuration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDuration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDuration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown\nSpeed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Liikkeen\nherkkyys",
-            "description": "1=vähäinen herkkyys | ... | 9=suurin herkkyys"
-        },
-        "SleepTemperature": {
-            "displayText": "Lepotilan\nlämpötila",
-            "description": "Kärjen lämpötila \"lepotilassa\""
-        },
-        "SleepTimeout": {
-            "displayText": "Lepotilan\nviive",
-            "description": "\"Lepotilan\" ajastus (s=sekuntia | m=minuuttia)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Sammutus\nviive",
-            "description": "Automaattisen sammutuksen ajastus (m=minuuttia)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Hall-\nherk.",
-            "description": "Hall-efektianturin herkkyys lepotilan tunnistuksessa (1=vähäinen herkkyys | ... | 9=suurin herkkyys)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Lämpötilan\nyksikkö",
-            "description": "C=celsius, F=fahrenheit"
-        },
-        "DisplayRotation": {
-            "displayText": "Näytön\nkierto",
-            "description": "O=oikeakätinen | V=vasenkätinen | A=automaattinen"
-        },
-        "CooldownBlink": {
-            "displayText": "Jäähdytyksen\nvilkutus",
-            "description": "Vilkuttaa jäähtyessä juotoskärjen lämpötilaa sen ollessa vielä vaarallisen kuuma"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Selityksien\nnopeus",
-            "description": "Selityksien vieritysnopeus (H=hidas | N=nopea)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Suunnanvaihto\n+ - näppäimille",
-            "description": "Lämpötilapainikkeiden suunnan vaihtaminen"
-        },
-        "AnimSpeed": {
-            "displayText": "Animaation\nnopeus",
-            "description": "Animaatioiden nopeus valikossa (A=alhainen | K=keskiverto | S=suuri)"
-        },
-        "AnimLoop": {
-            "displayText": "Animaation\ntoistaminen",
-            "description": "Toista animaatiot valikossa"
-        },
-        "Brightness": {
-            "displayText": "Screen\nbrightness",
-            "description": "Adjust the OLED screen brightness"
-        },
-        "ColourInversion": {
-            "displayText": "Invert\nscreen",
-            "description": "Invert the OLED screen colors"
-        },
-        "LOGOTime": {
-            "displayText": "Boot logo\nduration",
-            "description": "Set boot logo duration (s=seconds)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Tiedot\nlepotilassa",
-            "description": "Näyttää yksityiskohtaisemmat pienemmällä fontilla tiedot lepotilassa."
-        },
-        "AdvancedSoldering": {
-            "displayText": "Tarkempi\njuotosnäyttö",
-            "description": "Näyttää yksityiskohtaisemmat tiedot pienellä fontilla juotostilassa"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Enables BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Tehon-\nrajoitus",
-            "description": "Suurin sallittu teho (Watti)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Calibrate CJC\nat next boot",
-            "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Kalibroi\ntulojännite?",
-            "description": "Tulojännitten kalibrointi (VIN) (paina pitkään poistuaksesi)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Herätyspulssin\nvoimakkuus",
-            "description": "Herätyspulssin voimakkuus (Watti)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Pulssin\nodotusaika",
-            "description": "Odotusaika herätyspulssin lähetykseen (x 2.5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Pulssin\nkesto",
-            "description": "Herätyspulssin kesto (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Palauta\ntehdasasetukset?",
-            "description": "Palauta kaikki asetukset oletusarvoihin"
-        },
-        "LanguageSwitch": {
-            "displayText": "Kieli:\n FI       Suomi",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Kiihtyvyysanturi\npuuttuu!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "USB-PD IC\npuuttuu!"
+    },
+    "LockingKeysString": {
+      "message": " LUKITTU"
+    },
+    "UnlockingKeysString": {
+      "message": "AUKI"
+    },
+    "WarningKeysLockedString": {
+      "message": "!LUKKO!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Thermal\nRunaway"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Before rebooting, make sure tip & handle are at room temperature!"
+    },
+    "CJCCalibrating": {
+      "message": "calibrating\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Haluatko varmasti palauttaa oletusarvot?"
+    },
+    "UVLOWarningString": {
+      "message": "DC ALH."
+    },
+    "UndervoltageString": {
+      "message": "Alijännite\n"
+    },
+    "InputVoltageString": {
+      "message": "Jännite: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Lepotila...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Kärki: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Your device is most likely a counterfeit!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to\nstart profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "O",
+    "SettingLeftChar": "V",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "A",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "S",
+    "SettingStartSolderingChar": "J",
+    "SettingStartSleepChar": "L",
+    "SettingStartSleepOffChar": "H",
+    "SettingLockBoostChar": "V",
+    "SettingLockFullChar": "K"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Virta-\nasetukset",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Juotos-\nasetukset",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Lepotilan\nasetukset",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Käyttö-\nliittymä",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Lisä-\nasetukset",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Virtalähde\nDC",
+      "description": "Virtalähde. Asettaa katkaisujännitteen. (DC 10V) (S 3.3V per kenno, poistaa virtarajoitukset)"
+    },
+    "MinVolCell": {
+      "displayText": "Pienin\njännite",
+      "description": "Pienin sallittu jännite per kenno (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC\njännite",
+      "description": "Ensisijainen maksimi QC jännite"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\ntimeout",
+      "description": "PD negotiation timeout in 100ms steps for compatibility with some QC chargers"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Enables PPS & EPR modes"
+    },
+    "BoostTemperature": {
+      "displayText": "Tehostus-\nlämpötila",
+      "description": "Tehostustilan lämpötila"
+    },
+    "AutoStart": {
+      "displayText": "Autom.\nkäynnistys",
+      "description": "Käynnistää virrat kytkettäessä juotostilan automaattisesti. (J=juotostila | L=Lepotila | H=Lepotila huoneenlämpö)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Lämmön muutos\nlyhyt painal.",
+      "description": "Lämpötilan muutos lyhyellä painalluksella"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Lämmön muutos\npitkä painal.",
+      "description": "Lämpötilan muutos pitkällä painalluksella"
+    },
+    "LockingMode": {
+      "displayText": "Salli nappien\nlukitus",
+      "description": "Kolvatessa paina molempia näppäimiä lukitaksesi ne (V=vain tehostus | K=kaikki)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat\nTemp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat\nSpeed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDuration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDuration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDuration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDuration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDuration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown\nSpeed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Liikkeen\nherkkyys",
+      "description": "1=vähäinen herkkyys | ... | 9=suurin herkkyys"
+    },
+    "SleepTemperature": {
+      "displayText": "Lepotilan\nlämpötila",
+      "description": "Kärjen lämpötila \"lepotilassa\""
+    },
+    "SleepTimeout": {
+      "displayText": "Lepotilan\nviive",
+      "description": "\"Lepotilan\" ajastus (s=sekuntia | m=minuuttia)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Sammutus\nviive",
+      "description": "Automaattisen sammutuksen ajastus (m=minuuttia)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Hall-\nherk.",
+      "description": "Hall-efektianturin herkkyys lepotilan tunnistuksessa (1=vähäinen herkkyys | ... | 9=suurin herkkyys)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Lämpötilan\nyksikkö",
+      "description": "C=celsius, F=fahrenheit"
+    },
+    "DisplayRotation": {
+      "displayText": "Näytön\nkierto",
+      "description": "O=oikeakätinen | V=vasenkätinen | A=automaattinen"
+    },
+    "CooldownBlink": {
+      "displayText": "Jäähdytyksen\nvilkutus",
+      "description": "Vilkuttaa jäähtyessä juotoskärjen lämpötilaa sen ollessa vielä vaarallisen kuuma"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Selityksien\nnopeus",
+      "description": "Selityksien vieritysnopeus (H=hidas | N=nopea)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Suunnanvaihto\n+ - näppäimille",
+      "description": "Lämpötilapainikkeiden suunnan vaihtaminen"
+    },
+    "AnimSpeed": {
+      "displayText": "Animaation\nnopeus",
+      "description": "Animaatioiden nopeus valikossa (A=alhainen | K=keskiverto | S=suuri)"
+    },
+    "AnimLoop": {
+      "displayText": "Animaation\ntoistaminen",
+      "description": "Toista animaatiot valikossa"
+    },
+    "Brightness": {
+      "displayText": "Screen\nbrightness",
+      "description": "Adjust the OLED screen brightness"
+    },
+    "ColourInversion": {
+      "displayText": "Invert\nscreen",
+      "description": "Invert the OLED screen colors"
+    },
+    "LOGOTime": {
+      "displayText": "Boot logo\nduration",
+      "description": "Set boot logo duration (s=seconds)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Tiedot\nlepotilassa",
+      "description": "Näyttää yksityiskohtaisemmat pienemmällä fontilla tiedot lepotilassa."
+    },
+    "AdvancedSoldering": {
+      "displayText": "Tarkempi\njuotosnäyttö",
+      "description": "Näyttää yksityiskohtaisemmat tiedot pienellä fontilla juotostilassa"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Enables BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Tehon-\nrajoitus",
+      "description": "Suurin sallittu teho (Watti)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Calibrate CJC\nat next boot",
+      "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Kalibroi\ntulojännite?",
+      "description": "Tulojännitten kalibrointi (VIN) (paina pitkään poistuaksesi)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Herätyspulssin\nvoimakkuus",
+      "description": "Herätyspulssin voimakkuus (Watti)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Pulssin\nodotusaika",
+      "description": "Odotusaika herätyspulssin lähetykseen (x 2.5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Pulssin\nkesto",
+      "description": "Herätyspulssin kesto (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Palauta\ntehdasasetukset?",
+      "description": "Palauta kaikki asetukset oletusarvoihin"
+    },
+    "LanguageSwitch": {
+      "displayText": "Kieli:\n FI       Suomi",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_FI.json
+++ b/Translations/translation_FI.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Virtalähde\nDC",
@@ -123,8 +134,8 @@
       "description": "PD negotiation timeout in 100ms steps for compatibility with some QC chargers"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
-      "description": "Enables PPS & EPR modes"
+      "displayText": "PD\nMode",
+      "description": "No Dynamic disables EPR & PPS, Safe mode does not use padding resistance"
     },
     "BoostTemperature": {
       "displayText": "Tehostus-\nlämpötila",

--- a/Translations/translation_FR.json
+++ b/Translations/translation_FR.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Source\nd'alim.",
@@ -123,8 +134,8 @@
       "description": "Délai de la negociation PD par étapes de 100ms pour la compatiblité avec certains chargeurs QC"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
-      "description": "Enables PPS & EPR modes"
+      "displayText": "PD\nMode",
+      "description": "No Dynamic disables EPR & PPS, Safe mode does not use padding resistance"
     },
     "BoostTemperature": {
       "displayText": "Temp.\nboost",

--- a/Translations/translation_FR.json
+++ b/Translations/translation_FR.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "FR",
-    "languageLocalName": "Français",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Étalonnage\nterminé!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Réglages\nréinitialisés !"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Accéléromètre\nnon détecté !"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "USB-PD\nnon détecté !"
-        },
-        "LockingKeysString": {
-            "message": "VERROUIL"
-        },
-        "UnlockingKeysString": {
-            "message": "DEVERROU"
-        },
-        "WarningKeysLockedString": {
-            "message": "! VERR. !"
-        },
-        "WarningThermalRunaway": {
-            "message": "Emballement\nthermique"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Avant de redémarrer, assurez-vous que la panne et la poignée sont à température ambiante !"
-        },
-        "CJCCalibrating": {
-            "message": "Etalonnage\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Voulez-vous vraiment réinitialiser les paramètres aux valeurs par défaut ?"
-        },
-        "UVLOWarningString": {
-            "message": "DC FAIBL"
-        },
-        "UndervoltageString": {
-            "message": "Sous-tension\n"
-        },
-        "InputVoltageString": {
-            "message": "V d'entrée: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "En veille...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Panne: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Votre appareil semble être une contrefaçon !"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to\nstart profile"
-        }
+  "languageCode": "FR",
+  "languageLocalName": "Français",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Étalonnage\nterminé!"
     },
-    "characters": {
-        "SettingRightChar": "D",
-        "SettingLeftChar": "G",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "L",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "R",
-        "SettingStartSolderingChar": "A",
-        "SettingStartSleepChar": "V",
-        "SettingStartSleepOffChar": "O",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "V"
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Paramètres\nd'alim.",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Paramètres\nde soudure",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Mode\nveille",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Interface\nutilisateur",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Options\navancées",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Réglages\nréinitialisés !"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Source\nd'alim.",
-            "description": "Source d'alimentation. Règle la tension de coupure (DC 10V) (S 3.3V par cellules, désactive la limite de puissance)"
-        },
-        "MinVolCell": {
-            "displayText": "Tension\nminimale",
-            "description": "Tension minimale autorisée par cellule (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Tension\nQC",
-            "description": "Tension maximale désirée avec une alimentation QC"
-        },
-        "PDNegTimeout": {
-            "displayText": "Délai\nexpir. PD",
-            "description": "Délai de la negociation PD par étapes de 100ms pour la compatiblité avec certains chargeurs QC"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Enables PPS & EPR modes"
-        },
-        "BoostTemperature": {
-            "displayText": "Temp.\nboost",
-            "description": "Température utilisée en \"mode boost\""
-        },
-        "AutoStart": {
-            "displayText": "Chauffer au\ndémarrage",
-            "description": "A=activé | V=mode veille | O=mode veille à température ambiante"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Incrément\nappui court",
-            "description": "Incrément de changement de température sur appui court"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Incrément\nappui long",
-            "description": "Incrément de changement de température sur appui long"
-        },
-        "LockingMode": {
-            "displayText": "Verrouiller\nles boutons",
-            "description": "Pendant la soudure, appuyer sur les deux boutons pour les verrouiller (B=boost seulement | V=verr. total)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat\nTemp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat\nSpeed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDuration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDuration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDuration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDuration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDuration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown\nSpeed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Sensibilité\nau mouvement",
-            "description": "1=peu sensible | ... | 9=très sensible"
-        },
-        "SleepTemperature": {
-            "displayText": "Temp.\nveille",
-            "description": "Température de la panne en \"mode veille\""
-        },
-        "SleepTimeout": {
-            "displayText": "Délai\nveille",
-            "description": "Délai avant mise en veille (s=secondes | m=minutes)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Délai\narrêt",
-            "description": "Délai avant l'arrêt du fer à souder (m=minutes)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Sensibilité\ncapteur effet hall",
-            "description": "Sensibilité du capteur à effet Hall pour la mise en veille (1=peu sensible | ... | 9=très sensible)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Unité de\ntempérature",
-            "description": "C=Celsius | F=Fahrenheit"
-        },
-        "DisplayRotation": {
-            "displayText": "Orientation\nde l'écran",
-            "description": "D=droitier | G=gaucher | A=automatique"
-        },
-        "CooldownBlink": {
-            "displayText": "Refroidir en\nclignotant",
-            "description": "Faire clignoter la température lors du refroidissement tant que la panne est chaude"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Vitesse de\ndéfilement",
-            "description": "Vitesse de défilement du texte (R=rapide | L=lent)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Inverser les\ntouches + -",
-            "description": "Inverser les boutons d'ajustement de température"
-        },
-        "AnimSpeed": {
-            "displayText": "Vitesse\nanim. icônes",
-            "description": "Vitesse des animations des icônes dans le menu (L=lente | M=moyenne | R=rapide)"
-        },
-        "AnimLoop": {
-            "displayText": "Rejouer\nanim. icônes",
-            "description": "Rejouer en boucle les animations des icônes dans le menu principal"
-        },
-        "Brightness": {
-            "displayText": "Luminosité\nde l'écran",
-            "description": "Ajuster la luminosité de l'écran OLED"
-        },
-        "ColourInversion": {
-            "displayText": "Inverser\nles couleurs",
-            "description": "Inverser les couleurs de l'écran OLED"
-        },
-        "LOGOTime": {
-            "displayText": "Durée logo\ndémarrage",
-            "description": "Définit la durée d'affichage du logo au démarrage (s=secondes)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Écran veille\ndétaillé",
-            "description": "Afficher les informations détaillées sur l'écran de veille"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Écran soudure\ndétaillé",
-            "description": "Afficher les informations détaillées sur l'écran de soudure"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Activer le bluetooth basse consommation"
-        },
-        "PowerLimit": {
-            "displayText": "Limite de\npuissance",
-            "description": "Puissance maximale utilisable (W=watts)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Étalonner CJC\nau prochain démarrage",
-            "description": "Au prochain démarrage, la compensation de soudure froide sera calibrée (non nécessaire si Delta T est < 5°C)."
-        },
-        "VoltageCalibration": {
-            "displayText": "Étalonner\ntension d'entrée",
-            "description": "Étalonner tension d'entrée (appui long pour quitter)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Puissance\nimpulsions",
-            "description": "Puissance des impulsions pour éviter la mise en veille des batteries (watts)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Délai entre\nles impulsions",
-            "description": "Délai entre chaque impulsion pour empêcher la mise en veille (x 2.5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Durée des\nimpulsions",
-            "description": "Durée des impulsions pour empêcher la mise en veille (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Réinitialisation\nd'usine",
-            "description": "Réinitialiser tous les réglages"
-        },
-        "LanguageSwitch": {
-            "displayText": "Langue:\n FR    Français",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Accéléromètre\nnon détecté !"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "USB-PD\nnon détecté !"
+    },
+    "LockingKeysString": {
+      "message": "VERROUIL"
+    },
+    "UnlockingKeysString": {
+      "message": "DEVERROU"
+    },
+    "WarningKeysLockedString": {
+      "message": "! VERR. !"
+    },
+    "WarningThermalRunaway": {
+      "message": "Emballement\nthermique"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Avant de redémarrer, assurez-vous que la panne et la poignée sont à température ambiante !"
+    },
+    "CJCCalibrating": {
+      "message": "Etalonnage\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Voulez-vous vraiment réinitialiser les paramètres aux valeurs par défaut ?"
+    },
+    "UVLOWarningString": {
+      "message": "DC FAIBL"
+    },
+    "UndervoltageString": {
+      "message": "Sous-tension\n"
+    },
+    "InputVoltageString": {
+      "message": "V d'entrée: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "En veille...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Panne: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Votre appareil semble être une contrefaçon !"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to\nstart profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "D",
+    "SettingLeftChar": "G",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "L",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "R",
+    "SettingStartSolderingChar": "A",
+    "SettingStartSleepChar": "V",
+    "SettingStartSleepOffChar": "O",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "V"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Paramètres\nd'alim.",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Paramètres\nde soudure",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Mode\nveille",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Interface\nutilisateur",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Options\navancées",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Source\nd'alim.",
+      "description": "Source d'alimentation. Règle la tension de coupure (DC 10V) (S 3.3V par cellules, désactive la limite de puissance)"
+    },
+    "MinVolCell": {
+      "displayText": "Tension\nminimale",
+      "description": "Tension minimale autorisée par cellule (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Tension\nQC",
+      "description": "Tension maximale désirée avec une alimentation QC"
+    },
+    "PDNegTimeout": {
+      "displayText": "Délai\nexpir. PD",
+      "description": "Délai de la negociation PD par étapes de 100ms pour la compatiblité avec certains chargeurs QC"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Enables PPS & EPR modes"
+    },
+    "BoostTemperature": {
+      "displayText": "Temp.\nboost",
+      "description": "Température utilisée en \"mode boost\""
+    },
+    "AutoStart": {
+      "displayText": "Chauffer au\ndémarrage",
+      "description": "A=activé | V=mode veille | O=mode veille à température ambiante"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Incrément\nappui court",
+      "description": "Incrément de changement de température sur appui court"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Incrément\nappui long",
+      "description": "Incrément de changement de température sur appui long"
+    },
+    "LockingMode": {
+      "displayText": "Verrouiller\nles boutons",
+      "description": "Pendant la soudure, appuyer sur les deux boutons pour les verrouiller (B=boost seulement | V=verr. total)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat\nTemp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat\nSpeed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDuration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDuration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDuration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDuration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDuration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown\nSpeed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Sensibilité\nau mouvement",
+      "description": "1=peu sensible | ... | 9=très sensible"
+    },
+    "SleepTemperature": {
+      "displayText": "Temp.\nveille",
+      "description": "Température de la panne en \"mode veille\""
+    },
+    "SleepTimeout": {
+      "displayText": "Délai\nveille",
+      "description": "Délai avant mise en veille (s=secondes | m=minutes)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Délai\narrêt",
+      "description": "Délai avant l'arrêt du fer à souder (m=minutes)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Sensibilité\ncapteur effet hall",
+      "description": "Sensibilité du capteur à effet Hall pour la mise en veille (1=peu sensible | ... | 9=très sensible)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Unité de\ntempérature",
+      "description": "C=Celsius | F=Fahrenheit"
+    },
+    "DisplayRotation": {
+      "displayText": "Orientation\nde l'écran",
+      "description": "D=droitier | G=gaucher | A=automatique"
+    },
+    "CooldownBlink": {
+      "displayText": "Refroidir en\nclignotant",
+      "description": "Faire clignoter la température lors du refroidissement tant que la panne est chaude"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Vitesse de\ndéfilement",
+      "description": "Vitesse de défilement du texte (R=rapide | L=lent)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Inverser les\ntouches + -",
+      "description": "Inverser les boutons d'ajustement de température"
+    },
+    "AnimSpeed": {
+      "displayText": "Vitesse\nanim. icônes",
+      "description": "Vitesse des animations des icônes dans le menu (L=lente | M=moyenne | R=rapide)"
+    },
+    "AnimLoop": {
+      "displayText": "Rejouer\nanim. icônes",
+      "description": "Rejouer en boucle les animations des icônes dans le menu principal"
+    },
+    "Brightness": {
+      "displayText": "Luminosité\nde l'écran",
+      "description": "Ajuster la luminosité de l'écran OLED"
+    },
+    "ColourInversion": {
+      "displayText": "Inverser\nles couleurs",
+      "description": "Inverser les couleurs de l'écran OLED"
+    },
+    "LOGOTime": {
+      "displayText": "Durée logo\ndémarrage",
+      "description": "Définit la durée d'affichage du logo au démarrage (s=secondes)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Écran veille\ndétaillé",
+      "description": "Afficher les informations détaillées sur l'écran de veille"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Écran soudure\ndétaillé",
+      "description": "Afficher les informations détaillées sur l'écran de soudure"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Activer le bluetooth basse consommation"
+    },
+    "PowerLimit": {
+      "displayText": "Limite de\npuissance",
+      "description": "Puissance maximale utilisable (W=watts)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Étalonner CJC\nau prochain démarrage",
+      "description": "Au prochain démarrage, la compensation de soudure froide sera calibrée (non nécessaire si Delta T est < 5°C)."
+    },
+    "VoltageCalibration": {
+      "displayText": "Étalonner\ntension d'entrée",
+      "description": "Étalonner tension d'entrée (appui long pour quitter)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Puissance\nimpulsions",
+      "description": "Puissance des impulsions pour éviter la mise en veille des batteries (watts)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Délai entre\nles impulsions",
+      "description": "Délai entre chaque impulsion pour empêcher la mise en veille (x 2.5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Durée des\nimpulsions",
+      "description": "Durée des impulsions pour empêcher la mise en veille (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Réinitialisation\nd'usine",
+      "description": "Réinitialiser tous les réglages"
+    },
+    "LanguageSwitch": {
+      "displayText": "Langue:\n FR    Français",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_HR.json
+++ b/Translations/translation_HR.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "HR",
-    "languageLocalName": "Hrvatski",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Kalibracija\ndovršena!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Neke postavke\nsu izmijenjene!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Akcelerometar\nnije pronađen!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "USB-PD IC\nnije pronađen!"
-        },
-        "LockingKeysString": {
-            "message": "ZAKLJUČ"
-        },
-        "UnlockingKeysString": {
-            "message": "OTKLJUČ"
-        },
-        "WarningKeysLockedString": {
-            "message": "ZAKLJUČ!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Neispravan\ngrijač"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Prije restarta provjerite da su vrh i ručka na sobnoj temperaturi!"
-        },
-        "CJCCalibrating": {
-            "message": "kalibriram\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Jeste li sigurni da želite sve postavke vratiti na tvorničke vrijednosti?"
-        },
-        "UVLOWarningString": {
-            "message": "BAT!!!"
-        },
-        "UndervoltageString": {
-            "message": "PRENIZAK NAPON\n"
-        },
-        "InputVoltageString": {
-            "message": "Napon V: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "SPAVAM...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Vrh: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Vaš uređaj je najvjerojatnije krivotvoren!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to\nstart profile"
-        }
+  "languageCode": "HR",
+  "languageLocalName": "Hrvatski",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Kalibracija\ndovršena!"
     },
-    "characters": {
-        "SettingRightChar": "D",
-        "SettingLeftChar": "L",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "S",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "B",
-        "SettingStartSolderingChar": "L",
-        "SettingStartSleepChar": "T",
-        "SettingStartSleepOffChar": "H",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "Z"
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Postavke\nnapajanja",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Postavke\nlemljenja",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Ušteda\nenergije",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Korisničko\nsučelje",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Napredne\nopcije",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Neke postavke\nsu izmijenjene!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Izvor\nnapajanja",
-            "description": "Izvor napajanja. Postavlja napon isključivanja. (DC 10V) (S 3.3V po ćeliji)"
-        },
-        "MinVolCell": {
-            "displayText": "Najniži\nnapon",
-            "description": "Najniži dozvoljeni napon po ćeliji baterije (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Snaga\nnapajanja",
-            "description": "Snaga modula za napajanje"
-        },
-        "PDNegTimeout": {
-            "displayText": "USB-PD\ntimeout",
-            "description": "Timeout za USB-Power Delivery u koracima od 100ms za kompatibilnost s nekim QC punjačima"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Enables PPS & EPR modes"
-        },
-        "BoostTemperature": {
-            "displayText": "Boost\ntemp",
-            "description": "Temperatura u pojačanom (Boost) načinu."
-        },
-        "AutoStart": {
-            "displayText": "Auto\nstart",
-            "description": "Ako je aktivno, lemilica po uključivanju napajanja odmah počinje grijati. (L=lemljenje | T=spavanje toplo | H=spavanje hladno)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Korak temp\nkratki pritisak",
-            "description": "Korak temperature pri kratkom pritisku tipke"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Korak temp\ndugi pritisak",
-            "description": "Korak temperature pri dugačkom pritisku tipke"
-        },
-        "LockingMode": {
-            "displayText": "Zaključavanje\ntipki",
-            "description": "Tokom lemljenja, držite obje tipke kako biste ih zaključali ili otključali (B=zaključan boost | Z=zaključano sve)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat\nTemp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat\nSpeed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDuration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDuration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDuration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDuration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDuration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown\nSpeed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Osjetljivost\npokreta",
-            "description": "Osjetljivost prepoznavanja pokreta. (1=najmanje osjetljivo | ... | 9=najosjetljivije)"
-        },
-        "SleepTemperature": {
-            "displayText": "Temp\nspavanja",
-            "description": "Temperatura na koju se spušta lemilica nakon određenog vremena mirovanja (C | F)"
-        },
-        "SleepTimeout": {
-            "displayText": "Vrijeme\nspavanja",
-            "description": "Vrijeme mirovanja nakon kojega lemilica spušta temperaturu. (Minute | Sekunde)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Vrijeme\ngašenja",
-            "description": "Vrijeme mirovanja nakon kojega će se lemilica ugasiti (Minute)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Osjetljivost\nHall senzora",
-            "description": "Osjetljivost senzora magnetskog polja za detekciju spavanja (N=Najmanja | S=Srednja | V=Visoka)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Jedinica\ntemperature",
-            "description": "Jedinica temperature (C=Celzij | F=Fahrenheit)"
-        },
-        "DisplayRotation": {
-            "displayText": "Rotacija\nekrana",
-            "description": "Orijentacija ekrana (D=desnoruki | L=ljevoruki | A=automatski)"
-        },
-        "CooldownBlink": {
-            "displayText": "Upozorenje\npri hlađenju",
-            "description": "Bljeskanje temperature prilikom hlađenja, ako je lemilica vruća"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Brzina\nporuka",
-            "description": "Brzina kretanja dugačkih poruka (B=brzo | S=sporo)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Zamjena\n+ - tipki",
-            "description": "Zamjenjuje funkciju gornje i donje tipke za podešavanje temperature"
-        },
-        "AnimSpeed": {
-            "displayText": "Brzina\nanimacije",
-            "description": "Brzina animacije ikona u menijima (S=sporo | M=srednje | B=brzo)"
-        },
-        "AnimLoop": {
-            "displayText": "Ponavljanje\nanimacije",
-            "description": "Hoće li se animacije menija vrtiti u petlji - samo ako brzina animacije nije na \"Ugašeno\""
-        },
-        "Brightness": {
-            "displayText": "Svjetlina\nekrana",
-            "description": "Podešavanje svjetline OLED ekrana. Veća svjetlina može dugotrajno dovesti do pojave duhova na ekranu."
-        },
-        "ColourInversion": {
-            "displayText": "Inverzija\nekrana",
-            "description": "Inverzan prikaz slike na ekranu"
-        },
-        "LOGOTime": {
-            "displayText": "Trajanje\nboot logotipa",
-            "description": "Trajanje prikaza boot logotipa (s=seconds)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Detalji\npri čekanju",
-            "description": "Prikazivanje detaljnih informacija tijekom čekanja"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Detalji\npri lemljenju",
-            "description": "Prikazivanje detaljnih informacija tijekom lemljenja"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Enables BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Ograničenje\nsnage",
-            "description": "Najveća snaga koju lemilica smije vući iz napajanja (W=watt)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Kalibracija kod\nsljed. starta",
-            "description": "Kod sljedećeg starta izvršit će se kalibracija (nije potrebno ako je pogreška manja od 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Kalibracija\nnapajanja",
-            "description": "Kalibracija ulaznog napona napajanja (Podešavanje tipkama, dugački pritisak za kraj)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Snaga period.\npulsa napajanja",
-            "description": "Intenzitet periodičkog pulsa kojega lemilica povlači kako se USB napajanje ne bi ugasilo (W=watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Interval per.\npulsa nap.",
-            "description": "Razmak periodičkih pulseva koje lemilica povlači kako se USB napajanje ne bi ugasilo (x 2.5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Trajanje per.\npulsa nap.",
-            "description": "Trajanje periodičkog pulsa kojega lemilica povlači kako se USB napajanje ne bi ugasilo (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Tvorničke\npostavke",
-            "description": "Vraćanje svih postavki na tvorničke vrijednosti"
-        },
-        "LanguageSwitch": {
-            "displayText": "Jezik:\n HR    Hrvatski",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Akcelerometar\nnije pronađen!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "USB-PD IC\nnije pronađen!"
+    },
+    "LockingKeysString": {
+      "message": "ZAKLJUČ"
+    },
+    "UnlockingKeysString": {
+      "message": "OTKLJUČ"
+    },
+    "WarningKeysLockedString": {
+      "message": "ZAKLJUČ!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Neispravan\ngrijač"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Prije restarta provjerite da su vrh i ručka na sobnoj temperaturi!"
+    },
+    "CJCCalibrating": {
+      "message": "kalibriram\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Jeste li sigurni da želite sve postavke vratiti na tvorničke vrijednosti?"
+    },
+    "UVLOWarningString": {
+      "message": "BAT!!!"
+    },
+    "UndervoltageString": {
+      "message": "PRENIZAK NAPON\n"
+    },
+    "InputVoltageString": {
+      "message": "Napon V: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "SPAVAM...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Vrh: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Vaš uređaj je najvjerojatnije krivotvoren!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to\nstart profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "D",
+    "SettingLeftChar": "L",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "S",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "B",
+    "SettingStartSolderingChar": "L",
+    "SettingStartSleepChar": "T",
+    "SettingStartSleepOffChar": "H",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "Z"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Postavke\nnapajanja",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Postavke\nlemljenja",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Ušteda\nenergije",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Korisničko\nsučelje",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Napredne\nopcije",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Izvor\nnapajanja",
+      "description": "Izvor napajanja. Postavlja napon isključivanja. (DC 10V) (S 3.3V po ćeliji)"
+    },
+    "MinVolCell": {
+      "displayText": "Najniži\nnapon",
+      "description": "Najniži dozvoljeni napon po ćeliji baterije (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Snaga\nnapajanja",
+      "description": "Snaga modula za napajanje"
+    },
+    "PDNegTimeout": {
+      "displayText": "USB-PD\ntimeout",
+      "description": "Timeout za USB-Power Delivery u koracima od 100ms za kompatibilnost s nekim QC punjačima"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Enables PPS & EPR modes"
+    },
+    "BoostTemperature": {
+      "displayText": "Boost\ntemp",
+      "description": "Temperatura u pojačanom (Boost) načinu."
+    },
+    "AutoStart": {
+      "displayText": "Auto\nstart",
+      "description": "Ako je aktivno, lemilica po uključivanju napajanja odmah počinje grijati. (L=lemljenje | T=spavanje toplo | H=spavanje hladno)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Korak temp\nkratki pritisak",
+      "description": "Korak temperature pri kratkom pritisku tipke"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Korak temp\ndugi pritisak",
+      "description": "Korak temperature pri dugačkom pritisku tipke"
+    },
+    "LockingMode": {
+      "displayText": "Zaključavanje\ntipki",
+      "description": "Tokom lemljenja, držite obje tipke kako biste ih zaključali ili otključali (B=zaključan boost | Z=zaključano sve)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat\nTemp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat\nSpeed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDuration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDuration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDuration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDuration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDuration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown\nSpeed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Osjetljivost\npokreta",
+      "description": "Osjetljivost prepoznavanja pokreta. (1=najmanje osjetljivo | ... | 9=najosjetljivije)"
+    },
+    "SleepTemperature": {
+      "displayText": "Temp\nspavanja",
+      "description": "Temperatura na koju se spušta lemilica nakon određenog vremena mirovanja (C | F)"
+    },
+    "SleepTimeout": {
+      "displayText": "Vrijeme\nspavanja",
+      "description": "Vrijeme mirovanja nakon kojega lemilica spušta temperaturu. (Minute | Sekunde)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Vrijeme\ngašenja",
+      "description": "Vrijeme mirovanja nakon kojega će se lemilica ugasiti (Minute)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Osjetljivost\nHall senzora",
+      "description": "Osjetljivost senzora magnetskog polja za detekciju spavanja (N=Najmanja | S=Srednja | V=Visoka)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Jedinica\ntemperature",
+      "description": "Jedinica temperature (C=Celzij | F=Fahrenheit)"
+    },
+    "DisplayRotation": {
+      "displayText": "Rotacija\nekrana",
+      "description": "Orijentacija ekrana (D=desnoruki | L=ljevoruki | A=automatski)"
+    },
+    "CooldownBlink": {
+      "displayText": "Upozorenje\npri hlađenju",
+      "description": "Bljeskanje temperature prilikom hlađenja, ako je lemilica vruća"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Brzina\nporuka",
+      "description": "Brzina kretanja dugačkih poruka (B=brzo | S=sporo)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Zamjena\n+ - tipki",
+      "description": "Zamjenjuje funkciju gornje i donje tipke za podešavanje temperature"
+    },
+    "AnimSpeed": {
+      "displayText": "Brzina\nanimacije",
+      "description": "Brzina animacije ikona u menijima (S=sporo | M=srednje | B=brzo)"
+    },
+    "AnimLoop": {
+      "displayText": "Ponavljanje\nanimacije",
+      "description": "Hoće li se animacije menija vrtiti u petlji - samo ako brzina animacije nije na \"Ugašeno\""
+    },
+    "Brightness": {
+      "displayText": "Svjetlina\nekrana",
+      "description": "Podešavanje svjetline OLED ekrana. Veća svjetlina može dugotrajno dovesti do pojave duhova na ekranu."
+    },
+    "ColourInversion": {
+      "displayText": "Inverzija\nekrana",
+      "description": "Inverzan prikaz slike na ekranu"
+    },
+    "LOGOTime": {
+      "displayText": "Trajanje\nboot logotipa",
+      "description": "Trajanje prikaza boot logotipa (s=seconds)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Detalji\npri čekanju",
+      "description": "Prikazivanje detaljnih informacija tijekom čekanja"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Detalji\npri lemljenju",
+      "description": "Prikazivanje detaljnih informacija tijekom lemljenja"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Enables BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Ograničenje\nsnage",
+      "description": "Najveća snaga koju lemilica smije vući iz napajanja (W=watt)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Kalibracija kod\nsljed. starta",
+      "description": "Kod sljedećeg starta izvršit će se kalibracija (nije potrebno ako je pogreška manja od 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Kalibracija\nnapajanja",
+      "description": "Kalibracija ulaznog napona napajanja (Podešavanje tipkama, dugački pritisak za kraj)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Snaga period.\npulsa napajanja",
+      "description": "Intenzitet periodičkog pulsa kojega lemilica povlači kako se USB napajanje ne bi ugasilo (W=watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Interval per.\npulsa nap.",
+      "description": "Razmak periodičkih pulseva koje lemilica povlači kako se USB napajanje ne bi ugasilo (x 2.5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Trajanje per.\npulsa nap.",
+      "description": "Trajanje periodičkog pulsa kojega lemilica povlači kako se USB napajanje ne bi ugasilo (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Tvorničke\npostavke",
+      "description": "Vraćanje svih postavki na tvorničke vrijednosti"
+    },
+    "LanguageSwitch": {
+      "displayText": "Jezik:\n HR    Hrvatski",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_HR.json
+++ b/Translations/translation_HR.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Izvor\nnapajanja",
@@ -123,8 +134,8 @@
       "description": "Timeout za USB-Power Delivery u koracima od 100ms za kompatibilnost s nekim QC punjačima"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
-      "description": "Enables PPS & EPR modes"
+      "displayText": "PD\nMode",
+      "description": "No Dynamic disables EPR & PPS, Safe mode does not use padding resistance"
     },
     "BoostTemperature": {
       "displayText": "Boost\ntemp",

--- a/Translations/translation_HU.json
+++ b/Translations/translation_HU.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "HU",
-    "languageLocalName": "Magyar",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Kalibráció\nkész!"
-        },
-        "ResetOKMessage": {
-            "message": "Törlés OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Beállítások\nvisszaállítva!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Nincs\ngyorsulásmérő!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "Nincs\nUSB-PD IC!"
-        },
-        "LockingKeysString": {
-            "message": "LEZÁRVA"
-        },
-        "UnlockingKeysString": {
-            "message": "FELOLDVA"
-        },
-        "WarningKeysLockedString": {
-            "message": "!LEZÁRVA!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Kontrollálatlan\nhőmérséklet!"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Újraindítás előtt a hegy és az eszköz legyen szobahőmérsékletű!"
-        },
-        "CJCCalibrating": {
-            "message": "Kalibrálás\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Biztos visszaállítja a beállításokat alapértékekre?"
-        },
-        "UVLOWarningString": {
-            "message": "DC túl alacsony"
-        },
-        "UndervoltageString": {
-            "message": "Alulfeszültség\n"
-        },
-        "InputVoltageString": {
-            "message": "Bemenet V: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Alvás...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Hegy: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Az eszköz valószínűleg nem eredeti!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to\nstart profile"
-        }
+  "languageCode": "HU",
+  "languageLocalName": "Magyar",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Kalibráció\nkész!"
     },
-    "characters": {
-        "SettingRightChar": "J",
-        "SettingLeftChar": "B",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "L",
-        "SettingMediumChar": "K",
-        "SettingFastChar": "Gy",
-        "SettingStartSolderingChar": "F",
-        "SettingStartSleepChar": "A",
-        "SettingStartSleepOffChar": "Sz",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "T"
+    "ResetOKMessage": {
+      "message": "Törlés OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Táp\nbeállítások",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Forrasztási\nbeállítások",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Alvási\nmódok",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Felhasználói\nfelület",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Haladó\nbeállítások",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Beállítások\nvisszaállítva!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Áram\nforrás",
-            "description": "Kikapcsolási feszültség beállítása (DC:10V | S:3.3V/LiPo cella | ki)"
-        },
-        "MinVolCell": {
-            "displayText": "Minimum\nfeszültség",
-            "description": "Minimális engedélyezett cellafeszültség (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Max. USB\nfeszültség",
-            "description": "Maximális USB feszültség (QuickCharge)"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\nidőtúllépés",
-            "description": "PD egyeztetés időkerete (kompatibilitás QC töltőkkel) (x 100ms)"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Enables PPS & EPR modes"
-        },
-        "BoostTemperature": {
-            "displayText": "Boost\nhőmérséklet",
-            "description": "Hőmérséklet \"boost\" módban"
-        },
-        "AutoStart": {
-            "displayText": "Automatikus\nindítás",
-            "description": "Bekapcsolás után automatikusan lépjen forrasztás módba (F=forrasztás | A=alvó mód | Sz=szobahőmérséklet)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Hőm. állítás\nrövid",
-            "description": "Hőmérséklet állítás rövid gombnyomásra (C | F)"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Hőm. állítás\nhosszú",
-            "description": "Hőmérséklet állítás hosszú gombnyomásra (C | F)"
-        },
-        "LockingMode": {
-            "displayText": "Lezárás\nengedélyezés",
-            "description": "Forrasztás közben mindkét gombot hosszan lenyomva lezárja a kezelést (B=csak \"boost\" módban | T=teljes lezárás)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat\nTemp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat\nSpeed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDuration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDuration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDuration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDuration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDuration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown\nSpeed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Mozgás\nérzékenység",
-            "description": "Mozgás érzékenység beállítása (1=legkevésbé érzékeny | ... | 9=legérzékenyebb)"
-        },
-        "SleepTemperature": {
-            "displayText": "Alvási\nhőmérséklet",
-            "description": "Hőmérséklet alvó módban (C | F)"
-        },
-        "SleepTimeout": {
-            "displayText": "Alvás\nidőzítő",
-            "description": "Alvási időzítő (perc | másodperc)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Kikapcsolás\nidőzítő",
-            "description": "Kikapcsolási időzítő (perc)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Alvásérzékelő\nérzékenység",
-            "description": "Alvásérzékelő gyorsulásmérő érzékenysége (1=legkevésbé érzékeny | ... | 9=legérzékenyebb)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Hőmérséklet\nmértékegysége",
-            "description": "Hőmérséklet mértékegysége (C=Celsius | F=Fahrenheit)"
-        },
-        "DisplayRotation": {
-            "displayText": "Kijelző\ntájolása",
-            "description": "Kijelző tájolása (J=jobbkezes | B=balkezes | A=automatikus)"
-        },
-        "CooldownBlink": {
-            "displayText": "Villogás\nhűléskor",
-            "description": "Villogjon a hőmérséklet kijelzése hűlés közben, amíg a forrasztó hegy forró"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Görgetés\nsebessége",
-            "description": "Szöveggörgetés sebessége"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "+/- gomb\nmegfordítása",
-            "description": "Forrasztó hegy hőmérsékletállító gombok felcserélése"
-        },
-        "AnimSpeed": {
-            "displayText": "Animáció\nsebessége",
-            "description": "Menüikonok animációjának sebessége (L=lassú | K=közepes | Gy=gyors)"
-        },
-        "AnimLoop": {
-            "displayText": "Folytonos\nanimáció",
-            "description": "Főmenü ikonjainak folytonos animációja"
-        },
-        "Brightness": {
-            "displayText": "Képernyő\nkontraszt",
-            "description": "Képernyő kontrasztjának állítása"
-        },
-        "ColourInversion": {
-            "displayText": "Képernyő\ninvertálás",
-            "description": "Képernyő színeinek invertálása"
-        },
-        "LOGOTime": {
-            "displayText": "Boot logo\nmegjelenítés",
-            "description": "Boot logo megjelenítési idejének beállítása (s=seconds)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Részletes\nkészenlét",
-            "description": "Részletes információk megjelenítése kisebb betűméretben a készenléti képernyőn"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Részletes\nforrasztás infó",
-            "description": "Részletes információk megjelenítése forrasztás közben"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Enables BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Teljesítmény\nmaximum",
-            "description": "Maximális felvett teljesitmény beállitása"
-        },
-        "CalibrateCJC": {
-            "displayText": "Calibrate CJC\nköv. indításnál",
-            "description": "Következő indításnál a hegy Cold Junction Compensation kalibrálása (nem szükséges ha Delta T kisebb mint 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Bemeneti fesz.\nkalibrálása?",
-            "description": "Bemeneti feszültség kalibrálása (hosszan nyomva kilép)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Ébr. pulzus\nnagysága",
-            "description": "Powerbankot ébrentartó áramfelvételi pulzusok nagysága (W)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Ébr. pulzus\nidőköze",
-            "description": "Powerbankot ébrentartó áramfelvételi pulzusok időköze (x 2.5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Ébr. pulzus\nidőtartama",
-            "description": "Powerbankot ébrentartó áramfelvételi pulzusok időtartama (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Gyári\nbeállítások?",
-            "description": "Beállítások alaphelyzetbe állítása"
-        },
-        "LanguageSwitch": {
-            "displayText": "Nyelv:\n HU      Magyar",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Nincs\ngyorsulásmérő!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "Nincs\nUSB-PD IC!"
+    },
+    "LockingKeysString": {
+      "message": "LEZÁRVA"
+    },
+    "UnlockingKeysString": {
+      "message": "FELOLDVA"
+    },
+    "WarningKeysLockedString": {
+      "message": "!LEZÁRVA!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Kontrollálatlan\nhőmérséklet!"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Újraindítás előtt a hegy és az eszköz legyen szobahőmérsékletű!"
+    },
+    "CJCCalibrating": {
+      "message": "Kalibrálás\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Biztos visszaállítja a beállításokat alapértékekre?"
+    },
+    "UVLOWarningString": {
+      "message": "DC túl alacsony"
+    },
+    "UndervoltageString": {
+      "message": "Alulfeszültség\n"
+    },
+    "InputVoltageString": {
+      "message": "Bemenet V: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Alvás...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Hegy: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Az eszköz valószínűleg nem eredeti!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to\nstart profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "J",
+    "SettingLeftChar": "B",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "L",
+    "SettingMediumChar": "K",
+    "SettingFastChar": "Gy",
+    "SettingStartSolderingChar": "F",
+    "SettingStartSleepChar": "A",
+    "SettingStartSleepOffChar": "Sz",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "T"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Táp\nbeállítások",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Forrasztási\nbeállítások",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Alvási\nmódok",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Felhasználói\nfelület",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Haladó\nbeállítások",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Áram\nforrás",
+      "description": "Kikapcsolási feszültség beállítása (DC:10V | S:3.3V/LiPo cella | ki)"
+    },
+    "MinVolCell": {
+      "displayText": "Minimum\nfeszültség",
+      "description": "Minimális engedélyezett cellafeszültség (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Max. USB\nfeszültség",
+      "description": "Maximális USB feszültség (QuickCharge)"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\nidőtúllépés",
+      "description": "PD egyeztetés időkerete (kompatibilitás QC töltőkkel) (x 100ms)"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Enables PPS & EPR modes"
+    },
+    "BoostTemperature": {
+      "displayText": "Boost\nhőmérséklet",
+      "description": "Hőmérséklet \"boost\" módban"
+    },
+    "AutoStart": {
+      "displayText": "Automatikus\nindítás",
+      "description": "Bekapcsolás után automatikusan lépjen forrasztás módba (F=forrasztás | A=alvó mód | Sz=szobahőmérséklet)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Hőm. állítás\nrövid",
+      "description": "Hőmérséklet állítás rövid gombnyomásra (C | F)"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Hőm. állítás\nhosszú",
+      "description": "Hőmérséklet állítás hosszú gombnyomásra (C | F)"
+    },
+    "LockingMode": {
+      "displayText": "Lezárás\nengedélyezés",
+      "description": "Forrasztás közben mindkét gombot hosszan lenyomva lezárja a kezelést (B=csak \"boost\" módban | T=teljes lezárás)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat\nTemp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat\nSpeed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDuration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDuration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDuration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDuration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDuration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown\nSpeed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Mozgás\nérzékenység",
+      "description": "Mozgás érzékenység beállítása (1=legkevésbé érzékeny | ... | 9=legérzékenyebb)"
+    },
+    "SleepTemperature": {
+      "displayText": "Alvási\nhőmérséklet",
+      "description": "Hőmérséklet alvó módban (C | F)"
+    },
+    "SleepTimeout": {
+      "displayText": "Alvás\nidőzítő",
+      "description": "Alvási időzítő (perc | másodperc)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Kikapcsolás\nidőzítő",
+      "description": "Kikapcsolási időzítő (perc)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Alvásérzékelő\nérzékenység",
+      "description": "Alvásérzékelő gyorsulásmérő érzékenysége (1=legkevésbé érzékeny | ... | 9=legérzékenyebb)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Hőmérséklet\nmértékegysége",
+      "description": "Hőmérséklet mértékegysége (C=Celsius | F=Fahrenheit)"
+    },
+    "DisplayRotation": {
+      "displayText": "Kijelző\ntájolása",
+      "description": "Kijelző tájolása (J=jobbkezes | B=balkezes | A=automatikus)"
+    },
+    "CooldownBlink": {
+      "displayText": "Villogás\nhűléskor",
+      "description": "Villogjon a hőmérséklet kijelzése hűlés közben, amíg a forrasztó hegy forró"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Görgetés\nsebessége",
+      "description": "Szöveggörgetés sebessége"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "+/- gomb\nmegfordítása",
+      "description": "Forrasztó hegy hőmérsékletállító gombok felcserélése"
+    },
+    "AnimSpeed": {
+      "displayText": "Animáció\nsebessége",
+      "description": "Menüikonok animációjának sebessége (L=lassú | K=közepes | Gy=gyors)"
+    },
+    "AnimLoop": {
+      "displayText": "Folytonos\nanimáció",
+      "description": "Főmenü ikonjainak folytonos animációja"
+    },
+    "Brightness": {
+      "displayText": "Képernyő\nkontraszt",
+      "description": "Képernyő kontrasztjának állítása"
+    },
+    "ColourInversion": {
+      "displayText": "Képernyő\ninvertálás",
+      "description": "Képernyő színeinek invertálása"
+    },
+    "LOGOTime": {
+      "displayText": "Boot logo\nmegjelenítés",
+      "description": "Boot logo megjelenítési idejének beállítása (s=seconds)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Részletes\nkészenlét",
+      "description": "Részletes információk megjelenítése kisebb betűméretben a készenléti képernyőn"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Részletes\nforrasztás infó",
+      "description": "Részletes információk megjelenítése forrasztás közben"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Enables BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Teljesítmény\nmaximum",
+      "description": "Maximális felvett teljesitmény beállitása"
+    },
+    "CalibrateCJC": {
+      "displayText": "Calibrate CJC\nköv. indításnál",
+      "description": "Következő indításnál a hegy Cold Junction Compensation kalibrálása (nem szükséges ha Delta T kisebb mint 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Bemeneti fesz.\nkalibrálása?",
+      "description": "Bemeneti feszültség kalibrálása (hosszan nyomva kilép)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Ébr. pulzus\nnagysága",
+      "description": "Powerbankot ébrentartó áramfelvételi pulzusok nagysága (W)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Ébr. pulzus\nidőköze",
+      "description": "Powerbankot ébrentartó áramfelvételi pulzusok időköze (x 2.5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Ébr. pulzus\nidőtartama",
+      "description": "Powerbankot ébrentartó áramfelvételi pulzusok időtartama (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Gyári\nbeállítások?",
+      "description": "Beállítások alaphelyzetbe állítása"
+    },
+    "LanguageSwitch": {
+      "displayText": "Nyelv:\n HU      Magyar",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_HU.json
+++ b/Translations/translation_HU.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Áram\nforrás",
@@ -123,8 +134,8 @@
       "description": "PD egyeztetés időkerete (kompatibilitás QC töltőkkel) (x 100ms)"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
-      "description": "Enables PPS & EPR modes"
+      "displayText": "PD\nMode",
+      "description": "No Dynamic disables EPR & PPS, Safe mode does not use padding resistance"
     },
     "BoostTemperature": {
       "displayText": "Boost\nhőmérséklet",

--- a/Translations/translation_IT.json
+++ b/Translations/translation_IT.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Sorgente\nalimentaz",
@@ -123,7 +134,7 @@
       "description": "Regola il massimo tempo utile per la negoziazione del protocollo USB Power Delivery con alimentatori compatibili [0: disattiva; multipli di 100 ms]"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "Abilita le modalità Power Delivery PPS ed EPR"
     },
     "BoostTemperature": {

--- a/Translations/translation_IT.json
+++ b/Translations/translation_IT.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "IT",
-    "languageLocalName": "Italiano",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Calibrazione\ncompletata!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Impostazioni\nripristinate"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Accelerometro\nnon rilevato"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "USB PD\nnon rilevato"
-        },
-        "LockingKeysString": {
-            "message": "Blocc."
-        },
-        "UnlockingKeysString": {
-            "message": "Sblocc."
-        },
-        "WarningKeysLockedString": {
-            "message": "BLOCCATO"
-        },
-        "WarningThermalRunaway": {
-            "message": "Temperatura\nfuori controllo"
-        },
-        "WarningTipShorted": {
-            "message": "Punta in cortocircuito!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Prima di riavviare assicurati che la punta e l'impugnatura siano a temperatura ambiente!"
-        },
-        "CJCCalibrating": {
-            "message": "Calibrazione in corso\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Ripristinare le impostazioni predefinite?"
-        },
-        "UVLOWarningString": {
-            "message": "DC BASSA"
-        },
-        "UndervoltageString": {
-            "message": "DC INSUFFICIENTE\n"
-        },
-        "InputVoltageString": {
-            "message": "V in: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Riposo\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Punta: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preriscaldamento\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Raffreddamento\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "È probabile che questo dispositivo sia contraffatto!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Troppo caldo\nper il profilo"
-        }
+  "languageCode": "IT",
+  "languageLocalName": "Italiano",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Calibrazione\ncompletata!"
     },
-    "characters": {
-        "SettingRightChar": "D",
-        "SettingLeftChar": "S",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "L",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "V",
-        "SettingStartSolderingChar": "S",
-        "SettingStartSleepChar": "R",
-        "SettingStartSleepOffChar": "A",
-        "SettingLockBoostChar": "T",
-        "SettingLockFullChar": "C"
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Opzioni\nalimentaz",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Opzioni\nsaldatura",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Risparmio\nenergetico",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Interfaccia\nutente",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Opzioni\navanzate",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Impostazioni\nripristinate"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Sorgente\nalimentaz",
-            "description": "Imposta una tensione minima di alimentazione attraverso la selezione di una sorgente [DC: 10 V; 3S/4S/5S/6S: 3,3 V per cella]"
-        },
-        "MinVolCell": {
-            "displayText": "Tensione\nmin celle",
-            "description": "Modifica la tensione di minima carica delle celle di una batteria Li-Po [3S: 3,0-3,7 V; 4S/5S/6S: 2,4-3,7 V]"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Tensione\nQC",
-            "description": "Imposta la massima tensione negoziabile con un alimentatore Quick Charge [volt]"
-        },
-        "PDNegTimeout": {
-            "displayText": "Abilitazione\nUSB PD",
-            "description": "Regola il massimo tempo utile per la negoziazione del protocollo USB Power Delivery con alimentatori compatibili [0: disattiva; multipli di 100 ms]"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-	    "description": "Abilita le modalità Power Delivery PPS ed EPR"
-        },
-        "BoostTemperature": {
-            "displayText": "Temp\nTurbo",
-            "description": "Imposta la temperatura della funzione turbo [°C/°F]"
-        },
-        "AutoStart": {
-            "displayText": "Avvio\nautomatico",
-            "description": "Attiva automaticamente il saldatore quando viene alimentato [S: saldatura; R: riposo; A: temperatura ambiente]"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Temp passo\nbreve",
-            "description": "Imposta il passo dei valori di temperatura per una breve pressione dei tasti"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Temp passo\nlungo",
-            "description": "Imposta il passo dei valori di temperatura per una lunga pressione dei tasti"
-        },
-        "LockingMode": {
-            "displayText": "Blocco\ntasti",
-            "description": "Blocca i tasti durante la modalità saldatura; tieni premuto entrambi per bloccare o sbloccare [T: consenti Turbo; C: blocco completo]"
-        },
-        "ProfilePhases": {
-            "displayText": "Fasi modalità\nprofilo",
-            "description": "Imposta il numero di fasi da attuare per un profilo di riscaldamento personalizzato"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Temperatura\npreriscaldamento",
-            "description": "Imposta la temperatura di preriscaldamento da raggiungere all'inizio del profilo di riscaldamento"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Velocità\npreriscaldamento",
-            "description": "Imposta la velocità di preriscaldamento [°C/s]"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Temperatura\nfase 1",
-            "description": "Imposta la temperatura da raggiungere alla fine di questa fase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Durata\nfase 1",
-            "description": "Imposta la durata di questa fase [secondi]"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Temperatura\nfase 2",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Durata\nfase 2",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Temperatura\nfase 3",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Durata\nfase 3",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Temperatura\nfase 4",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Durata\nfase 4",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Temperatura\nfase 5",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Durata\nfase 5",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Velocità\nraffreddamento",
-            "description": "Imposta la velocità di raffreddamento al termine del profilo di riscaldamento [°C/s]"
-        },
-        "MotionSensitivity": {
-            "displayText": "Sensibilità\nal movimento",
-            "description": "Imposta la sensibilità al movimento per uscire dalla modalità riposo [1: minima; 9: massima]"
-        },
-        "SleepTemperature": {
-            "displayText": "Temperatura\nriposo",
-            "description": "Imposta la temperatura da mantenere in modalità riposo [°C/°F]"
-        },
-        "SleepTimeout": {
-            "displayText": "Timer\nriposo",
-            "description": "Imposta il timer per entrare in modalità riposo [secondi/minuti]"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Timer\nspegnimento",
-            "description": "Imposta il timer per lo spegnimento [minuti]"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Sensore\nHall",
-            "description": "Regola la sensibilità del sensore ad effetto Hall per entrare in modalità riposo [1: minima; 9: massima]"
-        },
-        "TemperatureUnit": {
-            "displayText": "Unità di\ntemperatura",
-            "description": "Scegli l'unità di misura per la temperatura [C: grado Celsius; F: grado Farenheit]"
-        },
-        "DisplayRotation": {
-            "displayText": "Orientamento\nschermo",
-            "description": "Imposta l'orientamento dello schermo [D: mano destra; S: mano sinistra; A: automatico]"
-        },
-        "CooldownBlink": {
-            "displayText": "Avviso\npunta calda",
-            "description": "Evidenzia il valore di temperatura durante il raffreddamento se la punta è ancora calda"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Velocità\ntesto",
-            "description": "Imposta la velocità di scorrimento del testo [L: lenta; V: veloce]"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Inversione\ntasti",
-            "description": "Inverti i tasti per aumentare o diminuire la temperatura della punta"
-        },
-        "AnimSpeed": {
-            "displayText": "Velocità\nanimazioni",
-            "description": "Imposta la velocità di riproduzione delle animazioni del menù principale [L: lenta; M: media; V: veloce]"
-        },
-        "AnimLoop": {
-            "displayText": "Ciclo\nanimazioni",
-            "description": "Abilita la riproduzione ciclica delle animazioni del menù principale"
-        },
-        "Brightness": {
-            "displayText": "Luminosità\nschermo",
-            "description": "Regola la luminosità dello schermo [1: minimo; 10: massimo]"
-        },
-        "ColourInversion": {
-            "displayText": "Inverti\ncolori",
-            "description": "Inverti i colori dello schermo"
-        },
-        "LOGOTime": {
-            "displayText": "Durata\nlogo",
-            "description": "Imposta la permanenza sullo schermo del logo iniziale [secondi]"
-        },
-        "AdvancedIdle": {
-            "displayText": "Interfaccia\ntestuale",
-            "description": "Mostra informazioni dettagliate all'interno della schermata principale"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Dettagli\nsaldatura",
-            "description": "Mostra informazioni dettagliate durante la modalità saldatura"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Abilita BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Limite\npotenza",
-            "description": "Imposta il valore di potenza massima erogabile al saldatore [watt]"
-        },
-        "CalibrateCJC": {
-            "displayText": "Calibra T\nall'avvio",
-            "description": "Calibra le rilevazioni di temperatura al prossimo riavvio (non necessario se lo scarto di temperatura è minore di 5 °C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Calibrazione\ntensione",
-            "description": "Calibra la tensione in ingresso; regola con entrambi i tasti, tieni premuto il tasto superiore per uscire"
-        },
-        "PowerPulsePower": {
-            "displayText": "Potenza\nimpulso",
-            "description": "Regola la potenza di un \"impulso sveglia\" atto a prevenire lo standby eventuale dell'alimentatore [watt]"
-        },
-        "PowerPulseWait": {
-            "displayText": "Distanza\nimpulsi",
-            "description": "Imposta il tempo che deve intercorrere tra due \"impulsi sveglia\" [multipli di 2,5 s]"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Durata\nimpulso",
-            "description": "Regola la durata dell'«impulso sveglia» [multipli di 250 ms]"
-        },
-        "SettingsReset": {
-            "displayText": "Ripristino\nimpostazioni",
-            "description": "Ripristina le impostazioni predefinite"
-        },
-        "LanguageSwitch": {
-            "displayText": "Lingua:\n IT    Italiano",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Accelerometro\nnon rilevato"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "USB PD\nnon rilevato"
+    },
+    "LockingKeysString": {
+      "message": "Blocc."
+    },
+    "UnlockingKeysString": {
+      "message": "Sblocc."
+    },
+    "WarningKeysLockedString": {
+      "message": "BLOCCATO"
+    },
+    "WarningThermalRunaway": {
+      "message": "Temperatura\nfuori controllo"
+    },
+    "WarningTipShorted": {
+      "message": "Punta in cortocircuito!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Prima di riavviare assicurati che la punta e l'impugnatura siano a temperatura ambiente!"
+    },
+    "CJCCalibrating": {
+      "message": "Calibrazione in corso\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Ripristinare le impostazioni predefinite?"
+    },
+    "UVLOWarningString": {
+      "message": "DC BASSA"
+    },
+    "UndervoltageString": {
+      "message": "DC INSUFFICIENTE\n"
+    },
+    "InputVoltageString": {
+      "message": "V in: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Riposo\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Punta: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preriscaldamento\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Raffreddamento\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "È probabile che questo dispositivo sia contraffatto!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Troppo caldo\nper il profilo"
     }
+  },
+  "characters": {
+    "SettingRightChar": "D",
+    "SettingLeftChar": "S",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "L",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "V",
+    "SettingStartSolderingChar": "S",
+    "SettingStartSleepChar": "R",
+    "SettingStartSleepOffChar": "A",
+    "SettingLockBoostChar": "T",
+    "SettingLockFullChar": "C"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Opzioni\nalimentaz",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Opzioni\nsaldatura",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Risparmio\nenergetico",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Interfaccia\nutente",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Opzioni\navanzate",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Sorgente\nalimentaz",
+      "description": "Imposta una tensione minima di alimentazione attraverso la selezione di una sorgente [DC: 10 V; 3S/4S/5S/6S: 3,3 V per cella]"
+    },
+    "MinVolCell": {
+      "displayText": "Tensione\nmin celle",
+      "description": "Modifica la tensione di minima carica delle celle di una batteria Li-Po [3S: 3,0-3,7 V; 4S/5S/6S: 2,4-3,7 V]"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Tensione\nQC",
+      "description": "Imposta la massima tensione negoziabile con un alimentatore Quick Charge [volt]"
+    },
+    "PDNegTimeout": {
+      "displayText": "Abilitazione\nUSB PD",
+      "description": "Regola il massimo tempo utile per la negoziazione del protocollo USB Power Delivery con alimentatori compatibili [0: disattiva; multipli di 100 ms]"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Abilita le modalità Power Delivery PPS ed EPR"
+    },
+    "BoostTemperature": {
+      "displayText": "Temp\nTurbo",
+      "description": "Imposta la temperatura della funzione turbo [°C/°F]"
+    },
+    "AutoStart": {
+      "displayText": "Avvio\nautomatico",
+      "description": "Attiva automaticamente il saldatore quando viene alimentato [S: saldatura; R: riposo; A: temperatura ambiente]"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Temp passo\nbreve",
+      "description": "Imposta il passo dei valori di temperatura per una breve pressione dei tasti"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Temp passo\nlungo",
+      "description": "Imposta il passo dei valori di temperatura per una lunga pressione dei tasti"
+    },
+    "LockingMode": {
+      "displayText": "Blocco\ntasti",
+      "description": "Blocca i tasti durante la modalità saldatura; tieni premuto entrambi per bloccare o sbloccare [T: consenti Turbo; C: blocco completo]"
+    },
+    "ProfilePhases": {
+      "displayText": "Fasi modalità\nprofilo",
+      "description": "Imposta il numero di fasi da attuare per un profilo di riscaldamento personalizzato"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Temperatura\npreriscaldamento",
+      "description": "Imposta la temperatura di preriscaldamento da raggiungere all'inizio del profilo di riscaldamento"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Velocità\npreriscaldamento",
+      "description": "Imposta la velocità di preriscaldamento [°C/s]"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Temperatura\nfase 1",
+      "description": "Imposta la temperatura da raggiungere alla fine di questa fase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Durata\nfase 1",
+      "description": "Imposta la durata di questa fase [secondi]"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Temperatura\nfase 2",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Durata\nfase 2",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Temperatura\nfase 3",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Durata\nfase 3",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Temperatura\nfase 4",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Durata\nfase 4",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Temperatura\nfase 5",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Durata\nfase 5",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Velocità\nraffreddamento",
+      "description": "Imposta la velocità di raffreddamento al termine del profilo di riscaldamento [°C/s]"
+    },
+    "MotionSensitivity": {
+      "displayText": "Sensibilità\nal movimento",
+      "description": "Imposta la sensibilità al movimento per uscire dalla modalità riposo [1: minima; 9: massima]"
+    },
+    "SleepTemperature": {
+      "displayText": "Temperatura\nriposo",
+      "description": "Imposta la temperatura da mantenere in modalità riposo [°C/°F]"
+    },
+    "SleepTimeout": {
+      "displayText": "Timer\nriposo",
+      "description": "Imposta il timer per entrare in modalità riposo [secondi/minuti]"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Timer\nspegnimento",
+      "description": "Imposta il timer per lo spegnimento [minuti]"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Sensore\nHall",
+      "description": "Regola la sensibilità del sensore ad effetto Hall per entrare in modalità riposo [1: minima; 9: massima]"
+    },
+    "TemperatureUnit": {
+      "displayText": "Unità di\ntemperatura",
+      "description": "Scegli l'unità di misura per la temperatura [C: grado Celsius; F: grado Farenheit]"
+    },
+    "DisplayRotation": {
+      "displayText": "Orientamento\nschermo",
+      "description": "Imposta l'orientamento dello schermo [D: mano destra; S: mano sinistra; A: automatico]"
+    },
+    "CooldownBlink": {
+      "displayText": "Avviso\npunta calda",
+      "description": "Evidenzia il valore di temperatura durante il raffreddamento se la punta è ancora calda"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Velocità\ntesto",
+      "description": "Imposta la velocità di scorrimento del testo [L: lenta; V: veloce]"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Inversione\ntasti",
+      "description": "Inverti i tasti per aumentare o diminuire la temperatura della punta"
+    },
+    "AnimSpeed": {
+      "displayText": "Velocità\nanimazioni",
+      "description": "Imposta la velocità di riproduzione delle animazioni del menù principale [L: lenta; M: media; V: veloce]"
+    },
+    "AnimLoop": {
+      "displayText": "Ciclo\nanimazioni",
+      "description": "Abilita la riproduzione ciclica delle animazioni del menù principale"
+    },
+    "Brightness": {
+      "displayText": "Luminosità\nschermo",
+      "description": "Regola la luminosità dello schermo [1: minimo; 10: massimo]"
+    },
+    "ColourInversion": {
+      "displayText": "Inverti\ncolori",
+      "description": "Inverti i colori dello schermo"
+    },
+    "LOGOTime": {
+      "displayText": "Durata\nlogo",
+      "description": "Imposta la permanenza sullo schermo del logo iniziale [secondi]"
+    },
+    "AdvancedIdle": {
+      "displayText": "Interfaccia\ntestuale",
+      "description": "Mostra informazioni dettagliate all'interno della schermata principale"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Dettagli\nsaldatura",
+      "description": "Mostra informazioni dettagliate durante la modalità saldatura"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Abilita BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Limite\npotenza",
+      "description": "Imposta il valore di potenza massima erogabile al saldatore [watt]"
+    },
+    "CalibrateCJC": {
+      "displayText": "Calibra T\nall'avvio",
+      "description": "Calibra le rilevazioni di temperatura al prossimo riavvio (non necessario se lo scarto di temperatura è minore di 5 °C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Calibrazione\ntensione",
+      "description": "Calibra la tensione in ingresso; regola con entrambi i tasti, tieni premuto il tasto superiore per uscire"
+    },
+    "PowerPulsePower": {
+      "displayText": "Potenza\nimpulso",
+      "description": "Regola la potenza di un \"impulso sveglia\" atto a prevenire lo standby eventuale dell'alimentatore [watt]"
+    },
+    "PowerPulseWait": {
+      "displayText": "Distanza\nimpulsi",
+      "description": "Imposta il tempo che deve intercorrere tra due \"impulsi sveglia\" [multipli di 2,5 s]"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Durata\nimpulso",
+      "description": "Regola la durata dell'«impulso sveglia» [multipli di 250 ms]"
+    },
+    "SettingsReset": {
+      "displayText": "Ripristino\nimpostazioni",
+      "description": "Ripristina le impostazioni predefinite"
+    },
+    "LanguageSwitch": {
+      "displayText": "Lingua:\n IT    Italiano",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_JA_JP.json
+++ b/Translations/translation_JA_JP.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "下限電圧",
@@ -124,7 +135,7 @@
     },
     "USBPDMode": {
       "displayText": "PD VPDO",
-      "description": "Enables PPS & EPR modes"
+      "description": "No Dynamic disables EPR & PPS, Safe mode does not use padding resistance"
     },
     "BoostTemperature": {
       "displayText": "ブースト温度",

--- a/Translations/translation_JA_JP.json
+++ b/Translations/translation_JA_JP.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "JA_JP",
-    "languageLocalName": "日本語",
-    "tempUnitFahrenheit": true,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Calibration done!"
-        },
-        "ResetOKMessage": {
-            "message": "リセットOK"
-        },
-        "SettingsResetMessage": {
-            "message": "初期化されました"
-        },
-        "NoAccelerometerMessage": {
-            "message": "加速度計未検出"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "PD IC未検出"
-        },
-        "LockingKeysString": {
-            "message": "ボタンロック"
-        },
-        "UnlockingKeysString": {
-            "message": "ロックを解除"
-        },
-        "WarningKeysLockedString": {
-            "message": "!入力ロック中!"
-        },
-        "WarningThermalRunaway": {
-            "message": "過熱"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Before rebooting, make sure tip & handle are at room temperature!"
-        },
-        "CJCCalibrating": {
-            "message": "calibrating"
-        },
-        "SettingsResetWarning": {
-            "message": "設定をリセットしますか？"
-        },
-        "UVLOWarningString": {
-            "message": "電圧が低すぎます"
-        },
-        "UndervoltageString": {
-            "message": "Undervoltage"
-        },
-        "InputVoltageString": {
-            "message": "Input V: "
-        },
-        "SleepingAdvancedString": {
-            "message": "Sleeping..."
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Tip: "
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "このデバイスはおそらく偽造品です"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to start profile"
-        }
+  "languageCode": "JA_JP",
+  "languageLocalName": "日本語",
+  "tempUnitFahrenheit": true,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Calibration done!"
     },
-    "characters": {
-        "SettingRightChar": "右",
-        "SettingLeftChar": "左",
-        "SettingAutoChar": "自",
-        "SettingSlowChar": "遅",
-        "SettingMediumChar": "中",
-        "SettingFastChar": "速",
-        "SettingStartSolderingChar": "熱",
-        "SettingStartSleepChar": "待",
-        "SettingStartSleepOffChar": "室",
-        "SettingLockBoostChar": "ブ",
-        "SettingLockFullChar": "全"
+    "ResetOKMessage": {
+      "message": "リセットOK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "電源設定",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "半田付け設定",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "待機設定",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "UI設定",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "高度な設定",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "初期化されました"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "下限電圧",
-            "description": "下限電圧を指定する <DC=10V | S=セルあたり3.3V、電力制限を無効化>"
-        },
-        "MinVolCell": {
-            "displayText": "最低電圧",
-            "description": "セルあたりの最低電圧 <ボルト> <3S: 3.0V - 3.7V, 4/5/6S: 2.4V - 3.7V>"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC電圧",
-            "description": "QC電源使用時に要求する目標電圧"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\ntimeout",
-            "description": "一部のQC電源との互換性のため、PDネゴシエーションをタイムアウトする時間 <x100ms（ミリ秒）>"
-        },
-        "PDVpdo": {
-            "displayText": "PD VPDO",
-            "description": "Enables PPS & EPR modes"
-        },
-        "BoostTemperature": {
-            "displayText": "ブースト温度",
-            "description": "ブーストモードで使用される温度"
-        },
-        "AutoStart": {
-            "displayText": "自動加熱",
-            "description": "電源投入時に自動的に加熱する <熱=半田付けモード | 待=スタンバイモード | 室=室温スタンバイモード>"
-        },
-        "TempChangeShortStep": {
-            "displayText": "温度変化 短",
-            "description": "ボタンを短く押した時の温度変化値"
-        },
-        "TempChangeLongStep": {
-            "displayText": "温度変化 長",
-            "description": "ボタンを長押しした時の温度変化値"
-        },
-        "LockingMode": {
-            "displayText": "ボタンロック",
-            "description": "半田付けモード時に両方のボタンを長押しし、ボタンロックする <ブ=ブーストのみ許可 | 全=すべてをロック>"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile Phases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat Temp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat Speed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1 Temp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1 Duration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2 Temp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2 Duration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3 Temp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3 Duration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4 Temp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4 Duration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5 Temp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5 Duration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown Speed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "動きの感度",
-            "description": "1=最低感度 | ... | 9=最高感度"
-        },
-        "SleepTemperature": {
-            "displayText": "待機温度",
-            "description": "スタンバイ時のコテ先温度"
-        },
-        "SleepTimeout": {
-            "displayText": "待機遅延",
-            "description": "スタンバイモードに入るまでの待機時間 <s=秒 | m=分>"
-        },
-        "ShutdownTimeout": {
-            "displayText": "自動オフ",
-            "description": "自動電源オフまでの待機時間 <m=分>"
-        },
-        "HallEffSensitivity": {
-            "displayText": "磁界感度",
-            "description": "スタンバイモードに入るのに使用される磁場センサーの感度 <1=最低感度 | ... | 9=最高感度>"
-        },
-        "TemperatureUnit": {
-            "displayText": "温度単位",
-            "description": "C=摂氏 | F=華氏"
-        },
-        "DisplayRotation": {
-            "displayText": "画面の向き",
-            "description": "右=右利き | 左=左利き | 自=自動"
-        },
-        "CooldownBlink": {
-            "displayText": "冷却中に点滅",
-            "description": "加熱の停止後、コテ先が熱い間は温度表示を点滅する"
-        },
-        "ScrollingSpeed": {
-            "displayText": "スクロール速度",
-            "description": "テキストをスクロールする速さ <遅=遅い | 速=速い>"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "キー入れ替え",
-            "description": "温度設定時に+ボタンと-ボタンを入れ替える"
-        },
-        "AnimSpeed": {
-            "displayText": "動画の速度",
-            "description": "メニューアイコンのアニメーションの速さ <遅=低速 | 中=中速 | 速=高速>"
-        },
-        "AnimLoop": {
-            "displayText": "動画をループ",
-            "description": "メニューアイコンのアニメーションをループする"
-        },
-        "Brightness": {
-            "displayText": "画面輝度",
-            "description": "画面の明るさ・コントラストを変更する"
-        },
-        "ColourInversion": {
-            "displayText": "色反転",
-            "description": "画面の色を反転する"
-        },
-        "LOGOTime": {
-            "displayText": "起動画面",
-            "description": "起動画面の表示時間を設定する"
-        },
-        "AdvancedIdle": {
-            "displayText": "詳細な待受画面",
-            "description": "待ち受け画面に詳細情報を表示する"
-        },
-        "AdvancedSoldering": {
-            "displayText": "詳細な作業画面",
-            "description": "半田付け画面に詳細情報を表示する"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth",
-            "description": "Enables BLE"
-        },
-        "PowerLimit": {
-            "displayText": "電力制限",
-            "description": "最大電力を制限する <W=ワット>"
-        },
-        "CalibrateCJC": {
-            "displayText": "Calibrate CJC",
-            "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5 C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "電圧校正",
-            "description": "入力電圧(VIN)の校正を開始する <長押しで終了>"
-        },
-        "PowerPulsePower": {
-            "displayText": "電力パルス",
-            "description": "電源をオンに保つための電力パルス <ワット>"
-        },
-        "PowerPulseWait": {
-            "displayText": "パルス間隔",
-            "description": "電源をオンに保つための電力パルスの時間間隔 <x2.5s（秒）>"
-        },
-        "PowerPulseDuration": {
-            "displayText": "パルス時間長",
-            "description": "電源をオンに保つための電力パルスの時間長 <x250ms（ミリ秒）>"
-        },
-        "SettingsReset": {
-            "displayText": "設定をリセット",
-            "description": "すべての設定を初期化する"
-        },
-        "LanguageSwitch": {
-            "displayText": "言語： 日本語",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "加速度計未検出"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "PD IC未検出"
+    },
+    "LockingKeysString": {
+      "message": "ボタンロック"
+    },
+    "UnlockingKeysString": {
+      "message": "ロックを解除"
+    },
+    "WarningKeysLockedString": {
+      "message": "!入力ロック中!"
+    },
+    "WarningThermalRunaway": {
+      "message": "過熱"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Before rebooting, make sure tip & handle are at room temperature!"
+    },
+    "CJCCalibrating": {
+      "message": "calibrating"
+    },
+    "SettingsResetWarning": {
+      "message": "設定をリセットしますか？"
+    },
+    "UVLOWarningString": {
+      "message": "電圧が低すぎます"
+    },
+    "UndervoltageString": {
+      "message": "Undervoltage"
+    },
+    "InputVoltageString": {
+      "message": "Input V: "
+    },
+    "SleepingAdvancedString": {
+      "message": "Sleeping..."
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Tip: "
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "このデバイスはおそらく偽造品です"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to start profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "右",
+    "SettingLeftChar": "左",
+    "SettingAutoChar": "自",
+    "SettingSlowChar": "遅",
+    "SettingMediumChar": "中",
+    "SettingFastChar": "速",
+    "SettingStartSolderingChar": "熱",
+    "SettingStartSleepChar": "待",
+    "SettingStartSleepOffChar": "室",
+    "SettingLockBoostChar": "ブ",
+    "SettingLockFullChar": "全"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "電源設定",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "半田付け設定",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "待機設定",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "UI設定",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "高度な設定",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "下限電圧",
+      "description": "下限電圧を指定する <DC=10V | S=セルあたり3.3V、電力制限を無効化>"
+    },
+    "MinVolCell": {
+      "displayText": "最低電圧",
+      "description": "セルあたりの最低電圧 <ボルト> <3S: 3.0V - 3.7V, 4/5/6S: 2.4V - 3.7V>"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC電圧",
+      "description": "QC電源使用時に要求する目標電圧"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\ntimeout",
+      "description": "一部のQC電源との互換性のため、PDネゴシエーションをタイムアウトする時間 <x100ms（ミリ秒）>"
+    },
+    "USBPDMode": {
+      "displayText": "PD VPDO",
+      "description": "Enables PPS & EPR modes"
+    },
+    "BoostTemperature": {
+      "displayText": "ブースト温度",
+      "description": "ブーストモードで使用される温度"
+    },
+    "AutoStart": {
+      "displayText": "自動加熱",
+      "description": "電源投入時に自動的に加熱する <熱=半田付けモード | 待=スタンバイモード | 室=室温スタンバイモード>"
+    },
+    "TempChangeShortStep": {
+      "displayText": "温度変化 短",
+      "description": "ボタンを短く押した時の温度変化値"
+    },
+    "TempChangeLongStep": {
+      "displayText": "温度変化 長",
+      "description": "ボタンを長押しした時の温度変化値"
+    },
+    "LockingMode": {
+      "displayText": "ボタンロック",
+      "description": "半田付けモード時に両方のボタンを長押しし、ボタンロックする <ブ=ブーストのみ許可 | 全=すべてをロック>"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile Phases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat Temp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat Speed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1 Temp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1 Duration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2 Temp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2 Duration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3 Temp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3 Duration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4 Temp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4 Duration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5 Temp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5 Duration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown Speed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "動きの感度",
+      "description": "1=最低感度 | ... | 9=最高感度"
+    },
+    "SleepTemperature": {
+      "displayText": "待機温度",
+      "description": "スタンバイ時のコテ先温度"
+    },
+    "SleepTimeout": {
+      "displayText": "待機遅延",
+      "description": "スタンバイモードに入るまでの待機時間 <s=秒 | m=分>"
+    },
+    "ShutdownTimeout": {
+      "displayText": "自動オフ",
+      "description": "自動電源オフまでの待機時間 <m=分>"
+    },
+    "HallEffSensitivity": {
+      "displayText": "磁界感度",
+      "description": "スタンバイモードに入るのに使用される磁場センサーの感度 <1=最低感度 | ... | 9=最高感度>"
+    },
+    "TemperatureUnit": {
+      "displayText": "温度単位",
+      "description": "C=摂氏 | F=華氏"
+    },
+    "DisplayRotation": {
+      "displayText": "画面の向き",
+      "description": "右=右利き | 左=左利き | 自=自動"
+    },
+    "CooldownBlink": {
+      "displayText": "冷却中に点滅",
+      "description": "加熱の停止後、コテ先が熱い間は温度表示を点滅する"
+    },
+    "ScrollingSpeed": {
+      "displayText": "スクロール速度",
+      "description": "テキストをスクロールする速さ <遅=遅い | 速=速い>"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "キー入れ替え",
+      "description": "温度設定時に+ボタンと-ボタンを入れ替える"
+    },
+    "AnimSpeed": {
+      "displayText": "動画の速度",
+      "description": "メニューアイコンのアニメーションの速さ <遅=低速 | 中=中速 | 速=高速>"
+    },
+    "AnimLoop": {
+      "displayText": "動画をループ",
+      "description": "メニューアイコンのアニメーションをループする"
+    },
+    "Brightness": {
+      "displayText": "画面輝度",
+      "description": "画面の明るさ・コントラストを変更する"
+    },
+    "ColourInversion": {
+      "displayText": "色反転",
+      "description": "画面の色を反転する"
+    },
+    "LOGOTime": {
+      "displayText": "起動画面",
+      "description": "起動画面の表示時間を設定する"
+    },
+    "AdvancedIdle": {
+      "displayText": "詳細な待受画面",
+      "description": "待ち受け画面に詳細情報を表示する"
+    },
+    "AdvancedSoldering": {
+      "displayText": "詳細な作業画面",
+      "description": "半田付け画面に詳細情報を表示する"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth",
+      "description": "Enables BLE"
+    },
+    "PowerLimit": {
+      "displayText": "電力制限",
+      "description": "最大電力を制限する <W=ワット>"
+    },
+    "CalibrateCJC": {
+      "displayText": "Calibrate CJC",
+      "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5 C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "電圧校正",
+      "description": "入力電圧(VIN)の校正を開始する <長押しで終了>"
+    },
+    "PowerPulsePower": {
+      "displayText": "電力パルス",
+      "description": "電源をオンに保つための電力パルス <ワット>"
+    },
+    "PowerPulseWait": {
+      "displayText": "パルス間隔",
+      "description": "電源をオンに保つための電力パルスの時間間隔 <x2.5s（秒）>"
+    },
+    "PowerPulseDuration": {
+      "displayText": "パルス時間長",
+      "description": "電源をオンに保つための電力パルスの時間長 <x250ms（ミリ秒）>"
+    },
+    "SettingsReset": {
+      "displayText": "設定をリセット",
+      "description": "すべての設定を初期化する"
+    },
+    "LanguageSwitch": {
+      "displayText": "言語： 日本語",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_LT.json
+++ b/Translations/translation_LT.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Maitinimo\nšaltinis",
@@ -123,8 +134,8 @@
       "description": "PD suderinimo laikas žingsniais po 100ms suderinamumui su kai kuriais QC įkrovikliais"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
-      "description": "Enables PPS & EPR modes"
+      "displayText": "PD\nMode",
+      "description": "No Dynamic disables EPR & PPS, Safe mode does not use padding resistance"
     },
     "BoostTemperature": {
       "displayText": "Turbo\ntemperat.",

--- a/Translations/translation_LT.json
+++ b/Translations/translation_LT.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "LT",
-    "languageLocalName": "Lietuvių",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Calibration\ndone!"
-        },
-        "ResetOKMessage": {
-            "message": "Atstatyta"
-        },
-        "SettingsResetMessage": {
-            "message": "Nust. \natstatyti!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Nerastas\nakselerometras!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "Nerastas\nUSB-PD IC!"
-        },
-        "LockingKeysString": {
-            "message": "UŽRAKIN"
-        },
-        "UnlockingKeysString": {
-            "message": "ATRAKIN"
-        },
-        "WarningKeysLockedString": {
-            "message": "!UŽRAK!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Perkaitimo\npavojus"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Before rebooting, make sure tip & handle are at room temperature!"
-        },
-        "CJCCalibrating": {
-            "message": "calibrating\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Ar norite atstatyti nustatymus į numatytas reikšmes?"
-        },
-        "UVLOWarningString": {
-            "message": "MAŽ VOLT"
-        },
-        "UndervoltageString": {
-            "message": "Žema įtampa\n"
-        },
-        "InputVoltageString": {
-            "message": "Įvestis V: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Miegu...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Antg: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Your device is most likely a counterfeit!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to\nstart profile"
-        }
+  "languageCode": "LT",
+  "languageLocalName": "Lietuvių",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Calibration\ndone!"
     },
-    "characters": {
-        "SettingRightChar": "D",
-        "SettingLeftChar": "K",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "L",
-        "SettingMediumChar": "V",
-        "SettingFastChar": "G",
-        "SettingStartSolderingChar": "T",
-        "SettingStartSleepChar": "M",
-        "SettingStartSleepOffChar": "K",
-        "SettingLockBoostChar": "T",
-        "SettingLockFullChar": "V"
+    "ResetOKMessage": {
+      "message": "Atstatyta"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Maitinimo\nnustatymai",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Litavimo\nnustatymai",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Miego\nrežimai",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Naudotojo\nsąsaja",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Išplėsti.\nnustatymai",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Nust. \natstatyti!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Maitinimo\nšaltinis",
-            "description": "Išjungimo įtampa. (DC 10V) (arba celių [S] kiekis [3.3V per celę])"
-        },
-        "MinVolCell": {
-            "displayText": "Minimalus\nvoltažas",
-            "description": "Minimalus voltažas, kuris yra leidžiamas kiekvienam baterijos elementui (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC mait.\nįtampa",
-            "description": "Maksimali QC maitinimo bloko įtampa"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\nlaikas",
-            "description": "PD suderinimo laikas žingsniais po 100ms suderinamumui su kai kuriais QC įkrovikliais"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Enables PPS & EPR modes"
-        },
-        "BoostTemperature": {
-            "displayText": "Turbo\ntemperat.",
-            "description": "Temperatūra turbo režimu"
-        },
-        "AutoStart": {
-            "displayText": "Automatinis\npaleidimas",
-            "description": "Ar pradėti kaitininti iš karto įjungus lituoklį (T=Taip | M=Miegas | K=Miegoti kambario temperatūroje)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Temp.keitim.\ntrump.spust.",
-            "description": "Temperatūros keitimo žingsnis trumpai spustėlėjus mygtuką"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Temp.keitim.\nilgas pasp.",
-            "description": "Temperatūros keitimo žingsnis ilgai paspaudus mygtuką"
-        },
-        "LockingMode": {
-            "displayText": "Mygtukų\nužraktas",
-            "description": "Lituodami, ilgai paspauskite abu mygtukus, kad juos užrakintumėte (T=leidžiamas tik Turbo režimas | V=Visiškas užrakinimas)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat\nTemp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat\nSpeed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDuration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDuration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDuration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDuration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDuration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown\nSpeed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Judesio\njautrumas",
-            "description": "Judesio jautrumas (1=Mažiausias | ... | 9=Didžiausias)"
-        },
-        "SleepTemperature": {
-            "displayText": "Miego\ntemperat.",
-            "description": "Antgalio temperatūra miego režimu"
-        },
-        "SleepTimeout": {
-            "displayText": "Miego\nlaikas",
-            "description": "Užmigimo laikas (sekundės | minutės)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Išjungimo\nlaikas",
-            "description": "Išjungimo laikas (minutės)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Holo\njutiklis",
-            "description": "Holo jutiklio jautrumas nustatant miegą (1=Mažiausias | ... | 9=Didžiausias)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Temperatūros\nvienetai",
-            "description": "Temperatūros vienetai (C=Celsijus | F=Farenheitas)"
-        },
-        "DisplayRotation": {
-            "displayText": "Ekrano\norientacija",
-            "description": "Ekrano orientacija (D=Dešiniarankiams | K=Kairiarankiams | A=Automatinė)"
-        },
-        "CooldownBlink": {
-            "displayText": "Atvėsimo\nmirksėjimas",
-            "description": "Ar mirksėti temperatūrą ekrane kol vėstantis antgalis vis dar karštas?"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Aprašymo\ngreitis",
-            "description": "Greitis, kuriuo šis tekstas slenka"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Sukeisti + -\nmygtukus?",
-            "description": "Sukeisti + - temperatūros keitimo mygtukus vietomis"
-        },
-        "AnimSpeed": {
-            "displayText": "Animacijų\ngreitis",
-            "description": "Paveiksliukų animacijų greitis meniu punktuose (L=Lėtas | V=Vidutinis | G=Greitas)"
-        },
-        "AnimLoop": {
-            "displayText": "Animacijų\npakartojimas",
-            "description": "Leidžia kartoti animacijas be sustojimo pagrindiniame meniu"
-        },
-        "Brightness": {
-            "displayText": "Ekrano\nšviesumas",
-            "description": "Nustato OLED ekrano kontrastą/šviesumą."
-        },
-        "ColourInversion": {
-            "displayText": "Ekrano\ninvertavimas",
-            "description": "Invertuoja OLED ekrano spalvas"
-        },
-        "LOGOTime": {
-            "displayText": "Boot logo\nduration",
-            "description": "Set boot logo duration (s=seconds)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Detalus lau-\nkimo ekranas",
-            "description": "Ar rodyti papildomą informaciją mažesniu šriftu laukimo ekrane"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Detalus lita-\nvimo ekranas",
-            "description": "Ar rodyti išsamią informaciją lituojant"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Enables BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Galios\nriba",
-            "description": "Didžiausia galia, kurią gali naudoti lituoklis (Vatai)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Calibrate CJC\nat next boot",
-            "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Kalibruoti\nįvesties įtampą?",
-            "description": "Įvesties įtampos kalibravimas. Trumpai paspauskite, norėdami nustatyti, ilgai paspauskite, kad išeitumėte."
-        },
-        "PowerPulsePower": {
-            "displayText": "Galios\npulso W",
-            "description": "Periodinis galios pulso intensyvumas maitinblokiui, neleidžiantis jam užmigti."
-        },
-        "PowerPulseWait": {
-            "displayText": "Galios pulso\ndažnumas",
-            "description": "Pasikartojantis laiko intervalas (x 2.5s), ties kuriuo kartojamas galios pulsas maitinblokiui, neleidžiantis jam užmigti"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Galios pulso\ntrukmė",
-            "description": "Galios pulso aktyvioji trukmė (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Atstatyti\nnustatymus?",
-            "description": "Nustato nustatymus į numatytuosius"
-        },
-        "LanguageSwitch": {
-            "displayText": "Kalba:\n LT    Lietuvių",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Nerastas\nakselerometras!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "Nerastas\nUSB-PD IC!"
+    },
+    "LockingKeysString": {
+      "message": "UŽRAKIN"
+    },
+    "UnlockingKeysString": {
+      "message": "ATRAKIN"
+    },
+    "WarningKeysLockedString": {
+      "message": "!UŽRAK!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Perkaitimo\npavojus"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Before rebooting, make sure tip & handle are at room temperature!"
+    },
+    "CJCCalibrating": {
+      "message": "calibrating\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Ar norite atstatyti nustatymus į numatytas reikšmes?"
+    },
+    "UVLOWarningString": {
+      "message": "MAŽ VOLT"
+    },
+    "UndervoltageString": {
+      "message": "Žema įtampa\n"
+    },
+    "InputVoltageString": {
+      "message": "Įvestis V: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Miegu...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Antg: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Your device is most likely a counterfeit!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to\nstart profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "D",
+    "SettingLeftChar": "K",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "L",
+    "SettingMediumChar": "V",
+    "SettingFastChar": "G",
+    "SettingStartSolderingChar": "T",
+    "SettingStartSleepChar": "M",
+    "SettingStartSleepOffChar": "K",
+    "SettingLockBoostChar": "T",
+    "SettingLockFullChar": "V"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Maitinimo\nnustatymai",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Litavimo\nnustatymai",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Miego\nrežimai",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Naudotojo\nsąsaja",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Išplėsti.\nnustatymai",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Maitinimo\nšaltinis",
+      "description": "Išjungimo įtampa. (DC 10V) (arba celių [S] kiekis [3.3V per celę])"
+    },
+    "MinVolCell": {
+      "displayText": "Minimalus\nvoltažas",
+      "description": "Minimalus voltažas, kuris yra leidžiamas kiekvienam baterijos elementui (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC mait.\nįtampa",
+      "description": "Maksimali QC maitinimo bloko įtampa"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\nlaikas",
+      "description": "PD suderinimo laikas žingsniais po 100ms suderinamumui su kai kuriais QC įkrovikliais"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Enables PPS & EPR modes"
+    },
+    "BoostTemperature": {
+      "displayText": "Turbo\ntemperat.",
+      "description": "Temperatūra turbo režimu"
+    },
+    "AutoStart": {
+      "displayText": "Automatinis\npaleidimas",
+      "description": "Ar pradėti kaitininti iš karto įjungus lituoklį (T=Taip | M=Miegas | K=Miegoti kambario temperatūroje)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Temp.keitim.\ntrump.spust.",
+      "description": "Temperatūros keitimo žingsnis trumpai spustėlėjus mygtuką"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Temp.keitim.\nilgas pasp.",
+      "description": "Temperatūros keitimo žingsnis ilgai paspaudus mygtuką"
+    },
+    "LockingMode": {
+      "displayText": "Mygtukų\nužraktas",
+      "description": "Lituodami, ilgai paspauskite abu mygtukus, kad juos užrakintumėte (T=leidžiamas tik Turbo režimas | V=Visiškas užrakinimas)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat\nTemp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat\nSpeed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDuration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDuration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDuration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDuration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDuration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown\nSpeed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Judesio\njautrumas",
+      "description": "Judesio jautrumas (1=Mažiausias | ... | 9=Didžiausias)"
+    },
+    "SleepTemperature": {
+      "displayText": "Miego\ntemperat.",
+      "description": "Antgalio temperatūra miego režimu"
+    },
+    "SleepTimeout": {
+      "displayText": "Miego\nlaikas",
+      "description": "Užmigimo laikas (sekundės | minutės)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Išjungimo\nlaikas",
+      "description": "Išjungimo laikas (minutės)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Holo\njutiklis",
+      "description": "Holo jutiklio jautrumas nustatant miegą (1=Mažiausias | ... | 9=Didžiausias)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Temperatūros\nvienetai",
+      "description": "Temperatūros vienetai (C=Celsijus | F=Farenheitas)"
+    },
+    "DisplayRotation": {
+      "displayText": "Ekrano\norientacija",
+      "description": "Ekrano orientacija (D=Dešiniarankiams | K=Kairiarankiams | A=Automatinė)"
+    },
+    "CooldownBlink": {
+      "displayText": "Atvėsimo\nmirksėjimas",
+      "description": "Ar mirksėti temperatūrą ekrane kol vėstantis antgalis vis dar karštas?"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Aprašymo\ngreitis",
+      "description": "Greitis, kuriuo šis tekstas slenka"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Sukeisti + -\nmygtukus?",
+      "description": "Sukeisti + - temperatūros keitimo mygtukus vietomis"
+    },
+    "AnimSpeed": {
+      "displayText": "Animacijų\ngreitis",
+      "description": "Paveiksliukų animacijų greitis meniu punktuose (L=Lėtas | V=Vidutinis | G=Greitas)"
+    },
+    "AnimLoop": {
+      "displayText": "Animacijų\npakartojimas",
+      "description": "Leidžia kartoti animacijas be sustojimo pagrindiniame meniu"
+    },
+    "Brightness": {
+      "displayText": "Ekrano\nšviesumas",
+      "description": "Nustato OLED ekrano kontrastą/šviesumą."
+    },
+    "ColourInversion": {
+      "displayText": "Ekrano\ninvertavimas",
+      "description": "Invertuoja OLED ekrano spalvas"
+    },
+    "LOGOTime": {
+      "displayText": "Boot logo\nduration",
+      "description": "Set boot logo duration (s=seconds)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Detalus lau-\nkimo ekranas",
+      "description": "Ar rodyti papildomą informaciją mažesniu šriftu laukimo ekrane"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Detalus lita-\nvimo ekranas",
+      "description": "Ar rodyti išsamią informaciją lituojant"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Enables BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Galios\nriba",
+      "description": "Didžiausia galia, kurią gali naudoti lituoklis (Vatai)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Calibrate CJC\nat next boot",
+      "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Kalibruoti\nįvesties įtampą?",
+      "description": "Įvesties įtampos kalibravimas. Trumpai paspauskite, norėdami nustatyti, ilgai paspauskite, kad išeitumėte."
+    },
+    "PowerPulsePower": {
+      "displayText": "Galios\npulso W",
+      "description": "Periodinis galios pulso intensyvumas maitinblokiui, neleidžiantis jam užmigti."
+    },
+    "PowerPulseWait": {
+      "displayText": "Galios pulso\ndažnumas",
+      "description": "Pasikartojantis laiko intervalas (x 2.5s), ties kuriuo kartojamas galios pulsas maitinblokiui, neleidžiantis jam užmigti"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Galios pulso\ntrukmė",
+      "description": "Galios pulso aktyvioji trukmė (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Atstatyti\nnustatymus?",
+      "description": "Nustato nustatymus į numatytuosius"
+    },
+    "LanguageSwitch": {
+      "displayText": "Kalba:\n LT    Lietuvių",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_NB.json
+++ b/Translations/translation_NB.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "NB",
-    "languageLocalName": "Norsk bokmål",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Calibration\ndone!"
-        },
-        "ResetOKMessage": {
-            "message": "Tilbakestilling OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Noen innstillinger\nble endret!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Ingen akselerometer\nfunnet!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "Ingen USB-PD IC\nfunnet!"
-        },
-        "LockingKeysString": {
-            "message": "LÅST"
-        },
-        "UnlockingKeysString": {
-            "message": "ÅPNET"
-        },
-        "WarningKeysLockedString": {
-            "message": "!LÅST!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Termisk\nrømling"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Before rebooting, make sure tip & handle are at room temperature!"
-        },
-        "CJCCalibrating": {
-            "message": "calibrating\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Er du sikker på at du vil tilbakestille til standardinnstillinger?"
-        },
-        "UVLOWarningString": {
-            "message": "Lavspenn"
-        },
-        "UndervoltageString": {
-            "message": "Underspenning\n"
-        },
-        "InputVoltageString": {
-            "message": "Innspenn.: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Dvale...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Spiss: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Enheten din er sannsynligvis en forfalskning!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to\nstart profile"
-        }
+  "languageCode": "NB",
+  "languageLocalName": "Norsk bokmål",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Calibration\ndone!"
     },
-    "characters": {
-        "SettingRightChar": "H",
-        "SettingLeftChar": "V",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "S",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "F",
-        "SettingStartSolderingChar": "L",
-        "SettingStartSleepChar": "D",
-        "SettingStartSleepOffChar": "R",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "F"
+    "ResetOKMessage": {
+      "message": "Tilbakestilling OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Effekt-\ninnst.",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Lodde-\ninnst.",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Dvale-\ninnst.",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Bruker-\ngrensesn.",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Avanserte\nvalg",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Noen innstillinger\nble endret!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Kilde\n",
-            "description": "Strømforsyning. Sett nedre spenning for automatisk nedstenging. (DC 10V) (S 3.3V per celle)"
-        },
-        "MinVolCell": {
-            "displayText": "Minimum\nspenning",
-            "description": "Minimum tillatt spenning per celle (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC-\nspenning",
-            "description": "Maks QC-spenning bolten skal forhandle om"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD-\ntidsavb.",
-            "description": "PD-forhandlingstidsavbrudd i steg på 100 ms for kompatibilitet med noen QC-ladere"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Enables PPS & EPR modes"
-        },
-        "BoostTemperature": {
-            "displayText": "KTmp\n",
-            "description": "Temperatur i \"kraft-modus\""
-        },
-        "AutoStart": {
-            "displayText": "AStart\n",
-            "description": "Start automatisk med lodding når strøm kobles til. (L=Lodding | D=Dvale | R=Dvale romtemperatur)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Temp-endring\nkort",
-            "description": "Hvor mye temperaturen skal endres ved kort trykk på knapp"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Temp-endring\nlang",
-            "description": "Hvor mye temperaturen skal endres ved langt trykk på knapp"
-        },
-        "LockingMode": {
-            "displayText": "Tillat å låse\nknapper",
-            "description": "Mens du lodder, hold nede begge knapper for å bytte mellom låsemodus (B=kun boost | F=full lås)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat\nTemp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat\nSpeed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDuration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDuration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDuration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDuration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDuration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown\nSpeed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "BSensr\n",
-            "description": "Bevegelsesfølsomhet (1=Minst følsom | ... | 9=Mest følsom)"
-        },
-        "SleepTemperature": {
-            "displayText": "DTmp\n",
-            "description": "Dvaletemperatur (C)"
-        },
-        "SleepTimeout": {
-            "displayText": "DTid\n",
-            "description": "Tid før dvale (Minutter | Sekunder)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "AvTid\n",
-            "description": "Tid før automatisk nedstenging (Minutter)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Hall-sensor\nfølsomhet",
-            "description": "Sensitiviteten til Hall-effekt-sensoren for å detektere inaktivitet (1=Minst følsom | ... | 9=Mest følsom)"
-        },
-        "TemperatureUnit": {
-            "displayText": "TmpEnh\n",
-            "description": "Temperaturskala (C=Celsius | F=Fahrenheit)"
-        },
-        "DisplayRotation": {
-            "displayText": "SkRetn\n",
-            "description": "Skjermretning (H=Høyrehendt | V=Venstrehendt | A=Automatisk)"
-        },
-        "CooldownBlink": {
-            "displayText": "KjBlnk\n",
-            "description": "Blink temperaturen på skjermen mens spissen fortsatt er varm."
-        },
-        "ScrollingSpeed": {
-            "displayText": "RullHa\n",
-            "description": "Hastigheten på rulletekst"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Bytt\n+ - kn.",
-            "description": "Bytt om på knappene for å stille temperatur"
-        },
-        "AnimSpeed": {
-            "displayText": "Anim.\nhastighet",
-            "description": "Hastigheten til animasjonene i menyen (S=slow | M=medium | F=fast)"
-        },
-        "AnimLoop": {
-            "displayText": "Anim.\nloop",
-            "description": "Loop ikon-animasjoner i hovedmenyen"
-        },
-        "Brightness": {
-            "displayText": "Skjerm-\nlysstyrke",
-            "description": "Juster lysstyrken til OLED-skjermen"
-        },
-        "ColourInversion": {
-            "displayText": "Inverter\nskjerm",
-            "description": "Inverter fargene på OLED-skjermen"
-        },
-        "LOGOTime": {
-            "displayText": "Oppstartlogo\nvarighet",
-            "description": "Setter varigheten til oppstartlogoen (s=sekunder)"
-        },
-        "AdvancedIdle": {
-            "displayText": "AvDvSk\n",
-            "description": "Vis detaljert informasjon med liten skrift på dvaleskjermen."
-        },
-        "AdvancedSoldering": {
-            "displayText": "AvLdSk\n",
-            "description": "Vis detaljert informasjon ved lodding"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Enables BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Effekt-\ngrense",
-            "description": "Maks effekt jernet kan bruke (W=watt)"
-        },
-        "CalibrateCJC": {
-            "displayText": "TempKal?\n",
-            "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "KalSpIn?\n",
-            "description": "Kalibrer spenning. Knappene justerer. Langt trykk for å gå ut"
-        },
-        "PowerPulsePower": {
-            "displayText": "Effekt-\npuls",
-            "description": "Hvor høy effekt pulsen for å holde laderen våken skal ha (watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Effektpuls\nforsink.",
-            "description": "Forsinkelse før effektpulsen utløses (x 2.5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Effektpuls\nvarighet",
-            "description": "Hvor lenge holde-våken-pulsen varer (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "TilbStl?\n",
-            "description": "Tilbakestill alle innstillinger"
-        },
-        "LanguageSwitch": {
-            "displayText": "Språk:\n NB    Norsk bm",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Ingen akselerometer\nfunnet!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "Ingen USB-PD IC\nfunnet!"
+    },
+    "LockingKeysString": {
+      "message": "LÅST"
+    },
+    "UnlockingKeysString": {
+      "message": "ÅPNET"
+    },
+    "WarningKeysLockedString": {
+      "message": "!LÅST!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Termisk\nrømling"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Before rebooting, make sure tip & handle are at room temperature!"
+    },
+    "CJCCalibrating": {
+      "message": "calibrating\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Er du sikker på at du vil tilbakestille til standardinnstillinger?"
+    },
+    "UVLOWarningString": {
+      "message": "Lavspenn"
+    },
+    "UndervoltageString": {
+      "message": "Underspenning\n"
+    },
+    "InputVoltageString": {
+      "message": "Innspenn.: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Dvale...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Spiss: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Enheten din er sannsynligvis en forfalskning!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to\nstart profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "H",
+    "SettingLeftChar": "V",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "S",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "F",
+    "SettingStartSolderingChar": "L",
+    "SettingStartSleepChar": "D",
+    "SettingStartSleepOffChar": "R",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "F"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Effekt-\ninnst.",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Lodde-\ninnst.",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Dvale-\ninnst.",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Bruker-\ngrensesn.",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Avanserte\nvalg",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Kilde\n",
+      "description": "Strømforsyning. Sett nedre spenning for automatisk nedstenging. (DC 10V) (S 3.3V per celle)"
+    },
+    "MinVolCell": {
+      "displayText": "Minimum\nspenning",
+      "description": "Minimum tillatt spenning per celle (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC-\nspenning",
+      "description": "Maks QC-spenning bolten skal forhandle om"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD-\ntidsavb.",
+      "description": "PD-forhandlingstidsavbrudd i steg på 100 ms for kompatibilitet med noen QC-ladere"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Enables PPS & EPR modes"
+    },
+    "BoostTemperature": {
+      "displayText": "KTmp\n",
+      "description": "Temperatur i \"kraft-modus\""
+    },
+    "AutoStart": {
+      "displayText": "AStart\n",
+      "description": "Start automatisk med lodding når strøm kobles til. (L=Lodding | D=Dvale | R=Dvale romtemperatur)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Temp-endring\nkort",
+      "description": "Hvor mye temperaturen skal endres ved kort trykk på knapp"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Temp-endring\nlang",
+      "description": "Hvor mye temperaturen skal endres ved langt trykk på knapp"
+    },
+    "LockingMode": {
+      "displayText": "Tillat å låse\nknapper",
+      "description": "Mens du lodder, hold nede begge knapper for å bytte mellom låsemodus (B=kun boost | F=full lås)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat\nTemp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat\nSpeed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDuration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDuration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDuration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDuration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDuration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown\nSpeed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "BSensr\n",
+      "description": "Bevegelsesfølsomhet (1=Minst følsom | ... | 9=Mest følsom)"
+    },
+    "SleepTemperature": {
+      "displayText": "DTmp\n",
+      "description": "Dvaletemperatur (C)"
+    },
+    "SleepTimeout": {
+      "displayText": "DTid\n",
+      "description": "Tid før dvale (Minutter | Sekunder)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "AvTid\n",
+      "description": "Tid før automatisk nedstenging (Minutter)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Hall-sensor\nfølsomhet",
+      "description": "Sensitiviteten til Hall-effekt-sensoren for å detektere inaktivitet (1=Minst følsom | ... | 9=Mest følsom)"
+    },
+    "TemperatureUnit": {
+      "displayText": "TmpEnh\n",
+      "description": "Temperaturskala (C=Celsius | F=Fahrenheit)"
+    },
+    "DisplayRotation": {
+      "displayText": "SkRetn\n",
+      "description": "Skjermretning (H=Høyrehendt | V=Venstrehendt | A=Automatisk)"
+    },
+    "CooldownBlink": {
+      "displayText": "KjBlnk\n",
+      "description": "Blink temperaturen på skjermen mens spissen fortsatt er varm."
+    },
+    "ScrollingSpeed": {
+      "displayText": "RullHa\n",
+      "description": "Hastigheten på rulletekst"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Bytt\n+ - kn.",
+      "description": "Bytt om på knappene for å stille temperatur"
+    },
+    "AnimSpeed": {
+      "displayText": "Anim.\nhastighet",
+      "description": "Hastigheten til animasjonene i menyen (S=slow | M=medium | F=fast)"
+    },
+    "AnimLoop": {
+      "displayText": "Anim.\nloop",
+      "description": "Loop ikon-animasjoner i hovedmenyen"
+    },
+    "Brightness": {
+      "displayText": "Skjerm-\nlysstyrke",
+      "description": "Juster lysstyrken til OLED-skjermen"
+    },
+    "ColourInversion": {
+      "displayText": "Inverter\nskjerm",
+      "description": "Inverter fargene på OLED-skjermen"
+    },
+    "LOGOTime": {
+      "displayText": "Oppstartlogo\nvarighet",
+      "description": "Setter varigheten til oppstartlogoen (s=sekunder)"
+    },
+    "AdvancedIdle": {
+      "displayText": "AvDvSk\n",
+      "description": "Vis detaljert informasjon med liten skrift på dvaleskjermen."
+    },
+    "AdvancedSoldering": {
+      "displayText": "AvLdSk\n",
+      "description": "Vis detaljert informasjon ved lodding"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Enables BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Effekt-\ngrense",
+      "description": "Maks effekt jernet kan bruke (W=watt)"
+    },
+    "CalibrateCJC": {
+      "displayText": "TempKal?\n",
+      "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "KalSpIn?\n",
+      "description": "Kalibrer spenning. Knappene justerer. Langt trykk for å gå ut"
+    },
+    "PowerPulsePower": {
+      "displayText": "Effekt-\npuls",
+      "description": "Hvor høy effekt pulsen for å holde laderen våken skal ha (watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Effektpuls\nforsink.",
+      "description": "Forsinkelse før effektpulsen utløses (x 2.5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Effektpuls\nvarighet",
+      "description": "Hvor lenge holde-våken-pulsen varer (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "TilbStl?\n",
+      "description": "Tilbakestill alle innstillinger"
+    },
+    "LanguageSwitch": {
+      "displayText": "Språk:\n NB    Norsk bm",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_NB.json
+++ b/Translations/translation_NB.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Kilde\n",
@@ -123,8 +134,8 @@
       "description": "PD-forhandlingstidsavbrudd i steg på 100 ms for kompatibilitet med noen QC-ladere"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
-      "description": "Enables PPS & EPR modes"
+      "displayText": "PD\nMode",
+      "description": "No Dynamic disables EPR & PPS, Safe mode does not use padding resistance"
     },
     "BoostTemperature": {
       "displayText": "KTmp\n",

--- a/Translations/translation_NL.json
+++ b/Translations/translation_NL.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Vermogens\nbron",
@@ -123,7 +134,7 @@
       "description": "PD onderhandelings verlooptijd, afstemmingsduur in stappen van 100 ms (voor compatibiliteit met sommige QC laders)"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "Zet PPS & EPR modes aan"
     },
     "BoostTemperature": {

--- a/Translations/translation_NL.json
+++ b/Translations/translation_NL.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "NL",
-    "languageLocalName": "Nederlands",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Kalibratie\nklaar!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Sommige instellingen\nzijn veranderd!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Geen accelerometer\ngedetecteerd!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "Geen USB-PD IC\ngedetecteerd!"
-        },
-        "LockingKeysString": {
-            "message": "GEBLOKKEERD"
-        },
-        "UnlockingKeysString": {
-            "message": "VRIJ"
-        },
-        "WarningKeysLockedString": {
-            "message": "!GEBLOKKEERD!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Thermisch\nop hol geslagen"
-        },
-        "WarningTipShorted": {
-            "message": "!Kortgesloten Soldeerpunt!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Voordat je opnieuw opstart: zorg dat de soldeerpunt op kamertemperatuur is!"
-        },
-        "CJCCalibrating": {
-            "message": "Kalibreren\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Weet je zeker dat je de fabrieksinstellingen terug wilt zetten?"
-        },
-        "UVLOWarningString": {
-            "message": "DC Laag"
-        },
-        "UndervoltageString": {
-            "message": "Te lage spanning\n"
-        },
-        "InputVoltageString": {
-            "message": "Ingangs spanning: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Slaapt...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Punt: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Voorverwarmen\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Afkoelen\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Jou apparaat is waarschijnlijk een namaak!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Te warm om\nprofiel te starten"
-        }
+  "languageCode": "NL",
+  "languageLocalName": "Nederlands",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Kalibratie\nklaar!"
     },
-    "characters": {
-        "SettingRightChar": "R",
-        "SettingLeftChar": "L",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "L",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "S",
-        "SettingStartSolderingChar": "T",
-        "SettingStartSleepChar": "S",
-        "SettingStartSleepOffChar": "Z",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "V" 
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Energie-\ninstellingen",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Soldeer\ninstellingen",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Slaap-\nstand",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Gebruiker-\nsomgeving",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Geavanceerde\ninstellingen",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Sommige instellingen\nzijn veranderd!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Vermogens\nbron",
-            "description": "Minimale spanning om de batterij te beschermen tegen te ver ontladen (DC 10V) (S=3,3V per cell, zet PWR limiet uit)"
-        },
-        "MinVolCell": {
-            "displayText": "Minimum\nspanning",
-            "description": "Minimale toegelaten voltage per cel (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC\nspanning",
-            "description": "Maximale QC spanning de soldeerbout zou moeten aanvragen"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD ver-\nloop tijd",
-            "description": "PD onderhandelings verlooptijd, afstemmingsduur in stappen van 100 ms (voor compatibiliteit met sommige QC laders)"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Zet PPS & EPR modes aan"
-        },
-        "BoostTemperature": {
-            "displayText": "Boost\ntemp",
-            "description": "Tip temperatuur tijdens \"boost-modus\""
-        },
-        "AutoStart": {
-            "displayText": "start-\ngedrag",
-            "description": "T=verwarm naar soldeer temp | S=standby op slaap temp tot bewogen | Z=standby zonder verwarmen tot bewogen"
-        },
-        "TempChangeShortStep": {
-            "displayText": "temp veran-\ndering kort",
-            "description": "Temperatuur veranderings stap bij korte druk op de knop"
-        },
-        "TempChangeLongStep": {
-            "displayText": "temp veran-\ndering lang",
-            "description": "Temperatuur veranderings stap bij lange druk op de knop"
-        },
-        "LockingMode": {
-            "displayText": "Vergrendel-\nings knoppen",
-            "description": "Houd tijdens het solderen beide knoppen ingedrukt om de vergrendeling in of uit te schakelen (B=alleen boost-modus | V=volledige vergrendeling)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profiel\nfases",
-            "description": "Nummer van fases in profiel modus"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Voorverwarm\ntemperatuur",
-            "description": "Voorverwarm naar deze temperatuur op de start van profiel modus"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Voorverwarm\nsnelheid",
-            "description": "Voorverwarm op deze snelheid (graden per seconden)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Fase 1\ntemperatuur",
-            "description": "Doel temperatuur op het einde van deze fase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Fase\nduur",
-            "description": "Doel tijdsduur van deze fase (in seconden)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Fase 2\ntemperatuur",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Fase 2\nduur",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Fase 3\ntemperatuur",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Fase 3\nduur",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Fase 4\ntemperatuur",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Fase 4\nduur",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Fase 5\ntemperatuur",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Fase 5\nduur",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Afkoel\nsnelheid",
-            "description": "De snelheid van afkoelen op het eind van profiel modus (graden per seconden)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Bewegings-\ngevoeligheid",
-            "description": "Bewegingsgevoeligheid (1=minst gevoelig | ... | 9=meest gevoelig)"
-        },
-        "SleepTemperature": {
-            "displayText": "Slaap\ntemp",
-            "description": "Temperatuur in slaapstand (°C)"
-        },
-        "SleepTimeout": {
-            "displayText": "Slaap ver-\ntraging",
-            "description": "Interval voor \"slaap stand\" start (Minuten | Seconden)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Uitschakel\nna",
-            "description": "Automatisch afsluiten na (Minuten)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Hall sensor\ngevoeligheid",
-            "description": "Gevoeligheid naar de magneten (1=minst gevoelig | ... | 9=meest gevoelig)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Temperatuur\neenheid",
-            "description": "C=°Celsius | F=°Fahrenheit"
-        },
-        "DisplayRotation": {
-            "displayText": "Scherm-\noriëntatie",
-            "description": "R=Rechtshandig | L=Linkshandig | A=Automatisch"
-        },
-        "CooldownBlink": {
-            "displayText": "Afkoel\nknipper",
-            "description": "Temperatuur knippert in hoofdmenu tijdens afkoeling"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Scroll\nsnelheid",
-            "description": "Scrollsnelheid van de tekst. (Langzaam | Snel)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Wissel\n+ - knoppen",
-            "description": "Wissel de knoppen voor temperatuur controle om"
-        },
-        "AnimSpeed": {
-            "displayText": "Anim.\nsnelheid",
-            "description": "Snelheid van de icoon animaties in het menu (Langzaam | Middel | Snel)"
-        },
-        "AnimLoop": {
-            "displayText": "Anim.\nherhaling",
-            "description": "Herhaal icoon animaties in hoofdmenu"
-        },
-        "Brightness": {
-            "displayText": "Scherm\nhelderheid",
-            "description": "Verander de helderheid van het OLED scherm"
-        },
-        "ColourInversion": {
-            "displayText": "Inverteer\nscherm",
-            "description": "Keer de kleuren van het OLED scherm om"
-        },
-        "LOGOTime": {
-            "displayText": "Opstart\nlogo duur",
-            "description": "Zet het duur van het opstart logo (s=seconden)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Detail\nslaapscherm",
-            "description": "Gedetailleerde informatie in een kleiner lettertype in het slaapscherm"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Detail\nsoldeerscherm",
-            "description": "Gedetailleerde informatie in kleiner lettertype in soldeerscherm"
-        },
-        "BluetoothLE": {
-            "displayText": "Blue-\ntooth",
-            "description": "Zet Bluetooth aan"
-        },
-        "PowerLimit": {
-            "displayText": "P\nlimiet",
-            "description": "Gemiddelde maximale vermogen dat de soldeerbout mag gebruiken (W=watt)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Kalibreer CJC\nbij opstart",
-            "description": "Bij de volgende opstart tip \"Cold Junction Compensation\" wordt gekalibreerd (niet nodig als Delta T < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Kalibreer vo-\nedingsspanning",
-            "description": "VIN Kalibreren (lang in te drukken om te annuleren)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Power\npuls",
-            "description": "Power van de aanhoud puls (W=watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Energie pulse\nvertraging",
-            "description": "Vertraging voordat de aanhoud puls wordt geactiveerd (x 2,5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Power pulse\nduur",
-            "description": "Aanhoud pulse duur (x 250 ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Instellingen\nresetten?",
-            "description": "Alle instellingen terug zetten naar fabrieksinstellingen"
-        },
-        "LanguageSwitch": {
-            "displayText": "Taal:\n NL  Nederlands",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Geen accelerometer\ngedetecteerd!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "Geen USB-PD IC\ngedetecteerd!"
+    },
+    "LockingKeysString": {
+      "message": "GEBLOKKEERD"
+    },
+    "UnlockingKeysString": {
+      "message": "VRIJ"
+    },
+    "WarningKeysLockedString": {
+      "message": "!GEBLOKKEERD!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Thermisch\nop hol geslagen"
+    },
+    "WarningTipShorted": {
+      "message": "!Kortgesloten Soldeerpunt!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Voordat je opnieuw opstart: zorg dat de soldeerpunt op kamertemperatuur is!"
+    },
+    "CJCCalibrating": {
+      "message": "Kalibreren\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Weet je zeker dat je de fabrieksinstellingen terug wilt zetten?"
+    },
+    "UVLOWarningString": {
+      "message": "DC Laag"
+    },
+    "UndervoltageString": {
+      "message": "Te lage spanning\n"
+    },
+    "InputVoltageString": {
+      "message": "Ingangs spanning: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Slaapt...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Punt: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Voorverwarmen\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Afkoelen\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Jou apparaat is waarschijnlijk een namaak!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Te warm om\nprofiel te starten"
     }
+  },
+  "characters": {
+    "SettingRightChar": "R",
+    "SettingLeftChar": "L",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "L",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "S",
+    "SettingStartSolderingChar": "T",
+    "SettingStartSleepChar": "S",
+    "SettingStartSleepOffChar": "Z",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "V"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Energie-\ninstellingen",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Soldeer\ninstellingen",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Slaap-\nstand",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Gebruiker-\nsomgeving",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Geavanceerde\ninstellingen",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Vermogens\nbron",
+      "description": "Minimale spanning om de batterij te beschermen tegen te ver ontladen (DC 10V) (S=3,3V per cell, zet PWR limiet uit)"
+    },
+    "MinVolCell": {
+      "displayText": "Minimum\nspanning",
+      "description": "Minimale toegelaten voltage per cel (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC\nspanning",
+      "description": "Maximale QC spanning de soldeerbout zou moeten aanvragen"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD ver-\nloop tijd",
+      "description": "PD onderhandelings verlooptijd, afstemmingsduur in stappen van 100 ms (voor compatibiliteit met sommige QC laders)"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Zet PPS & EPR modes aan"
+    },
+    "BoostTemperature": {
+      "displayText": "Boost\ntemp",
+      "description": "Tip temperatuur tijdens \"boost-modus\""
+    },
+    "AutoStart": {
+      "displayText": "start-\ngedrag",
+      "description": "T=verwarm naar soldeer temp | S=standby op slaap temp tot bewogen | Z=standby zonder verwarmen tot bewogen"
+    },
+    "TempChangeShortStep": {
+      "displayText": "temp veran-\ndering kort",
+      "description": "Temperatuur veranderings stap bij korte druk op de knop"
+    },
+    "TempChangeLongStep": {
+      "displayText": "temp veran-\ndering lang",
+      "description": "Temperatuur veranderings stap bij lange druk op de knop"
+    },
+    "LockingMode": {
+      "displayText": "Vergrendel-\nings knoppen",
+      "description": "Houd tijdens het solderen beide knoppen ingedrukt om de vergrendeling in of uit te schakelen (B=alleen boost-modus | V=volledige vergrendeling)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profiel\nfases",
+      "description": "Nummer van fases in profiel modus"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Voorverwarm\ntemperatuur",
+      "description": "Voorverwarm naar deze temperatuur op de start van profiel modus"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Voorverwarm\nsnelheid",
+      "description": "Voorverwarm op deze snelheid (graden per seconden)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Fase 1\ntemperatuur",
+      "description": "Doel temperatuur op het einde van deze fase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Fase\nduur",
+      "description": "Doel tijdsduur van deze fase (in seconden)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Fase 2\ntemperatuur",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Fase 2\nduur",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Fase 3\ntemperatuur",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Fase 3\nduur",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Fase 4\ntemperatuur",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Fase 4\nduur",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Fase 5\ntemperatuur",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Fase 5\nduur",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Afkoel\nsnelheid",
+      "description": "De snelheid van afkoelen op het eind van profiel modus (graden per seconden)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Bewegings-\ngevoeligheid",
+      "description": "Bewegingsgevoeligheid (1=minst gevoelig | ... | 9=meest gevoelig)"
+    },
+    "SleepTemperature": {
+      "displayText": "Slaap\ntemp",
+      "description": "Temperatuur in slaapstand (°C)"
+    },
+    "SleepTimeout": {
+      "displayText": "Slaap ver-\ntraging",
+      "description": "Interval voor \"slaap stand\" start (Minuten | Seconden)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Uitschakel\nna",
+      "description": "Automatisch afsluiten na (Minuten)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Hall sensor\ngevoeligheid",
+      "description": "Gevoeligheid naar de magneten (1=minst gevoelig | ... | 9=meest gevoelig)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Temperatuur\neenheid",
+      "description": "C=°Celsius | F=°Fahrenheit"
+    },
+    "DisplayRotation": {
+      "displayText": "Scherm-\noriëntatie",
+      "description": "R=Rechtshandig | L=Linkshandig | A=Automatisch"
+    },
+    "CooldownBlink": {
+      "displayText": "Afkoel\nknipper",
+      "description": "Temperatuur knippert in hoofdmenu tijdens afkoeling"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Scroll\nsnelheid",
+      "description": "Scrollsnelheid van de tekst. (Langzaam | Snel)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Wissel\n+ - knoppen",
+      "description": "Wissel de knoppen voor temperatuur controle om"
+    },
+    "AnimSpeed": {
+      "displayText": "Anim.\nsnelheid",
+      "description": "Snelheid van de icoon animaties in het menu (Langzaam | Middel | Snel)"
+    },
+    "AnimLoop": {
+      "displayText": "Anim.\nherhaling",
+      "description": "Herhaal icoon animaties in hoofdmenu"
+    },
+    "Brightness": {
+      "displayText": "Scherm\nhelderheid",
+      "description": "Verander de helderheid van het OLED scherm"
+    },
+    "ColourInversion": {
+      "displayText": "Inverteer\nscherm",
+      "description": "Keer de kleuren van het OLED scherm om"
+    },
+    "LOGOTime": {
+      "displayText": "Opstart\nlogo duur",
+      "description": "Zet het duur van het opstart logo (s=seconden)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Detail\nslaapscherm",
+      "description": "Gedetailleerde informatie in een kleiner lettertype in het slaapscherm"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Detail\nsoldeerscherm",
+      "description": "Gedetailleerde informatie in kleiner lettertype in soldeerscherm"
+    },
+    "BluetoothLE": {
+      "displayText": "Blue-\ntooth",
+      "description": "Zet Bluetooth aan"
+    },
+    "PowerLimit": {
+      "displayText": "P\nlimiet",
+      "description": "Gemiddelde maximale vermogen dat de soldeerbout mag gebruiken (W=watt)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Kalibreer CJC\nbij opstart",
+      "description": "Bij de volgende opstart tip \"Cold Junction Compensation\" wordt gekalibreerd (niet nodig als Delta T < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Kalibreer vo-\nedingsspanning",
+      "description": "VIN Kalibreren (lang in te drukken om te annuleren)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Power\npuls",
+      "description": "Power van de aanhoud puls (W=watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Energie pulse\nvertraging",
+      "description": "Vertraging voordat de aanhoud puls wordt geactiveerd (x 2,5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Power pulse\nduur",
+      "description": "Aanhoud pulse duur (x 250 ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Instellingen\nresetten?",
+      "description": "Alle instellingen terug zetten naar fabrieksinstellingen"
+    },
+    "LanguageSwitch": {
+      "displayText": "Taal:\n NL  Nederlands",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_NL_BE.json
+++ b/Translations/translation_NL_BE.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "NL_BE",
-    "languageLocalName": "Vlaams",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Calibratie\ngedaan!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Sommige settings\nzijn veranderd!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Geen accelerometer\ngedectecteerd!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "Geen USB-PD IC\ngedetecteerd!"
-        },
-        "LockingKeysString": {
-            "message": "LOCKED"
-        },
-        "UnlockingKeysString": {
-            "message": "UNLOCKED"
-        },
-        "WarningKeysLockedString": {
-            "message": "!LOCKED!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Thermisch\nop hol geslagen"
-        },
-        "WarningTipShorted": {
-            "message": "!Soldeerpunt kortgesloten!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Voordat je opnieuw opstart: stel zeker dat de soldeerpunt op kamertemperatuur is!"
-        },
-        "CJCCalibrating": {
-            "message": "Calibreren\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Weet je zeker dat je de fabrieksinstellingen terug wilt zetten?"
-        },
-        "UVLOWarningString": {
-            "message": "Onderspanning"
-        },
-        "UndervoltageString": {
-            "message": "Onderspanning\n"
-        },
-        "InputVoltageString": {
-            "message": "Voedingsspanning: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Slaapstand...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Punt: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Jou apparaat is waarschijnlijk namaak!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Te warm om\nprofiel te starten!"
-        }
+  "languageCode": "NL_BE",
+  "languageLocalName": "Vlaams",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Calibratie\ngedaan!"
     },
-    "characters": {
-        "SettingRightChar": "R",
-        "SettingLeftChar": "L",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "T",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "S",
-        "SettingStartSolderingChar": "T",
-        "SettingStartSleepChar": "S",
-        "SettingStartSleepOffChar": "K",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "F"
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Vermogens-\ninstellingen",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Soldeer\ninstellingen",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Slaap-\nstanden",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Gebruikers-\ninterface",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Geavanceerde\ninstellingen",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Sommige settings\nzijn veranderd!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Spannings-\nbron",
-            "description": "Minimale toegelate voltage"
-        },
-        "MinVolCell": {
-            "displayText": "Minimum\nvoltage",
-            "description": "Minimale toegelaten voltage per cel (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Vermogen\nwatt",
-            "description": "Vermogen van de adapter"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\ntimeout",
-            "description": "PD afstemmingsduur in stappen van 100ms (voor compatibiliteit met sommige QC laders)"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Zet PPS & EPR modes aan"
-        },
-        "BoostTemperature": {
-            "displayText": "Verhog\nings temp",
-            "description": "Verhogingstemperatuur"
-        },
-        "AutoStart": {
-            "displayText": "start-\ntemperatuur",
-            "description": "Breng de soldeerbout op temperatuur bij het opstarten. (T=Soldeertemperatuur | S=Slaapstand-temperatuur | K=Slaapstand kamertemperatuur)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "temp veran\ndering kort",
-            "description": "Temperatuurveranderingsstap bij korte druk op de knop"
-        },
-        "TempChangeLongStep": {
-            "displayText": "temp veran\ndering lang",
-            "description": "Temperatuurveranderingsstap bij lange druk op de knop"
-        },
-        "LockingMode": {
-            "displayText": "Vergrendel-\ning knoppen",
-            "description": "Houd tijdens het solderen beide knoppen ingedrukt om de vergrendeling in of uit te schakelen (B=alleen boost-modus | F=volledige vergrendeling)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profiel\nfases",
-            "description": "Nummer van fases in profiel modus"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Voorverwarm\ntemperatuur",
-            "description": "Voorverwarm naar deze temperatuur op de start van profiel modus"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Voorverwarm\nsnelheid",
-            "description": "Voorverwarm op deze snelheid (graden per seconden)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Fase 1\ntemperatuur",
-            "description": "Doel temperatuur op het einde van deze fase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Fase\nduur",
-            "description": "Doel tijdsduur van deze fase (in seconden)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Fase 2\ntemperatuur",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Fase 2\nduur",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Fase 3\ntemperatuur",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Fase 3\nduur",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Fase 4\ntemperatuur",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Fase 4\nduur",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Fase 5\ntemperatuur",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Fase 5\nduur",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Afkoel\nsnelheid",
-            "description": "De snelheid van afkoelen op het eind van profiel modus (graden per seconden)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Bewegings-\ngevoeligheid",
-            "description": "Bewegingsgevoeligheid (1=minst gevoelig | ... | 9=meest gevoelig)"
-        },
-        "SleepTemperature": {
-            "displayText": "Slaap\ntemp",
-            "description": "Temperatuur in slaapstand (°C)"
-        },
-        "SleepTimeout": {
-            "displayText": "Slaap\ntime-out",
-            "description": "Slaapstand time-out (Minuten | Seconden)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Uitschakel\ntime-out",
-            "description": "Automatisch afsluiten time-out (Minuten)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Hall sensor\ngevoeligheid",
-            "description": "Gevoeligheid naar de magneten (1=minst gevoelig | ... | 9=meest gevoelig)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Temperatuur\nschaal",
-            "description": "Temperatuurschaal (°C=Celsius | °F=Fahrenheit)"
-        },
-        "DisplayRotation": {
-            "displayText": "Scherm-\noriëntatie",
-            "description": "Schermoriëntatie (R=Rechtshandig | L=Linkshandig | A=Automatisch)"
-        },
-        "CooldownBlink": {
-            "displayText": "Afkoel\nknipper",
-            "description": "Temperatuur knippert in hoofdmenu tijdens afkoeling."
-        },
-        "ScrollingSpeed": {
-            "displayText": "Scroll\nsnelheid",
-            "description": "Scrollsnelheid van de tekst."
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Wissel\n+ - knoppen",
-            "description": "Wissel de knoppen voor temperatuur controle"
-        },
-        "AnimSpeed": {
-            "displayText": "Anim.\nsnelheid",
-            "description": "Snelheid van de icoon animaties in het menu (T=sloom | M=middel | S=snel)"
-        },
-        "AnimLoop": {
-            "displayText": "Anim.\nherhaling",
-            "description": "Herhaal icoon animaties in hoofdmenu"
-        },
-        "Brightness": {
-            "displayText": "Scherm\nhelderheid",
-            "description": "Verander de helderheid van het OLED scherm"
-        },
-        "ColourInversion": {
-            "displayText": "Omkeer\nscherm",
-            "description": "Omkeer de kleuren van het OLED scherm"
-        },
-        "LOGOTime": {
-            "displayText": "Opstart\nlogo lengte",
-            "description": "Zet het lengte van het opstart logo (s=seconden)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Gedetailleerd\nslaapscherm",
-            "description": "Gedetailleerde informatie in een kleiner lettertype in het slaapscherm"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Gedetailleerd\nsoldeerscherm",
-            "description": "Gedetailleerde informatie in kleiner lettertype in soldeerscherm"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Zet Bluetooth aan"
-        },
-        "PowerLimit": {
-            "displayText": "Power\nlimit",
-            "description": "Gemiddelde maximale power dat de soldeerbout mag gebruiken (W=watt)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Calibreer CJC\nbij opstart",
-            "description": "Bij de volgende opstart tip Cold Junction Compensation wordt gecalibreerd (niet nodig als Delta T < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Calibreervo-\nedingsspanning?",
-            "description": "VIN Calibreren. Bevestigen door knoppen lang in te drukken."
-        },
-        "PowerPulsePower": {
-            "displayText": "Power\npuls",
-            "description": "Power van de wakker-houd-puls (W=watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Power pulse\nvertraging",
-            "description": "Vertraging voordat de wakker-houd-puls wordt geactiveerd (x 2,5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Power pulse\nduur",
-            "description": "Keep-awake-pulse duration (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Instellingen\nresetten?",
-            "description": "Alle instellingen resetten"
-        },
-        "LanguageSwitch": {
-            "displayText": "Spraak:\n NL_BE   Vlaams",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Geen accelerometer\ngedectecteerd!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "Geen USB-PD IC\ngedetecteerd!"
+    },
+    "LockingKeysString": {
+      "message": "LOCKED"
+    },
+    "UnlockingKeysString": {
+      "message": "UNLOCKED"
+    },
+    "WarningKeysLockedString": {
+      "message": "!LOCKED!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Thermisch\nop hol geslagen"
+    },
+    "WarningTipShorted": {
+      "message": "!Soldeerpunt kortgesloten!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Voordat je opnieuw opstart: stel zeker dat de soldeerpunt op kamertemperatuur is!"
+    },
+    "CJCCalibrating": {
+      "message": "Calibreren\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Weet je zeker dat je de fabrieksinstellingen terug wilt zetten?"
+    },
+    "UVLOWarningString": {
+      "message": "Onderspanning"
+    },
+    "UndervoltageString": {
+      "message": "Onderspanning\n"
+    },
+    "InputVoltageString": {
+      "message": "Voedingsspanning: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Slaapstand...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Punt: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Jou apparaat is waarschijnlijk namaak!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Te warm om\nprofiel te starten!"
     }
+  },
+  "characters": {
+    "SettingRightChar": "R",
+    "SettingLeftChar": "L",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "T",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "S",
+    "SettingStartSolderingChar": "T",
+    "SettingStartSleepChar": "S",
+    "SettingStartSleepOffChar": "K",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "F"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Vermogens-\ninstellingen",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Soldeer\ninstellingen",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Slaap-\nstanden",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Gebruikers-\ninterface",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Geavanceerde\ninstellingen",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Spannings-\nbron",
+      "description": "Minimale toegelate voltage"
+    },
+    "MinVolCell": {
+      "displayText": "Minimum\nvoltage",
+      "description": "Minimale toegelaten voltage per cel (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Vermogen\nwatt",
+      "description": "Vermogen van de adapter"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\ntimeout",
+      "description": "PD afstemmingsduur in stappen van 100ms (voor compatibiliteit met sommige QC laders)"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Zet PPS & EPR modes aan"
+    },
+    "BoostTemperature": {
+      "displayText": "Verhog\nings temp",
+      "description": "Verhogingstemperatuur"
+    },
+    "AutoStart": {
+      "displayText": "start-\ntemperatuur",
+      "description": "Breng de soldeerbout op temperatuur bij het opstarten. (T=Soldeertemperatuur | S=Slaapstand-temperatuur | K=Slaapstand kamertemperatuur)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "temp veran\ndering kort",
+      "description": "Temperatuurveranderingsstap bij korte druk op de knop"
+    },
+    "TempChangeLongStep": {
+      "displayText": "temp veran\ndering lang",
+      "description": "Temperatuurveranderingsstap bij lange druk op de knop"
+    },
+    "LockingMode": {
+      "displayText": "Vergrendel-\ning knoppen",
+      "description": "Houd tijdens het solderen beide knoppen ingedrukt om de vergrendeling in of uit te schakelen (B=alleen boost-modus | F=volledige vergrendeling)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profiel\nfases",
+      "description": "Nummer van fases in profiel modus"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Voorverwarm\ntemperatuur",
+      "description": "Voorverwarm naar deze temperatuur op de start van profiel modus"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Voorverwarm\nsnelheid",
+      "description": "Voorverwarm op deze snelheid (graden per seconden)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Fase 1\ntemperatuur",
+      "description": "Doel temperatuur op het einde van deze fase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Fase\nduur",
+      "description": "Doel tijdsduur van deze fase (in seconden)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Fase 2\ntemperatuur",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Fase 2\nduur",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Fase 3\ntemperatuur",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Fase 3\nduur",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Fase 4\ntemperatuur",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Fase 4\nduur",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Fase 5\ntemperatuur",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Fase 5\nduur",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Afkoel\nsnelheid",
+      "description": "De snelheid van afkoelen op het eind van profiel modus (graden per seconden)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Bewegings-\ngevoeligheid",
+      "description": "Bewegingsgevoeligheid (1=minst gevoelig | ... | 9=meest gevoelig)"
+    },
+    "SleepTemperature": {
+      "displayText": "Slaap\ntemp",
+      "description": "Temperatuur in slaapstand (°C)"
+    },
+    "SleepTimeout": {
+      "displayText": "Slaap\ntime-out",
+      "description": "Slaapstand time-out (Minuten | Seconden)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Uitschakel\ntime-out",
+      "description": "Automatisch afsluiten time-out (Minuten)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Hall sensor\ngevoeligheid",
+      "description": "Gevoeligheid naar de magneten (1=minst gevoelig | ... | 9=meest gevoelig)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Temperatuur\nschaal",
+      "description": "Temperatuurschaal (°C=Celsius | °F=Fahrenheit)"
+    },
+    "DisplayRotation": {
+      "displayText": "Scherm-\noriëntatie",
+      "description": "Schermoriëntatie (R=Rechtshandig | L=Linkshandig | A=Automatisch)"
+    },
+    "CooldownBlink": {
+      "displayText": "Afkoel\nknipper",
+      "description": "Temperatuur knippert in hoofdmenu tijdens afkoeling."
+    },
+    "ScrollingSpeed": {
+      "displayText": "Scroll\nsnelheid",
+      "description": "Scrollsnelheid van de tekst."
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Wissel\n+ - knoppen",
+      "description": "Wissel de knoppen voor temperatuur controle"
+    },
+    "AnimSpeed": {
+      "displayText": "Anim.\nsnelheid",
+      "description": "Snelheid van de icoon animaties in het menu (T=sloom | M=middel | S=snel)"
+    },
+    "AnimLoop": {
+      "displayText": "Anim.\nherhaling",
+      "description": "Herhaal icoon animaties in hoofdmenu"
+    },
+    "Brightness": {
+      "displayText": "Scherm\nhelderheid",
+      "description": "Verander de helderheid van het OLED scherm"
+    },
+    "ColourInversion": {
+      "displayText": "Omkeer\nscherm",
+      "description": "Omkeer de kleuren van het OLED scherm"
+    },
+    "LOGOTime": {
+      "displayText": "Opstart\nlogo lengte",
+      "description": "Zet het lengte van het opstart logo (s=seconden)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Gedetailleerd\nslaapscherm",
+      "description": "Gedetailleerde informatie in een kleiner lettertype in het slaapscherm"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Gedetailleerd\nsoldeerscherm",
+      "description": "Gedetailleerde informatie in kleiner lettertype in soldeerscherm"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Zet Bluetooth aan"
+    },
+    "PowerLimit": {
+      "displayText": "Power\nlimit",
+      "description": "Gemiddelde maximale power dat de soldeerbout mag gebruiken (W=watt)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Calibreer CJC\nbij opstart",
+      "description": "Bij de volgende opstart tip Cold Junction Compensation wordt gecalibreerd (niet nodig als Delta T < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Calibreervo-\nedingsspanning?",
+      "description": "VIN Calibreren. Bevestigen door knoppen lang in te drukken."
+    },
+    "PowerPulsePower": {
+      "displayText": "Power\npuls",
+      "description": "Power van de wakker-houd-puls (W=watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Power pulse\nvertraging",
+      "description": "Vertraging voordat de wakker-houd-puls wordt geactiveerd (x 2,5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Power pulse\nduur",
+      "description": "Keep-awake-pulse duration (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Instellingen\nresetten?",
+      "description": "Alle instellingen resetten"
+    },
+    "LanguageSwitch": {
+      "displayText": "Spraak:\n NL_BE   Vlaams",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_NL_BE.json
+++ b/Translations/translation_NL_BE.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Spannings-\nbron",
@@ -123,7 +134,7 @@
       "description": "PD afstemmingsduur in stappen van 100ms (voor compatibiliteit met sommige QC laders)"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "Zet PPS & EPR modes aan"
     },
     "BoostTemperature": {

--- a/Translations/translation_PL.json
+++ b/Translations/translation_PL.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "PL",
-    "languageLocalName": "Polski",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Kalibracja\nwykonana!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Ust. \nzresetowane"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Nie rozpoznano\nakcelerometru!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "Nie rozpoznano\nkont. USB-PD IC!"
-        },
-        "LockingKeysString": {
-            "message": " ZABLOK."
-        },
-        "UnlockingKeysString": {
-            "message": "ODBLOK."
-        },
-        "WarningKeysLockedString": {
-            "message": "!ZABLOK!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Ucieczka\ntermiczna"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Upewnij się, że końcówka i uchwyt mają temperaturę pokojową podczas następnego rozruchu!"
-        },
-        "CJCCalibrating": {
-            "message": "kalibracja\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Czy na pewno chcesz przywrócić ustawienia fabryczne?"
-        },
-        "UVLOWarningString": {
-            "message": "NIS. NAP"
-        },
-        "UndervoltageString": {
-            "message": "Zbyt niskie nap.\n"
-        },
-        "InputVoltageString": {
-            "message": "Nap. wej.: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Tr. uśpienia\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Grot: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Twoje urządzenie jest najprawdopodobniej podróbką!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to\nstart profile"
-        }
+  "languageCode": "PL",
+  "languageLocalName": "Polski",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Kalibracja\nwykonana!"
     },
-    "characters": {
-        "SettingRightChar": "P",
-        "SettingLeftChar": "L",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "W",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "S",
-        "SettingStartSolderingChar": "T",
-        "SettingStartSleepChar": "Z",
-        "SettingStartSleepOffChar": "O",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "P"
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Ustawienia\nzasilania",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Lutowanie\n",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Oszcz.\nenergii",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Interfejs\nużytkownika",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Ustawienia\nzaawans.",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Ust. \nzresetowane"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Źródło\nzasilania",
-            "description": "Źródło zasilania. Ustaw napięcie odcięcia. (DC 10V) (S 3.3V dla ogniw Li, wyłącz limit mocy)"
-        },
-        "MinVolCell": {
-            "displayText": "Minimalne\nnapięcie",
-            "description": "Minimalne dozwolone napięcie na komórkę (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC\nnapięcie",
-            "description": "Maksymalne napięcie, które lutownica będzie próbowała wynegocjować z ładowarką Quick Charge (V)"
-        },
-        "PDNegTimeout": {
-            "displayText": "Limit czasu\nPD",
-            "description": "Limit czasu negocjacji PD w krokach co 100 ms dla zgodności z niektórymi ładowarkami QC (0: wyłączone)"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Włącza tryby PPS & EPR."
-        },
-        "BoostTemperature": {
-            "displayText": "Temp.\nboost",
-            "description": "Temperatura w trybie \"boost\" "
-        },
-        "AutoStart": {
-            "displayText": "Aut. uruch.\ntr. lutowania",
-            "description": "Automatyczne uruchamianie trybu lutowania po włączeniu zasilania. (T: lutowanie | Z: uśpienie | O: uśpienie w temp. pokojowej)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Zm. temp.\nkr. przyc.",
-            "description": "Wartość zmiany temperatury, po krótkim przyciśnięciu (°C)"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Zm. temp.\ndł. przyc.",
-            "description": "Wartość zmiany temperatury, po długim przyciśnięciu (°C)"
-        },
-        "LockingMode": {
-            "displayText": "Blokada\nprzycisków",
-            "description": "W trybie lutowania, wciśnij oba przyciski aby je zablokować (B=tylko Boost | P=pełna blokada)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat\nTemp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat\nSpeed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDuration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDuration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDuration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDuration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDuration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown\nSpeed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Czułość\nwykr. ruchu",
-            "description": "Czułość wykrywania ruchu (1: Minimalna | ... | 9: Maksymalna)"
-        },
-        "SleepTemperature": {
-            "displayText": "Temp.\nuśpienia",
-            "description": "Temperatura w trybie uśpienia (°C)"
-        },
-        "SleepTimeout": {
-            "displayText": "Czas do\nuśpienia",
-            "description": "Czas do przejścia w tryb uśpienia (minuty | sekundy)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Czas do\nwyłączenia",
-            "description": "Czas do wyłączenia (minuty)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Czułość\ncz. Halla",
-            "description": "Czułość czujnika Halla, używanego do przechodznia w tryb uśpienia (1: Minimalna | ... | 9: Maksymalna)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Jednostka\ntemperatury",
-            "description": "Jednostka temperatury (C: Celciusz | F: Fahrenheit)"
-        },
-        "DisplayRotation": {
-            "displayText": "Obrót\nekranu",
-            "description": "Obrót ekranu (P: dla praworęcznych | L: dla leworęcznych | A: automatycznie)"
-        },
-        "CooldownBlink": {
-            "displayText": "Mig. podczas\nwychładzania",
-            "description": "Temperatura miga podczas wychładzania, gdy grot jest wciąż gorący"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Sz. przew.\ntekstu",
-            "description": "Szybkość przewijania tekstu"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Zamień przyc.\n+ -",
-            "description": "Zamienia działanie przycisków zmiany temperatury grotu"
-        },
-        "AnimSpeed": {
-            "displayText": "Prędkosć\nanimacji",
-            "description": "Prędkość animacji ikon w menu (W: mała | M: średnia | S: duża)"
-        },
-        "AnimLoop": {
-            "displayText": "Zapętlona\nanimacja",
-            "description": "Zapętla animację ikon w menu głównym"
-        },
-        "Brightness": {
-            "displayText": "Jasność\nwyświetlacza",
-            "description": "Regulacja kontrastu/jasności wyświetlacza OLED"
-        },
-        "ColourInversion": {
-            "displayText": "Odwrócenie\nkolorów",
-            "description": "Odwrócenie kolorów wyświetlacza OLED"
-        },
-        "LOGOTime": {
-            "displayText": "Długość wyś.\nloga",
-            "description": "Ustawia czas wyświetlania loga podczas uruchamiania (s=sekund)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Szeczegółowy\nekran bezczy.",
-            "description": "Wyświetla szczegółowe informacje za pomocą mniejszej czcionki na ekranie bezczynności"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Sz. inf. w\ntr. lutowania",
-            "description": "Wyświetl szczegółowe informacje w trybie lutowania"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Enables BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Ogr.\nmocy",
-            "description": "Maksymalna moc (W), jakiej może użyć lutownica"
-        },
-        "CalibrateCJC": {
-            "displayText": "Kalibracja temperatury\nprzy następnym uruchomieniu",
-            "description": "Kalibracja temperatury przy następnym włączeniu (nie jest wymagana, jeśli różnica temperatur jest mniejsza niż 5°C"
-        },
-        "VoltageCalibration": {
-            "displayText": "Kalibracja\nnapięcia",
-            "description": "Kalibracja napięcia wejściowego. Krótkie naciśnięcie, aby ustawić, długie naciśnięcie, aby wyjść."
-        },
-        "PowerPulsePower": {
-            "displayText": "Moc\nimpulsu",
-            "description": "W przypadku używania powerbanku, utrzymuj moc na poziomie (W) aby nie uśpić powerbanku"
-        },
-        "PowerPulseWait": {
-            "displayText": "Czas między\nimp. mocy",
-            "description": "Czas między kolejnymi impulsami mocy zapobiegającymi usypianiu powerbanku (x2,5 s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Długość\nimpulsu mocy",
-            "description": "Długość impulsu mocy zapobiegającego usypianiu powerbanku (x250 ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Ustawienia\nfabryczne",
-            "description": "Resetuje wszystkie ustawienia"
-        },
-        "LanguageSwitch": {
-            "displayText": "Język:\n PL      Polski",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Nie rozpoznano\nakcelerometru!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "Nie rozpoznano\nkont. USB-PD IC!"
+    },
+    "LockingKeysString": {
+      "message": " ZABLOK."
+    },
+    "UnlockingKeysString": {
+      "message": "ODBLOK."
+    },
+    "WarningKeysLockedString": {
+      "message": "!ZABLOK!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Ucieczka\ntermiczna"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Upewnij się, że końcówka i uchwyt mają temperaturę pokojową podczas następnego rozruchu!"
+    },
+    "CJCCalibrating": {
+      "message": "kalibracja\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Czy na pewno chcesz przywrócić ustawienia fabryczne?"
+    },
+    "UVLOWarningString": {
+      "message": "NIS. NAP"
+    },
+    "UndervoltageString": {
+      "message": "Zbyt niskie nap.\n"
+    },
+    "InputVoltageString": {
+      "message": "Nap. wej.: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Tr. uśpienia\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Grot: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Twoje urządzenie jest najprawdopodobniej podróbką!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to\nstart profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "P",
+    "SettingLeftChar": "L",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "W",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "S",
+    "SettingStartSolderingChar": "T",
+    "SettingStartSleepChar": "Z",
+    "SettingStartSleepOffChar": "O",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "P"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Ustawienia\nzasilania",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Lutowanie\n",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Oszcz.\nenergii",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Interfejs\nużytkownika",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Ustawienia\nzaawans.",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Źródło\nzasilania",
+      "description": "Źródło zasilania. Ustaw napięcie odcięcia. (DC 10V) (S 3.3V dla ogniw Li, wyłącz limit mocy)"
+    },
+    "MinVolCell": {
+      "displayText": "Minimalne\nnapięcie",
+      "description": "Minimalne dozwolone napięcie na komórkę (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC\nnapięcie",
+      "description": "Maksymalne napięcie, które lutownica będzie próbowała wynegocjować z ładowarką Quick Charge (V)"
+    },
+    "PDNegTimeout": {
+      "displayText": "Limit czasu\nPD",
+      "description": "Limit czasu negocjacji PD w krokach co 100 ms dla zgodności z niektórymi ładowarkami QC (0: wyłączone)"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Włącza tryby PPS & EPR."
+    },
+    "BoostTemperature": {
+      "displayText": "Temp.\nboost",
+      "description": "Temperatura w trybie \"boost\" "
+    },
+    "AutoStart": {
+      "displayText": "Aut. uruch.\ntr. lutowania",
+      "description": "Automatyczne uruchamianie trybu lutowania po włączeniu zasilania. (T: lutowanie | Z: uśpienie | O: uśpienie w temp. pokojowej)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Zm. temp.\nkr. przyc.",
+      "description": "Wartość zmiany temperatury, po krótkim przyciśnięciu (°C)"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Zm. temp.\ndł. przyc.",
+      "description": "Wartość zmiany temperatury, po długim przyciśnięciu (°C)"
+    },
+    "LockingMode": {
+      "displayText": "Blokada\nprzycisków",
+      "description": "W trybie lutowania, wciśnij oba przyciski aby je zablokować (B=tylko Boost | P=pełna blokada)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat\nTemp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat\nSpeed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDuration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDuration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDuration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDuration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDuration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown\nSpeed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Czułość\nwykr. ruchu",
+      "description": "Czułość wykrywania ruchu (1: Minimalna | ... | 9: Maksymalna)"
+    },
+    "SleepTemperature": {
+      "displayText": "Temp.\nuśpienia",
+      "description": "Temperatura w trybie uśpienia (°C)"
+    },
+    "SleepTimeout": {
+      "displayText": "Czas do\nuśpienia",
+      "description": "Czas do przejścia w tryb uśpienia (minuty | sekundy)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Czas do\nwyłączenia",
+      "description": "Czas do wyłączenia (minuty)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Czułość\ncz. Halla",
+      "description": "Czułość czujnika Halla, używanego do przechodznia w tryb uśpienia (1: Minimalna | ... | 9: Maksymalna)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Jednostka\ntemperatury",
+      "description": "Jednostka temperatury (C: Celciusz | F: Fahrenheit)"
+    },
+    "DisplayRotation": {
+      "displayText": "Obrót\nekranu",
+      "description": "Obrót ekranu (P: dla praworęcznych | L: dla leworęcznych | A: automatycznie)"
+    },
+    "CooldownBlink": {
+      "displayText": "Mig. podczas\nwychładzania",
+      "description": "Temperatura miga podczas wychładzania, gdy grot jest wciąż gorący"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Sz. przew.\ntekstu",
+      "description": "Szybkość przewijania tekstu"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Zamień przyc.\n+ -",
+      "description": "Zamienia działanie przycisków zmiany temperatury grotu"
+    },
+    "AnimSpeed": {
+      "displayText": "Prędkosć\nanimacji",
+      "description": "Prędkość animacji ikon w menu (W: mała | M: średnia | S: duża)"
+    },
+    "AnimLoop": {
+      "displayText": "Zapętlona\nanimacja",
+      "description": "Zapętla animację ikon w menu głównym"
+    },
+    "Brightness": {
+      "displayText": "Jasność\nwyświetlacza",
+      "description": "Regulacja kontrastu/jasności wyświetlacza OLED"
+    },
+    "ColourInversion": {
+      "displayText": "Odwrócenie\nkolorów",
+      "description": "Odwrócenie kolorów wyświetlacza OLED"
+    },
+    "LOGOTime": {
+      "displayText": "Długość wyś.\nloga",
+      "description": "Ustawia czas wyświetlania loga podczas uruchamiania (s=sekund)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Szeczegółowy\nekran bezczy.",
+      "description": "Wyświetla szczegółowe informacje za pomocą mniejszej czcionki na ekranie bezczynności"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Sz. inf. w\ntr. lutowania",
+      "description": "Wyświetl szczegółowe informacje w trybie lutowania"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Enables BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Ogr.\nmocy",
+      "description": "Maksymalna moc (W), jakiej może użyć lutownica"
+    },
+    "CalibrateCJC": {
+      "displayText": "Kalibracja temperatury\nprzy następnym uruchomieniu",
+      "description": "Kalibracja temperatury przy następnym włączeniu (nie jest wymagana, jeśli różnica temperatur jest mniejsza niż 5°C"
+    },
+    "VoltageCalibration": {
+      "displayText": "Kalibracja\nnapięcia",
+      "description": "Kalibracja napięcia wejściowego. Krótkie naciśnięcie, aby ustawić, długie naciśnięcie, aby wyjść."
+    },
+    "PowerPulsePower": {
+      "displayText": "Moc\nimpulsu",
+      "description": "W przypadku używania powerbanku, utrzymuj moc na poziomie (W) aby nie uśpić powerbanku"
+    },
+    "PowerPulseWait": {
+      "displayText": "Czas między\nimp. mocy",
+      "description": "Czas między kolejnymi impulsami mocy zapobiegającymi usypianiu powerbanku (x2,5 s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Długość\nimpulsu mocy",
+      "description": "Długość impulsu mocy zapobiegającego usypianiu powerbanku (x250 ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Ustawienia\nfabryczne",
+      "description": "Resetuje wszystkie ustawienia"
+    },
+    "LanguageSwitch": {
+      "displayText": "Język:\n PL      Polski",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_PL.json
+++ b/Translations/translation_PL.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Źródło\nzasilania",
@@ -123,7 +134,7 @@
       "description": "Limit czasu negocjacji PD w krokach co 100 ms dla zgodności z niektórymi ładowarkami QC (0: wyłączone)"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "Włącza tryby PPS & EPR."
     },
     "BoostTemperature": {

--- a/Translations/translation_PT.json
+++ b/Translations/translation_PT.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Fonte\nalimentação",
@@ -123,7 +134,7 @@
       "description": "Tempo limite de negoiciação de PD de 100ms para compatibilidade com alguns carregadores é (0: disabled)"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "Activa o modo PPS & EPR"
     },
     "BoostTemperature": {

--- a/Translations/translation_PT.json
+++ b/Translations/translation_PT.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "PT",
-    "languageLocalName": "Português",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Calibração\nfeita!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Algumas configurações\nforam alteradas!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Acelerómetro não\ndetetado!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "USB-PD IC não\ndetetado!"
-        },
-        "LockingKeysString": {
-            "message": "Bloqueado"
-        },
-        "UnlockingKeysString": {
-            "message": "Desbloqueado"
-        },
-        "WarningKeysLockedString": {
-            "message": "!Bloqueado!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Avalanche\nTérmica"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Antes de reiniciar certifique-se que o ferro está à temperatura ambiente!"
-        },
-        "CJCCalibrating": {
-            "message": "a calibrar\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Definições de fábrica?"
-        },
-        "UVLOWarningString": {
-            "message": "DC BAIXO"
-        },
-        "UndervoltageString": {
-            "message": "Subtensão\n"
-        },
-        "InputVoltageString": {
-            "message": "Tensão: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Repouso...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Ponta: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Pré-Aquecer\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Arrefecer\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "O seu dispositivo provavelmente é falsificado!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Demasiado quente para\niniciar perfil"
-        }
+  "languageCode": "PT",
+  "languageLocalName": "Português",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Calibração\nfeita!"
     },
-    "characters": {
-        "SettingRightChar": "D",
-        "SettingLeftChar": "C",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "S",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "F",
-        "SettingStartSolderingChar": "S",
-        "SettingStartSleepChar": "H",
-        "SettingStartSleepOffChar": "A",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "F"
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Opções de\nEnergia",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Opções de\nSolda",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Modo de\nRepouso",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Interface\nUtilizador",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Opções\nAvançadas",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Algumas configurações\nforam alteradas!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Fonte\nalimentação",
-            "description": "Fonte de alimentação. Define a tensão de corte. (DC=10V) (S=3.3V/célula)"
-        },
-        "MinVolCell": {
-            "displayText": "Tensão\nmínima",
-            "description": "Tensão mínima permitida por célula de bateria (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Potência\nFonte",
-            "description": "Potência da fonte usada (Watt)"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD tempo\nlimite",
-            "description": "Tempo limite de negoiciação de PD de 100ms para compatibilidade com alguns carregadores é (0: disabled)"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Activa o modo PPS & EPR"
-        },
-        "BoostTemperature": {
-            "displayText": "Temp.\nModo Turbo",
-            "description": "Ajuste de temperatura do \"modo turbo\""
-        },
-        "AutoStart": {
-            "displayText": "Aquecimento\nautomático",
-            "description": "Aquece a ponta automaticamente ao ligar (S=soldagem | H=hibernar | A=hibernar temp. ambiente)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Mudança temp.\ncurta",
-            "description": "A temperatura será aumentada com um click curto"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Mudança temp.\nlonga",
-            "description": "A temperatura será aumentada com um click longo"
-        },
-        "LockingMode": {
-            "displayText": "Permitir bloq.\nbotões",
-            "description": "Durante a solda premir os dois botões para alternar entre (B=modo turbo | F=bloqueio total)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Temperatura\nPré-aquecimento",
-            "description": "Pré-aquecer a esta temperatura quando o perfil é selecionado"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Velocidade\nPré-aquecimento",
-            "description": "Ritmo de pré-aquecimento (graus por segundo)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Temp.\nFase 1",
-            "description": "Temperatura alvo no final desta fase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Duração\nFase 1",
-            "description": "Duração alvo desta fase (segundos)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Temp.\nFase 2",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Duração\nFase 2",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Temp.\nFase 3",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Duração\nFase 3",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Temp.\nFase 4",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Duração\nFase 4",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Temp.\nFase 5",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Duração\nFase 5",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Velocidade\nArrefecimento",
-            "description": "Arrefecer a este ritmo após sair do perfil selecionado (graus por segundo)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Sensibilidade\nmovimento",
-            "description": "Sensibilidade ao movimento (1=Menor | ... | 9=Maior)"
-        },
-        "SleepTemperature": {
-            "displayText": "Temperatura\nrepouso",
-            "description": "Temperatura de repouso (C)"
-        },
-        "SleepTimeout": {
-            "displayText": "Tempo\nrepouso",
-            "description": "Tempo para repouso (Minutos | Segundos)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Tempo\ndesligar",
-            "description": "Tempo para desligar (Minutos)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Sensibilidade de\nmagnetismo",
-            "description": "Sensibilidade de magnetismo (1=Menor | ... | 9=Maior)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Unidade\ntemperatura",
-            "description": "Unidade de temperatura (C=Celsius | F=Fahrenheit)"
-        },
-        "DisplayRotation": {
-            "displayText": "Orientação\necrã",
-            "description": "Orientação do ecrã (D=estro | C=anhoto | A=utomática)"
-        },
-        "CooldownBlink": {
-            "displayText": "Piscar ao\narrefecer",
-            "description": "Faz o valor da temperatura piscar durante o arrefecimento"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Velocidade\ntexto ajuda",
-            "description": "Velocidade a que o texto de ajuda é apresentado"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Trocar\nbotões + -",
-            "description": "Inverte o funcionamento dos botões de ajuste da temperatura"
-        },
-        "AnimSpeed": {
-            "displayText": "Velocidade\nde animação",
-            "description": "Velocidade das animações no menu (S=lenta | M=média | F=rápida)"
-        },
-        "AnimLoop": {
-            "displayText": "Repetir\nanimações",
-            "description": "Repete animações de ícones no menu principal"
-        },
-        "Brightness": {
-            "displayText": "Brilho\ndo ecrã",
-            "description": "Ajusta o brilho do ecrã OLED"
-        },
-        "ColourInversion": {
-            "displayText": "Inverter\necrã",
-            "description": "Inverte as cores do ecrã OLED"
-        },
-        "LOGOTime": {
-            "displayText": "Tempo img.\nno arranque",
-            "description": "Define a duração do logotipo no arranque em (s=segundos)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Ecrã repouso\navançado",
-            "description": "Mostra informações avançadas quando em repouso"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Ecrã solda\navançado",
-            "description": "Mostra informações avançadas durante a solda"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Ativa o Bluetooth Low Energy (BLE)"
-        },
-        "PowerLimit": {
-            "displayText": "Limite\npotência",
-            "description": "Potência máxima a usar (W=watt)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Calibrar CJC\nno próximo arranque",
-            "description": "No próximo arranque CJC será calibrada  (não será necessário caso o Delta T seja < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Calibrar\ntensão",
-            "description": "Calibra a tensão de alimentação. Use os botões para ajustar o valor. Mantenha pressionado para sair"
-        },
-        "PowerPulsePower": {
-            "displayText": "Potência\ndo pulso",
-            "description": "Intensidade de potência de arranque (W=watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Espera do\npulso",
-            "description": "Espera entre o acordar e o envio da rectivação (x 2.5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Duração\npulso",
-            "description": "Manter os inplosus de rectivação em (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Reset de\nfábrica?",
-            "description": "Repôe todos os ajustes"
-        },
-        "LanguageSwitch": {
-            "displayText": "Idioma:\n PT   Português",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Acelerómetro não\ndetetado!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "USB-PD IC não\ndetetado!"
+    },
+    "LockingKeysString": {
+      "message": "Bloqueado"
+    },
+    "UnlockingKeysString": {
+      "message": "Desbloqueado"
+    },
+    "WarningKeysLockedString": {
+      "message": "!Bloqueado!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Avalanche\nTérmica"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Antes de reiniciar certifique-se que o ferro está à temperatura ambiente!"
+    },
+    "CJCCalibrating": {
+      "message": "a calibrar\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Definições de fábrica?"
+    },
+    "UVLOWarningString": {
+      "message": "DC BAIXO"
+    },
+    "UndervoltageString": {
+      "message": "Subtensão\n"
+    },
+    "InputVoltageString": {
+      "message": "Tensão: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Repouso...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Ponta: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Pré-Aquecer\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Arrefecer\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "O seu dispositivo provavelmente é falsificado!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Demasiado quente para\niniciar perfil"
     }
+  },
+  "characters": {
+    "SettingRightChar": "D",
+    "SettingLeftChar": "C",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "S",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "F",
+    "SettingStartSolderingChar": "S",
+    "SettingStartSleepChar": "H",
+    "SettingStartSleepOffChar": "A",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "F"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Opções de\nEnergia",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Opções de\nSolda",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Modo de\nRepouso",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Interface\nUtilizador",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Opções\nAvançadas",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Fonte\nalimentação",
+      "description": "Fonte de alimentação. Define a tensão de corte. (DC=10V) (S=3.3V/célula)"
+    },
+    "MinVolCell": {
+      "displayText": "Tensão\nmínima",
+      "description": "Tensão mínima permitida por célula de bateria (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Potência\nFonte",
+      "description": "Potência da fonte usada (Watt)"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD tempo\nlimite",
+      "description": "Tempo limite de negoiciação de PD de 100ms para compatibilidade com alguns carregadores é (0: disabled)"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Activa o modo PPS & EPR"
+    },
+    "BoostTemperature": {
+      "displayText": "Temp.\nModo Turbo",
+      "description": "Ajuste de temperatura do \"modo turbo\""
+    },
+    "AutoStart": {
+      "displayText": "Aquecimento\nautomático",
+      "description": "Aquece a ponta automaticamente ao ligar (S=soldagem | H=hibernar | A=hibernar temp. ambiente)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Mudança temp.\ncurta",
+      "description": "A temperatura será aumentada com um click curto"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Mudança temp.\nlonga",
+      "description": "A temperatura será aumentada com um click longo"
+    },
+    "LockingMode": {
+      "displayText": "Permitir bloq.\nbotões",
+      "description": "Durante a solda premir os dois botões para alternar entre (B=modo turbo | F=bloqueio total)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Temperatura\nPré-aquecimento",
+      "description": "Pré-aquecer a esta temperatura quando o perfil é selecionado"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Velocidade\nPré-aquecimento",
+      "description": "Ritmo de pré-aquecimento (graus por segundo)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Temp.\nFase 1",
+      "description": "Temperatura alvo no final desta fase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Duração\nFase 1",
+      "description": "Duração alvo desta fase (segundos)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Temp.\nFase 2",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Duração\nFase 2",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Temp.\nFase 3",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Duração\nFase 3",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Temp.\nFase 4",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Duração\nFase 4",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Temp.\nFase 5",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Duração\nFase 5",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Velocidade\nArrefecimento",
+      "description": "Arrefecer a este ritmo após sair do perfil selecionado (graus por segundo)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Sensibilidade\nmovimento",
+      "description": "Sensibilidade ao movimento (1=Menor | ... | 9=Maior)"
+    },
+    "SleepTemperature": {
+      "displayText": "Temperatura\nrepouso",
+      "description": "Temperatura de repouso (C)"
+    },
+    "SleepTimeout": {
+      "displayText": "Tempo\nrepouso",
+      "description": "Tempo para repouso (Minutos | Segundos)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Tempo\ndesligar",
+      "description": "Tempo para desligar (Minutos)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Sensibilidade de\nmagnetismo",
+      "description": "Sensibilidade de magnetismo (1=Menor | ... | 9=Maior)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Unidade\ntemperatura",
+      "description": "Unidade de temperatura (C=Celsius | F=Fahrenheit)"
+    },
+    "DisplayRotation": {
+      "displayText": "Orientação\necrã",
+      "description": "Orientação do ecrã (D=estro | C=anhoto | A=utomática)"
+    },
+    "CooldownBlink": {
+      "displayText": "Piscar ao\narrefecer",
+      "description": "Faz o valor da temperatura piscar durante o arrefecimento"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Velocidade\ntexto ajuda",
+      "description": "Velocidade a que o texto de ajuda é apresentado"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Trocar\nbotões + -",
+      "description": "Inverte o funcionamento dos botões de ajuste da temperatura"
+    },
+    "AnimSpeed": {
+      "displayText": "Velocidade\nde animação",
+      "description": "Velocidade das animações no menu (S=lenta | M=média | F=rápida)"
+    },
+    "AnimLoop": {
+      "displayText": "Repetir\nanimações",
+      "description": "Repete animações de ícones no menu principal"
+    },
+    "Brightness": {
+      "displayText": "Brilho\ndo ecrã",
+      "description": "Ajusta o brilho do ecrã OLED"
+    },
+    "ColourInversion": {
+      "displayText": "Inverter\necrã",
+      "description": "Inverte as cores do ecrã OLED"
+    },
+    "LOGOTime": {
+      "displayText": "Tempo img.\nno arranque",
+      "description": "Define a duração do logotipo no arranque em (s=segundos)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Ecrã repouso\navançado",
+      "description": "Mostra informações avançadas quando em repouso"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Ecrã solda\navançado",
+      "description": "Mostra informações avançadas durante a solda"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Ativa o Bluetooth Low Energy (BLE)"
+    },
+    "PowerLimit": {
+      "displayText": "Limite\npotência",
+      "description": "Potência máxima a usar (W=watt)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Calibrar CJC\nno próximo arranque",
+      "description": "No próximo arranque CJC será calibrada  (não será necessário caso o Delta T seja < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Calibrar\ntensão",
+      "description": "Calibra a tensão de alimentação. Use os botões para ajustar o valor. Mantenha pressionado para sair"
+    },
+    "PowerPulsePower": {
+      "displayText": "Potência\ndo pulso",
+      "description": "Intensidade de potência de arranque (W=watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Espera do\npulso",
+      "description": "Espera entre o acordar e o envio da rectivação (x 2.5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Duração\npulso",
+      "description": "Manter os inplosus de rectivação em (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Reset de\nfábrica?",
+      "description": "Repôe todos os ajustes"
+    },
+    "LanguageSwitch": {
+      "displayText": "Idioma:\n PT   Português",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_RO.json
+++ b/Translations/translation_RO.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Sursa de\nalimentare",
@@ -123,8 +134,8 @@
       "description": "Timp limită de negociere pentru tranzacţia PD, în paşi de 100ms, pentru compatibilitate cu alimentatoarele QC"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
-      "description": "Enables PPS & EPR modes"
+      "displayText": "PD\nMode",
+      "description": "No Dynamic disables EPR & PPS, Safe mode does not use padding resistance"
     },
     "BoostTemperature": {
       "displayText": "Modifică\ntemp. impuls",

--- a/Translations/translation_RO.json
+++ b/Translations/translation_RO.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "RO",
-    "languageLocalName": "Română",
-    "tempUnitFahrenheit": true,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Calibration\ndone!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Setările au fost\nresetate!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Fără accelerometru\ndetectat!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "Fără USB-PD IC\ndetectat!"
-        },
-        "LockingKeysString": {
-            "message": "BLOCAT"
-        },
-        "UnlockingKeysString": {
-            "message": "DEBLOCAT"
-        },
-        "WarningKeysLockedString": {
-            "message": "!BLOCAT!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Încălzire\nEşuată"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Înainte de repornire, asiguraţi-vă că vârful şi mânerul sunt la temperatura camerei!"
-        },
-        "CJCCalibrating": {
-            "message": "calibrare\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Sigur doriţi să restauraţi la setările implicite?"
-        },
-        "UVLOWarningString": {
-            "message": "DC SCĂZUT"
-        },
-        "UndervoltageString": {
-            "message": "Voltaj scăzut\n"
-        },
-        "InputVoltageString": {
-            "message": "Intrare V: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Adormit...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Tip: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Dispozitivul dvs. este cel mai probabil un fals!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to\nstart profile"
-        }
+  "languageCode": "RO",
+  "languageLocalName": "Română",
+  "tempUnitFahrenheit": true,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Calibration\ndone!"
     },
-    "characters": {
-        "SettingRightChar": "D",
-        "SettingLeftChar": "S",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "Î",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "R",
-        "SettingStartSolderingChar": "S",
-        "SettingStartSleepChar": "Z",
-        "SettingStartSleepOffChar": "R",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "F"
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Setări de\nalimentare",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Setări de\nlipire",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Modul\nrepaus",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Interfaţă\nutilizator",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Opţiuni\navansate",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Setările au fost\nresetate!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Sursa de\nalimentare",
-            "description": "Sursa de alimentare. Setează tensiunea de întrerupere. (DC 10V) (S 3.3V per celulă, dezactivaţi limita de alimentare)"
-        },
-        "MinVolCell": {
-            "displayText": "Voltaj\nminim",
-            "description": "Tensiunea minimă admisă pe celulă (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC\nvoltaj",
-            "description": "Tensiunea maximă QC dorită pentru care negociază letconul"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\ntimeout",
-            "description": "Timp limită de negociere pentru tranzacţia PD, în paşi de 100ms, pentru compatibilitate cu alimentatoarele QC"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Enables PPS & EPR modes"
-        },
-        "BoostTemperature": {
-            "displayText": "Modifică\ntemp. impuls",
-            "description": "Temperatura utilizată în \"modul de impuls\""
-        },
-        "AutoStart": {
-            "displayText": "Auto\nstart",
-            "description": "Start letcon în modul de lipire la pornire (S=lipire | Z=repaus | R=repaus la temperatura camerei)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Schimbare temp.\napăsare scută",
-            "description": "Schimbarea temperaturii la apăsarea scurtă a butonului"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Schimbare temp.\napăsare lungă",
-            "description": "Schimbarea temperaturii la apăsarea lungă a butonului"
-        },
-        "LockingMode": {
-            "displayText": "Blocare\nbutoane",
-            "description": "Când lipiţi, apăsaţi lung ambele butoane, pentru a le bloca (B=numai \"modul boost\" | F=blocare completă)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat\nTemp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat\nSpeed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDuration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDuration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDuration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDuration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDuration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown\nSpeed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Sensibilitate\nla miscare",
-            "description": "Sensibilitate senzor miscare (1=puţin sensibil | ... | 9=cel mai sensibil)"
-        },
-        "SleepTemperature": {
-            "displayText": "Temp\nrepaus",
-            "description": "Temperatura vârfului în \"modul repaus\""
-        },
-        "SleepTimeout": {
-            "displayText": "Expirare\nrepaus",
-            "description": "Interval înainte de lansarea \"modului de repaus\" în (s=secunde | m=minute)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Expirare\noprire",
-            "description": "Interval înainte ca letconul să se oprească (m=minute)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Sensibilitate\nsenzor Hall",
-            "description": "Sensibilitate senzor cu efect Hall pentru a detecta repausul (1=putin sensibil | ... | 9=cel mai sensibil)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Unitate de\ntemperatură",
-            "description": "C=Celsius | F=Fahrenheit"
-        },
-        "DisplayRotation": {
-            "displayText": "Orientare\necran",
-            "description": "R=dreptaci | L=stângaci | A=auto"
-        },
-        "CooldownBlink": {
-            "displayText": "Clipeşte\nla răcire",
-            "description": "Clipeşte temperatura după oprirea încălzirii, în timp ce vârful este încă fierbinte"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Viteză\nderulare",
-            "description": "Viteză derulare text cu informatii la (S=lent | F=rapid)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Inversare\n+ - butoane",
-            "description": "Inversarea butoanelor de reglare a temperaturii"
-        },
-        "AnimSpeed": {
-            "displayText": "Animaţii\nviteză",
-            "description": "Ritmul animaţiilor pictogramei din meniu (Î=încet | M=mediu | R=rapid)"
-        },
-        "AnimLoop": {
-            "displayText": "Animaţii\nbuclă",
-            "description": "Animaţii de pictograme în meniul principal"
-        },
-        "Brightness": {
-            "displayText": "Ecranului\nluminozitatea",
-            "description": "Ajusteaza luminozitatea ecranului"
-        },
-        "ColourInversion": {
-            "displayText": "Inversează\nculoarea",
-            "description": "Inversează culoarea ecranului"
-        },
-        "LOGOTime": {
-            "displayText": "Durată\nlogo încărcare",
-            "description": "Setaţi durată logo de pornire (s=secunde)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Detalii,\necran inactiv",
-            "description": "Afisaţi informaţii detaliate într-un font mai mic pe ecranul de repaus"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Detalii\necran lipire",
-            "description": "Afisaţi informaţii detaliate într-un font mai mic pe ecranul de lipire"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Activează BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Putere\nlimită",
-            "description": "Puterea maximă pe care letconul o poate folosi (W=watt)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Calibrare CJC\nla următoarea pornire",
-            "description": "La următorul vârf de pornire, compensarea joncţiunii reci va fi calibrată (nu este necesară dacă Delta T este < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Calibrare tens.\nde intrare?",
-            "description": "Porniţi calibrarea VIN (apăsaţi lung pentru a ieşi)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Putere\npuls",
-            "description": "Puterea pulsului de menţinere activă a blocului de alimentare (watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Întârziere\npuls putere",
-            "description": "Perioada pulsului de mentinere (x 2.5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Durată\npuls putere",
-            "description": "Durata pulsului de menţinere (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Setări\ndin fabrică",
-            "description": "Reveniţi la setările din fabrică"
-        },
-        "LanguageSwitch": {
-            "displayText": "Limbă:\n RO      Română",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Fără accelerometru\ndetectat!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "Fără USB-PD IC\ndetectat!"
+    },
+    "LockingKeysString": {
+      "message": "BLOCAT"
+    },
+    "UnlockingKeysString": {
+      "message": "DEBLOCAT"
+    },
+    "WarningKeysLockedString": {
+      "message": "!BLOCAT!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Încălzire\nEşuată"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Înainte de repornire, asiguraţi-vă că vârful şi mânerul sunt la temperatura camerei!"
+    },
+    "CJCCalibrating": {
+      "message": "calibrare\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Sigur doriţi să restauraţi la setările implicite?"
+    },
+    "UVLOWarningString": {
+      "message": "DC SCĂZUT"
+    },
+    "UndervoltageString": {
+      "message": "Voltaj scăzut\n"
+    },
+    "InputVoltageString": {
+      "message": "Intrare V: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Adormit...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Tip: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Dispozitivul dvs. este cel mai probabil un fals!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to\nstart profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "D",
+    "SettingLeftChar": "S",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "Î",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "R",
+    "SettingStartSolderingChar": "S",
+    "SettingStartSleepChar": "Z",
+    "SettingStartSleepOffChar": "R",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "F"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Setări de\nalimentare",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Setări de\nlipire",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Modul\nrepaus",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Interfaţă\nutilizator",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Opţiuni\navansate",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Sursa de\nalimentare",
+      "description": "Sursa de alimentare. Setează tensiunea de întrerupere. (DC 10V) (S 3.3V per celulă, dezactivaţi limita de alimentare)"
+    },
+    "MinVolCell": {
+      "displayText": "Voltaj\nminim",
+      "description": "Tensiunea minimă admisă pe celulă (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC\nvoltaj",
+      "description": "Tensiunea maximă QC dorită pentru care negociază letconul"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\ntimeout",
+      "description": "Timp limită de negociere pentru tranzacţia PD, în paşi de 100ms, pentru compatibilitate cu alimentatoarele QC"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Enables PPS & EPR modes"
+    },
+    "BoostTemperature": {
+      "displayText": "Modifică\ntemp. impuls",
+      "description": "Temperatura utilizată în \"modul de impuls\""
+    },
+    "AutoStart": {
+      "displayText": "Auto\nstart",
+      "description": "Start letcon în modul de lipire la pornire (S=lipire | Z=repaus | R=repaus la temperatura camerei)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Schimbare temp.\napăsare scută",
+      "description": "Schimbarea temperaturii la apăsarea scurtă a butonului"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Schimbare temp.\napăsare lungă",
+      "description": "Schimbarea temperaturii la apăsarea lungă a butonului"
+    },
+    "LockingMode": {
+      "displayText": "Blocare\nbutoane",
+      "description": "Când lipiţi, apăsaţi lung ambele butoane, pentru a le bloca (B=numai \"modul boost\" | F=blocare completă)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat\nTemp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat\nSpeed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDuration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDuration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDuration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDuration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDuration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown\nSpeed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Sensibilitate\nla miscare",
+      "description": "Sensibilitate senzor miscare (1=puţin sensibil | ... | 9=cel mai sensibil)"
+    },
+    "SleepTemperature": {
+      "displayText": "Temp\nrepaus",
+      "description": "Temperatura vârfului în \"modul repaus\""
+    },
+    "SleepTimeout": {
+      "displayText": "Expirare\nrepaus",
+      "description": "Interval înainte de lansarea \"modului de repaus\" în (s=secunde | m=minute)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Expirare\noprire",
+      "description": "Interval înainte ca letconul să se oprească (m=minute)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Sensibilitate\nsenzor Hall",
+      "description": "Sensibilitate senzor cu efect Hall pentru a detecta repausul (1=putin sensibil | ... | 9=cel mai sensibil)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Unitate de\ntemperatură",
+      "description": "C=Celsius | F=Fahrenheit"
+    },
+    "DisplayRotation": {
+      "displayText": "Orientare\necran",
+      "description": "R=dreptaci | L=stângaci | A=auto"
+    },
+    "CooldownBlink": {
+      "displayText": "Clipeşte\nla răcire",
+      "description": "Clipeşte temperatura după oprirea încălzirii, în timp ce vârful este încă fierbinte"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Viteză\nderulare",
+      "description": "Viteză derulare text cu informatii la (S=lent | F=rapid)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Inversare\n+ - butoane",
+      "description": "Inversarea butoanelor de reglare a temperaturii"
+    },
+    "AnimSpeed": {
+      "displayText": "Animaţii\nviteză",
+      "description": "Ritmul animaţiilor pictogramei din meniu (Î=încet | M=mediu | R=rapid)"
+    },
+    "AnimLoop": {
+      "displayText": "Animaţii\nbuclă",
+      "description": "Animaţii de pictograme în meniul principal"
+    },
+    "Brightness": {
+      "displayText": "Ecranului\nluminozitatea",
+      "description": "Ajusteaza luminozitatea ecranului"
+    },
+    "ColourInversion": {
+      "displayText": "Inversează\nculoarea",
+      "description": "Inversează culoarea ecranului"
+    },
+    "LOGOTime": {
+      "displayText": "Durată\nlogo încărcare",
+      "description": "Setaţi durată logo de pornire (s=secunde)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Detalii,\necran inactiv",
+      "description": "Afisaţi informaţii detaliate într-un font mai mic pe ecranul de repaus"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Detalii\necran lipire",
+      "description": "Afisaţi informaţii detaliate într-un font mai mic pe ecranul de lipire"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Activează BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Putere\nlimită",
+      "description": "Puterea maximă pe care letconul o poate folosi (W=watt)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Calibrare CJC\nla următoarea pornire",
+      "description": "La următorul vârf de pornire, compensarea joncţiunii reci va fi calibrată (nu este necesară dacă Delta T este < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Calibrare tens.\nde intrare?",
+      "description": "Porniţi calibrarea VIN (apăsaţi lung pentru a ieşi)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Putere\npuls",
+      "description": "Puterea pulsului de menţinere activă a blocului de alimentare (watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Întârziere\npuls putere",
+      "description": "Perioada pulsului de mentinere (x 2.5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Durată\npuls putere",
+      "description": "Durata pulsului de menţinere (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Setări\ndin fabrică",
+      "description": "Reveniţi la setările din fabrică"
+    },
+    "LanguageSwitch": {
+      "displayText": "Limbă:\n RO      Română",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_RU.json
+++ b/Translations/translation_RU.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Предельное\nнапряжение",
@@ -123,7 +134,7 @@
       "description": "Интервал согласования питания по Power Delivery с шагом 100 мс для совместимости с некоторыми источниками питания по QC (0=Откл.)"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "Включить режимы PPS & EPR"
     },
     "BoostTemperature": {

--- a/Translations/translation_RU.json
+++ b/Translations/translation_RU.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "RU",
-    "languageLocalName": "Русский",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Калибровка\nзавершена!"
-        },
-        "ResetOKMessage": {
-            "message": "Готово!"
-        },
-        "SettingsResetMessage": {
-            "message": "Настройки\nсброшены!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Акселерометр\nне обнаружен!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "Питание по USB-PD\nне обнаружено"
-        },
-        "LockingKeysString": {
-            "message": "ЗАБЛОК"
-        },
-        "UnlockingKeysString": {
-            "message": "РАЗБЛОК"
-        },
-        "WarningKeysLockedString": {
-            "message": "!ЗАБЛОК!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Неуправляемый\nразогрев"
-        },
-        "WarningTipShorted": {
-            "message": "!КЗ на жале!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Пожалуйста, убедитесь, что жало и корпус имеют комнатную температуру при следующей загрузке!"
-        },
-        "CJCCalibrating": {
-            "message": "калибровка\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Вы уверены, что хотите сбросить настройки к значениям по умолчанию?"
-        },
-        "UVLOWarningString": {
-            "message": "НИЗ.НАПР"
-        },
-        "UndervoltageString": {
-            "message": "Низ. напряжение\n"
-        },
-        "InputVoltageString": {
-            "message": "Питание(В):\n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Сон...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Жало: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Преднагрев\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Остывание\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Вероятно, это поддельное устройство!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Слишком горячо для\nстарта профиля"
-        }
+  "languageCode": "RU",
+  "languageLocalName": "Русский",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Калибровка\nзавершена!"
     },
-    "characters": {
-        "SettingRightChar": "П",
-        "SettingLeftChar": "Л",
-        "SettingAutoChar": "А",
-        "SettingSlowChar": "М",
-        "SettingMediumChar": "С",
-        "SettingFastChar": "Б",
-        "SettingStartSolderingChar": "П",
-        "SettingStartSleepChar": "С",
-        "SettingStartSleepOffChar": "К",
-        "SettingLockBoostChar": "Т",
-        "SettingLockFullChar": "П"
+    "ResetOKMessage": {
+      "message": "Готово!"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Настройки\nпитания",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Настройки\nпайки",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Авто\nвыключение",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Интерфейс\n",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Доп.\nнастройки",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Настройки\nсброшены!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Предельное\nнапряжение",
-            "description": "Установка минимально предельного напряжения от аккумулятора для предотвращения глубокого разряда (DC 10В | S 3,3В на ячейку, без ограничения мощности)"
-        },
-        "MinVolCell": {
-            "displayText": "Мин.\nнапряжение",
-            "description": "Минимально разрешённое напряжение на ячейку (3S: 3 - 3,7В | 4S-6S: 2,4 - 3,7В)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Напр-е\nдля QC",
-            "description": "Максимальное напряжение для согласования с источником питания по QC"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\nинтервал",
-            "description": "Интервал согласования питания по Power Delivery с шагом 100 мс для совместимости с некоторыми источниками питания по QC (0=Откл.)"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Включить режимы PPS & EPR"
-        },
-        "BoostTemperature": {
-            "displayText": "t° турбо\nрежима",
-            "description": "Температура жала в турбо-режиме"
-        },
-        "AutoStart": {
-            "displayText": "Режим при\nвключении",
-            "description": "Режим, в котором включается паяльник (П=Пайка | С=Сон | К=Ожидание при комн. темп.)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Шаг t° при\nкор.наж-ии",
-            "description": "Шаг изменения температуры при коротком нажатии кнопок"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Шаг t° при\nдол.наж-ии",
-            "description": "Шаг изменения температуры при долгом нажатии кнопок"
-        },
-        "LockingMode": {
-            "displayText": "Разрешить\nблок. кнопок",
-            "description": "Блокировать кнопки при их долгом нажатии в режиме пайки (Т=Только турбо | П=Полная блокировка)"
-        },
-        "ProfilePhases": {
-            "displayText": "Этапы\nпрофиля",
-            "description": "Количество этапов в режиме профиля"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Температура\nпреднагрева",
-            "description": "Температура предварительного нагрева в начале режима термопрофиля"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Скорость\nпреднагрева",
-            "description": "Скорость предварительного нагрева в начале режима термопрофиля (в градусах в секунду)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Температура\n1-го этапа",
-            "description": "Необходимая температура в конце 1-го этапа"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Длительность\n1-го этапа",
-            "description": "Необходимая длительность 1-го этапа (в секундах)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Температура\n2-го этапа",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Длительность\n2-го этапа",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Температура\n3-го этапа",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Длительность\n3-го этапа",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Температура\n4-го этапа",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Длительность\n4-го этапа",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Температура\n5-го этапа",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Длительность\n5-го этапа",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Скорость\nостывания",
-            "description": "Скорость остывания в конце режима термопрофиля (в градусах в секунду)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Чувствительн.\nакселерометра",
-            "description": "Чувствительность акселерометра (1=мин. | ... | 9=макс.)"
-        },
-        "SleepTemperature": {
-            "displayText": "t° при\nсне",
-            "description": "Температура жала в режиме сна"
-        },
-        "SleepTimeout": {
-            "displayText": "Интервал\nсна",
-            "description": "Время до перехода в режим сна (секунды | минуты)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Интервал\nотключ-я",
-            "description": "Время до выключения паяльника (в минутах)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Датчик\nХолла",
-            "description": "Чувствительность датчика Холла к магнитному полю (1=мин. | ... | 9=макс.)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Единицы\nизмерения",
-            "description": "Единицы измерения температуры (C=°Цельcия | F=°Фаренгейта)"
-        },
-        "DisplayRotation": {
-            "displayText": "Поворот\nэкрана",
-            "description": "Поворот экрана (П=Правша | Л=Левша | А=Авто)"
-        },
-        "CooldownBlink": {
-            "displayText": "Мигание t°\nпри остывании",
-            "description": "Мигать температурой на экране при остывании, пока жало ещё горячее"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Скорость\nтекста",
-            "description": "Скорость прокрутки текста (М=Медленная | Б=Быстрая)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Поменять\nкнопки +/-",
-            "description": "Поменять кнопки изменения температуры"
-        },
-        "AnimSpeed": {
-            "displayText": "Скорость\nанимации",
-            "description": "Скорость анимации иконок в главном меню (М=Медленная| С=Средняя | Б=Быстрая)"
-        },
-        "AnimLoop": {
-            "displayText": "Зацикленная\nанимация",
-            "description": "Зацикленная анимация иконок в главном меню"
-        },
-        "Brightness": {
-            "displayText": "Яркость\nэкрана",
-            "description": "Уровень яркости пикселей на экране"
-        },
-        "ColourInversion": {
-            "displayText": "Инверсия\nэкрана",
-            "description": "Инвертировать пиксели на экране"
-        },
-        "LOGOTime": {
-            "displayText": "Длит-ть\nлоготипа",
-            "description": "Длительность отображения логотипа (в секундах)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Подробный\nэкран ожидания",
-            "description": "Показывать дополнительную информацию на экране ожидания уменьшенным шрифтом"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Подробный\nэкран пайки",
-            "description": "Показывать дополнительную информацию на экране пайки уменьшенным шрифтом"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Включить BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Предел\nмощ-ти",
-            "description": "Максимальная мощность, которую может использовать паяльник (в ваттах)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Калибровка\nтемпературы",
-            "description": "Калибровка температуры (CJC) при следующем включении (не требуется при разнице менее 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Калибровка\nнапряжения",
-            "description": "Калибровка входного напряжения (долгое нажатие для выхода)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Сила имп.\nпитания",
-            "description": "Сила импульса, удерживающего от автовыключения источник питания (в ваттах)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Пауза имп.\nпитания (К)",
-            "description": "Коэффициент паузы между импульсами, удерживающими от автовыключения источник питания (К x 2,5 с)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Длина имп.\nпитания (К)",
-            "description": "Коэффициент длины импульса, удерживающего от автовыключения источник питания (К x 250 мс)"
-        },
-        "SettingsReset": {
-            "displayText": "Сброс\nнастроек",
-            "description": "Сброс настроек к значениям по умолчанию"
-        },
-        "LanguageSwitch": {
-            "displayText": "Язык:\n RU     Русский",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Акселерометр\nне обнаружен!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "Питание по USB-PD\nне обнаружено"
+    },
+    "LockingKeysString": {
+      "message": "ЗАБЛОК"
+    },
+    "UnlockingKeysString": {
+      "message": "РАЗБЛОК"
+    },
+    "WarningKeysLockedString": {
+      "message": "!ЗАБЛОК!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Неуправляемый\nразогрев"
+    },
+    "WarningTipShorted": {
+      "message": "!КЗ на жале!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Пожалуйста, убедитесь, что жало и корпус имеют комнатную температуру при следующей загрузке!"
+    },
+    "CJCCalibrating": {
+      "message": "калибровка\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Вы уверены, что хотите сбросить настройки к значениям по умолчанию?"
+    },
+    "UVLOWarningString": {
+      "message": "НИЗ.НАПР"
+    },
+    "UndervoltageString": {
+      "message": "Низ. напряжение\n"
+    },
+    "InputVoltageString": {
+      "message": "Питание(В):\n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Сон...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Жало: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Преднагрев\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Остывание\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Вероятно, это поддельное устройство!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Слишком горячо для\nстарта профиля"
     }
+  },
+  "characters": {
+    "SettingRightChar": "П",
+    "SettingLeftChar": "Л",
+    "SettingAutoChar": "А",
+    "SettingSlowChar": "М",
+    "SettingMediumChar": "С",
+    "SettingFastChar": "Б",
+    "SettingStartSolderingChar": "П",
+    "SettingStartSleepChar": "С",
+    "SettingStartSleepOffChar": "К",
+    "SettingLockBoostChar": "Т",
+    "SettingLockFullChar": "П"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Настройки\nпитания",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Настройки\nпайки",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Авто\nвыключение",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Интерфейс\n",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Доп.\nнастройки",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Предельное\nнапряжение",
+      "description": "Установка минимально предельного напряжения от аккумулятора для предотвращения глубокого разряда (DC 10В | S 3,3В на ячейку, без ограничения мощности)"
+    },
+    "MinVolCell": {
+      "displayText": "Мин.\nнапряжение",
+      "description": "Минимально разрешённое напряжение на ячейку (3S: 3 - 3,7В | 4S-6S: 2,4 - 3,7В)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Напр-е\nдля QC",
+      "description": "Максимальное напряжение для согласования с источником питания по QC"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\nинтервал",
+      "description": "Интервал согласования питания по Power Delivery с шагом 100 мс для совместимости с некоторыми источниками питания по QC (0=Откл.)"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Включить режимы PPS & EPR"
+    },
+    "BoostTemperature": {
+      "displayText": "t° турбо\nрежима",
+      "description": "Температура жала в турбо-режиме"
+    },
+    "AutoStart": {
+      "displayText": "Режим при\nвключении",
+      "description": "Режим, в котором включается паяльник (П=Пайка | С=Сон | К=Ожидание при комн. темп.)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Шаг t° при\nкор.наж-ии",
+      "description": "Шаг изменения температуры при коротком нажатии кнопок"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Шаг t° при\nдол.наж-ии",
+      "description": "Шаг изменения температуры при долгом нажатии кнопок"
+    },
+    "LockingMode": {
+      "displayText": "Разрешить\nблок. кнопок",
+      "description": "Блокировать кнопки при их долгом нажатии в режиме пайки (Т=Только турбо | П=Полная блокировка)"
+    },
+    "ProfilePhases": {
+      "displayText": "Этапы\nпрофиля",
+      "description": "Количество этапов в режиме профиля"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Температура\nпреднагрева",
+      "description": "Температура предварительного нагрева в начале режима термопрофиля"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Скорость\nпреднагрева",
+      "description": "Скорость предварительного нагрева в начале режима термопрофиля (в градусах в секунду)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Температура\n1-го этапа",
+      "description": "Необходимая температура в конце 1-го этапа"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Длительность\n1-го этапа",
+      "description": "Необходимая длительность 1-го этапа (в секундах)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Температура\n2-го этапа",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Длительность\n2-го этапа",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Температура\n3-го этапа",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Длительность\n3-го этапа",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Температура\n4-го этапа",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Длительность\n4-го этапа",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Температура\n5-го этапа",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Длительность\n5-го этапа",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Скорость\nостывания",
+      "description": "Скорость остывания в конце режима термопрофиля (в градусах в секунду)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Чувствительн.\nакселерометра",
+      "description": "Чувствительность акселерометра (1=мин. | ... | 9=макс.)"
+    },
+    "SleepTemperature": {
+      "displayText": "t° при\nсне",
+      "description": "Температура жала в режиме сна"
+    },
+    "SleepTimeout": {
+      "displayText": "Интервал\nсна",
+      "description": "Время до перехода в режим сна (секунды | минуты)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Интервал\nотключ-я",
+      "description": "Время до выключения паяльника (в минутах)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Датчик\nХолла",
+      "description": "Чувствительность датчика Холла к магнитному полю (1=мин. | ... | 9=макс.)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Единицы\nизмерения",
+      "description": "Единицы измерения температуры (C=°Цельcия | F=°Фаренгейта)"
+    },
+    "DisplayRotation": {
+      "displayText": "Поворот\nэкрана",
+      "description": "Поворот экрана (П=Правша | Л=Левша | А=Авто)"
+    },
+    "CooldownBlink": {
+      "displayText": "Мигание t°\nпри остывании",
+      "description": "Мигать температурой на экране при остывании, пока жало ещё горячее"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Скорость\nтекста",
+      "description": "Скорость прокрутки текста (М=Медленная | Б=Быстрая)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Поменять\nкнопки +/-",
+      "description": "Поменять кнопки изменения температуры"
+    },
+    "AnimSpeed": {
+      "displayText": "Скорость\nанимации",
+      "description": "Скорость анимации иконок в главном меню (М=Медленная| С=Средняя | Б=Быстрая)"
+    },
+    "AnimLoop": {
+      "displayText": "Зацикленная\nанимация",
+      "description": "Зацикленная анимация иконок в главном меню"
+    },
+    "Brightness": {
+      "displayText": "Яркость\nэкрана",
+      "description": "Уровень яркости пикселей на экране"
+    },
+    "ColourInversion": {
+      "displayText": "Инверсия\nэкрана",
+      "description": "Инвертировать пиксели на экране"
+    },
+    "LOGOTime": {
+      "displayText": "Длит-ть\nлоготипа",
+      "description": "Длительность отображения логотипа (в секундах)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Подробный\nэкран ожидания",
+      "description": "Показывать дополнительную информацию на экране ожидания уменьшенным шрифтом"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Подробный\nэкран пайки",
+      "description": "Показывать дополнительную информацию на экране пайки уменьшенным шрифтом"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Включить BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Предел\nмощ-ти",
+      "description": "Максимальная мощность, которую может использовать паяльник (в ваттах)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Калибровка\nтемпературы",
+      "description": "Калибровка температуры (CJC) при следующем включении (не требуется при разнице менее 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Калибровка\nнапряжения",
+      "description": "Калибровка входного напряжения (долгое нажатие для выхода)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Сила имп.\nпитания",
+      "description": "Сила импульса, удерживающего от автовыключения источник питания (в ваттах)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Пауза имп.\nпитания (К)",
+      "description": "Коэффициент паузы между импульсами, удерживающими от автовыключения источник питания (К x 2,5 с)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Длина имп.\nпитания (К)",
+      "description": "Коэффициент длины импульса, удерживающего от автовыключения источник питания (К x 250 мс)"
+    },
+    "SettingsReset": {
+      "displayText": "Сброс\nнастроек",
+      "description": "Сброс настроек к значениям по умолчанию"
+    },
+    "LanguageSwitch": {
+      "displayText": "Язык:\n RU     Русский",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_SK.json
+++ b/Translations/translation_SK.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Zdroj\nnapätia",
@@ -123,7 +134,7 @@
       "description": "Čas vyjednávania Power Delivery v 100ms krokoch pre kompatibilitu s niektorými QC nabíjačkami (0: vypnuté)"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "Zapína PPS & EPR režimy"
     },
     "BoostTemperature": {

--- a/Translations/translation_SK.json
+++ b/Translations/translation_SK.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "SK",
-    "languageLocalName": "Slovenčina",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Kalibrácia\ndokončená!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Nastavenia\nresetované"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Bez pohybového\nsenzora!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "Chýba čip\nUSB-PD!"
-        },
-        "LockingKeysString": {
-            "message": "ZABLOK."
-        },
-        "UnlockingKeysString": {
-            "message": "ODBLOK."
-        },
-        "WarningKeysLockedString": {
-            "message": "!ZABLOK!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Únik\nTepla"
-        },
-        "WarningTipShorted": {
-            "message": "!Skrat hrotu!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Pred reštartovaním sa uistite, že hrot a rúčka sú v izbovej teplote!"
-        },
-        "CJCCalibrating": {
-            "message": "kalibrovanie\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Naozaj chcete obnoviť továrenské nastavenia?"
-        },
-        "UVLOWarningString": {
-            "message": "Nízke U!"
-        },
-        "UndervoltageString": {
-            "message": "Nízke napätie\n"
-        },
-        "InputVoltageString": {
-            "message": "Vstupné U: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Pokojový režim.\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Hrot: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Predhrievanie\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Schladzovanie\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Vaše zariadenie je pravdepodobne falzifikát!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Teplota príliš vysoká pre štart profilu"
-        }
+  "languageCode": "SK",
+  "languageLocalName": "Slovenčina",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Kalibrácia\ndokončená!"
     },
-    "characters": {
-        "SettingRightChar": "P",
-        "SettingLeftChar": "L",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "P",
-        "SettingMediumChar": "S",
-        "SettingFastChar": "R",
-        "SettingStartSolderingChar": "Z",
-        "SettingStartSleepChar": "S",
-        "SettingStartSleepOffChar": "I",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "P"
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Nastavenie\nvýkonu",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Nastavenie\nspájkovania",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Úsporný\nrežim",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Nastavenie\nzobrazenia",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Pokročilé\nnastavenia",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Nastavenia\nresetované"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Zdroj\nnapätia",
-            "description": "Zdroj napätia. Nastavenie napätia pre vypnutie (cutoff)  (DC=10V | nS=n*3.3V pre LiIon články)"
-        },
-        "MinVolCell": {
-            "displayText": "Minimálne\nnapätie",
-            "description": "Minimálne napätie povolené na jeden článok (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Obmedzenie QC\nnapätia",
-            "description": "Maximálne QC napätie ktoré si má systém vyžiadať"
-        },
-        "PDNegTimeout": {
-            "displayText": "Čas vypršania\nPower Delivery",
-            "description": "Čas vyjednávania Power Delivery v 100ms krokoch pre kompatibilitu s niektorými QC nabíjačkami (0: vypnuté)"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Zapína PPS & EPR režimy"
-        },
-        "BoostTemperature": {
-            "displayText": "Boost\nteplota",
-            "description": "Cieľová teplota pre prudký náhrev (v nastavených jednotkách)"
-        },
-        "AutoStart": {
-            "displayText": "Automatické\nspustenie",
-            "description": "Pri štarte spustiť režim spájkovania (Z=Spájkovanie | S=Spanok | I=Spanok izbová teplota)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Malý krok\nteploty",
-            "description": "Zmena teploty pri krátkom stlačení tlačidla"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Veľký krok\nteploty",
-            "description": "Zmena teploty pri držaní tlačidla"
-        },
-        "LockingMode": {
-            "displayText": "Povoliť zámok\ntlačidiel",
-            "description": "Zamknutie tlačidiel - dlhé stlačenie oboch naraz počas spájkovania (B=Okrem boost | P=Plné zamknutie)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profilové\nFázy",
-            "description": "Počet fáz v profilovóm režime"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Teplota\nPredhriatia",
-            "description": "Teplota na ktorú sa má predohriať na začiatku profilového režimu"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Rýchlosť\nPredhriatia",
-            "description": "Rýchlosť predhrievania (stupňe za sekundu)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Teplota\nFáza 1",
-            "description": "Cieľová teplota na konci tejto fázy"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Trvanie\nFáza 1",
-            "description": "Doba trvania tejto fázy (sekundy)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Teplota\nFáza 2",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Trvanie\nFáza 2",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Teplota\nFáza 3",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Trvanie\nFáza 3",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Teplota\nFáza 4",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Trvanie\nFáza 4",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Teplota\nFáza 5",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Trvanie\nFáza 5",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Rýchlosť\nochladzovania",
-            "description": "Rýchlosť ochladzovania na konci profilového režimu (stupne za sekundu)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Citlivosť\npohybu",
-            "description": "Citlivosť detekcie pohybu (1=Min | ... | 9=Max)"
-        },
-        "SleepTemperature": {
-            "displayText": "Pokojová\nteplota",
-            "description": "Pokojová teplota (v nastavených jednotkách)"
-        },
-        "SleepTimeout": {
-            "displayText": "Pokojový\nrežim po",
-            "description": "Pokojový režim po (s=sekundách | m=minútach)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Vypnutie\npo",
-            "description": "Čas na vypnutie (minúty)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Citliv.\nHall",
-            "description": "Citlivosť Hallovho senzora pre detekciu spánku (1=Min | ... | 9=Max)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Jednotka\nteploty",
-            "description": "Jednotky merania teploty (C=stupne Celzia | F=stupne Fahrenheita)"
-        },
-        "DisplayRotation": {
-            "displayText": "Orientácia\ndispleja",
-            "description": "Orientácia displeja (P=Pravák | L=Ľavák | A=Auto)"
-        },
-        "CooldownBlink": {
-            "displayText": "Blikanie pri\nchladnutí",
-            "description": "Blikanie ukazovateľa teploty počas chladnutia hrotu"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Rýchlosť\nskrolovania",
-            "description": "Rýchlosť pohybu tohto textu"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Otočenie\ntlačidiel +/-",
-            "description": "Prehodenie tlačidiel na nastavovanie teploty"
-        },
-        "AnimSpeed": {
-            "displayText": "Rýchlosť\nanimácií",
-            "description": "Rýchlosť animácií ikoniek v menu (P=pomaly | S=stredne | R=rýchlo)"
-        },
-        "AnimLoop": {
-            "displayText": "Opakovanie\nanimácií",
-            "description": "Opakovanie animácií ikoniek v hlavnom menu"
-        },
-        "Brightness": {
-            "displayText": "Jas\nobrazovky",
-            "description": "Mení jas/kontrast OLED displeja"
-        },
-        "ColourInversion": {
-            "displayText": "Invertovať\nobrazovku",
-            "description": "Invertovať farby OLED displeja"
-        },
-        "LOGOTime": {
-            "displayText": "Trvanie\nboot loga",
-            "description": "Doba trvania boot loga (s=sekundy)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Detaily v\npokoj. režime",
-            "description": "Zobraziť detailné informácie v pokojovom režime (T=Zap | F=Vyp)"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Detaily počas\nspájkovania",
-            "description": "Zobrazenie detailov počas spájkovania"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Zapne BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Obmedzenie\nvýkonu",
-            "description": "Obmedzenie výkonu podľa použitého zdroja (watt)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Kalibrácia CJC\npri nasledujúcom štarte",
-            "description": "Pri nasledujúcom štarte bude kalibrovaná kompenzácia studeného spoja (nie je potrebné ak Delta T je < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Kalibrácia\nnap. napätia",
-            "description": "Kalibrácia napájacieho napätia. Krátke stlačenie mení nastavenie, dlhé stlačenie pre návrat"
-        },
-        "PowerPulsePower": {
-            "displayText": "Intenzita\nimpulzu",
-            "description": "Impulz udržujúci napájací zdroj zapnutý (power banky) (watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Interval\nimpulzu",
-            "description": "Interval medzi impulzami udržujúcimi napájací zdroj zapnutý (x 2.5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Dĺžka\nimpulzu",
-            "description": "Dĺžka impulzu udržujúci napájací zdroj zapnutý (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Obnovenie\nnastavení",
-            "description": "Obnovenie nastavení na pôvodné hodnoty"
-        },
-        "LanguageSwitch": {
-            "displayText": "Jazyk:\n SK  Slovenčina",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Bez pohybového\nsenzora!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "Chýba čip\nUSB-PD!"
+    },
+    "LockingKeysString": {
+      "message": "ZABLOK."
+    },
+    "UnlockingKeysString": {
+      "message": "ODBLOK."
+    },
+    "WarningKeysLockedString": {
+      "message": "!ZABLOK!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Únik\nTepla"
+    },
+    "WarningTipShorted": {
+      "message": "!Skrat hrotu!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Pred reštartovaním sa uistite, že hrot a rúčka sú v izbovej teplote!"
+    },
+    "CJCCalibrating": {
+      "message": "kalibrovanie\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Naozaj chcete obnoviť továrenské nastavenia?"
+    },
+    "UVLOWarningString": {
+      "message": "Nízke U!"
+    },
+    "UndervoltageString": {
+      "message": "Nízke napätie\n"
+    },
+    "InputVoltageString": {
+      "message": "Vstupné U: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Pokojový režim.\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Hrot: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Predhrievanie\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Schladzovanie\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Vaše zariadenie je pravdepodobne falzifikát!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Teplota príliš vysoká pre štart profilu"
     }
+  },
+  "characters": {
+    "SettingRightChar": "P",
+    "SettingLeftChar": "L",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "P",
+    "SettingMediumChar": "S",
+    "SettingFastChar": "R",
+    "SettingStartSolderingChar": "Z",
+    "SettingStartSleepChar": "S",
+    "SettingStartSleepOffChar": "I",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "P"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Nastavenie\nvýkonu",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Nastavenie\nspájkovania",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Úsporný\nrežim",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Nastavenie\nzobrazenia",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Pokročilé\nnastavenia",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Zdroj\nnapätia",
+      "description": "Zdroj napätia. Nastavenie napätia pre vypnutie (cutoff)  (DC=10V | nS=n*3.3V pre LiIon články)"
+    },
+    "MinVolCell": {
+      "displayText": "Minimálne\nnapätie",
+      "description": "Minimálne napätie povolené na jeden článok (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Obmedzenie QC\nnapätia",
+      "description": "Maximálne QC napätie ktoré si má systém vyžiadať"
+    },
+    "PDNegTimeout": {
+      "displayText": "Čas vypršania\nPower Delivery",
+      "description": "Čas vyjednávania Power Delivery v 100ms krokoch pre kompatibilitu s niektorými QC nabíjačkami (0: vypnuté)"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Zapína PPS & EPR režimy"
+    },
+    "BoostTemperature": {
+      "displayText": "Boost\nteplota",
+      "description": "Cieľová teplota pre prudký náhrev (v nastavených jednotkách)"
+    },
+    "AutoStart": {
+      "displayText": "Automatické\nspustenie",
+      "description": "Pri štarte spustiť režim spájkovania (Z=Spájkovanie | S=Spanok | I=Spanok izbová teplota)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Malý krok\nteploty",
+      "description": "Zmena teploty pri krátkom stlačení tlačidla"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Veľký krok\nteploty",
+      "description": "Zmena teploty pri držaní tlačidla"
+    },
+    "LockingMode": {
+      "displayText": "Povoliť zámok\ntlačidiel",
+      "description": "Zamknutie tlačidiel - dlhé stlačenie oboch naraz počas spájkovania (B=Okrem boost | P=Plné zamknutie)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profilové\nFázy",
+      "description": "Počet fáz v profilovóm režime"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Teplota\nPredhriatia",
+      "description": "Teplota na ktorú sa má predohriať na začiatku profilového režimu"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Rýchlosť\nPredhriatia",
+      "description": "Rýchlosť predhrievania (stupňe za sekundu)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Teplota\nFáza 1",
+      "description": "Cieľová teplota na konci tejto fázy"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Trvanie\nFáza 1",
+      "description": "Doba trvania tejto fázy (sekundy)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Teplota\nFáza 2",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Trvanie\nFáza 2",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Teplota\nFáza 3",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Trvanie\nFáza 3",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Teplota\nFáza 4",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Trvanie\nFáza 4",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Teplota\nFáza 5",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Trvanie\nFáza 5",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Rýchlosť\nochladzovania",
+      "description": "Rýchlosť ochladzovania na konci profilového režimu (stupne za sekundu)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Citlivosť\npohybu",
+      "description": "Citlivosť detekcie pohybu (1=Min | ... | 9=Max)"
+    },
+    "SleepTemperature": {
+      "displayText": "Pokojová\nteplota",
+      "description": "Pokojová teplota (v nastavených jednotkách)"
+    },
+    "SleepTimeout": {
+      "displayText": "Pokojový\nrežim po",
+      "description": "Pokojový režim po (s=sekundách | m=minútach)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Vypnutie\npo",
+      "description": "Čas na vypnutie (minúty)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Citliv.\nHall",
+      "description": "Citlivosť Hallovho senzora pre detekciu spánku (1=Min | ... | 9=Max)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Jednotka\nteploty",
+      "description": "Jednotky merania teploty (C=stupne Celzia | F=stupne Fahrenheita)"
+    },
+    "DisplayRotation": {
+      "displayText": "Orientácia\ndispleja",
+      "description": "Orientácia displeja (P=Pravák | L=Ľavák | A=Auto)"
+    },
+    "CooldownBlink": {
+      "displayText": "Blikanie pri\nchladnutí",
+      "description": "Blikanie ukazovateľa teploty počas chladnutia hrotu"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Rýchlosť\nskrolovania",
+      "description": "Rýchlosť pohybu tohto textu"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Otočenie\ntlačidiel +/-",
+      "description": "Prehodenie tlačidiel na nastavovanie teploty"
+    },
+    "AnimSpeed": {
+      "displayText": "Rýchlosť\nanimácií",
+      "description": "Rýchlosť animácií ikoniek v menu (P=pomaly | S=stredne | R=rýchlo)"
+    },
+    "AnimLoop": {
+      "displayText": "Opakovanie\nanimácií",
+      "description": "Opakovanie animácií ikoniek v hlavnom menu"
+    },
+    "Brightness": {
+      "displayText": "Jas\nobrazovky",
+      "description": "Mení jas/kontrast OLED displeja"
+    },
+    "ColourInversion": {
+      "displayText": "Invertovať\nobrazovku",
+      "description": "Invertovať farby OLED displeja"
+    },
+    "LOGOTime": {
+      "displayText": "Trvanie\nboot loga",
+      "description": "Doba trvania boot loga (s=sekundy)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Detaily v\npokoj. režime",
+      "description": "Zobraziť detailné informácie v pokojovom režime (T=Zap | F=Vyp)"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Detaily počas\nspájkovania",
+      "description": "Zobrazenie detailov počas spájkovania"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Zapne BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Obmedzenie\nvýkonu",
+      "description": "Obmedzenie výkonu podľa použitého zdroja (watt)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Kalibrácia CJC\npri nasledujúcom štarte",
+      "description": "Pri nasledujúcom štarte bude kalibrovaná kompenzácia studeného spoja (nie je potrebné ak Delta T je < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Kalibrácia\nnap. napätia",
+      "description": "Kalibrácia napájacieho napätia. Krátke stlačenie mení nastavenie, dlhé stlačenie pre návrat"
+    },
+    "PowerPulsePower": {
+      "displayText": "Intenzita\nimpulzu",
+      "description": "Impulz udržujúci napájací zdroj zapnutý (power banky) (watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Interval\nimpulzu",
+      "description": "Interval medzi impulzami udržujúcimi napájací zdroj zapnutý (x 2.5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Dĺžka\nimpulzu",
+      "description": "Dĺžka impulzu udržujúci napájací zdroj zapnutý (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Obnovenie\nnastavení",
+      "description": "Obnovenie nastavení na pôvodné hodnoty"
+    },
+    "LanguageSwitch": {
+      "displayText": "Jazyk:\n SK  Slovenčina",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_SL.json
+++ b/Translations/translation_SL.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Vir\nnapajanja",
@@ -123,8 +134,8 @@
       "description": "PD negotiation timeout in 100ms steps for compatibility with some QC chargers"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
-      "description": "Enables PPS & EPR modes"
+      "displayText": "PD\nMode",
+      "description": "No Dynamic disables EPR & PPS, Safe mode does not use padding resistance"
     },
     "BoostTemperature": {
       "displayText": "Pospešena\ntemp.",

--- a/Translations/translation_SL.json
+++ b/Translations/translation_SL.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "SL",
-    "languageLocalName": "Slovenščina",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Calibration\ndone!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Nastavitve \nOK!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Ni \npospeševalnik"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "Ni USB-PD \nčipa!"
-        },
-        "LockingKeysString": {
-            "message": "ZAKLENJ."
-        },
-        "UnlockingKeysString": {
-            "message": "ODKLENJ."
-        },
-        "WarningKeysLockedString": {
-            "message": "ZAKLENJ."
-        },
-        "WarningThermalRunaway": {
-            "message": "Thermal\nRunaway"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Before rebooting, make sure tip & handle are at room temperature!"
-        },
-        "CJCCalibrating": {
-            "message": "calibrating\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Res želite ponastaviti na privzete nastavitve?"
-        },
-        "UVLOWarningString": {
-            "message": "NIZKA U"
-        },
-        "UndervoltageString": {
-            "message": "Nizka napetost\n"
-        },
-        "InputVoltageString": {
-            "message": "Vhodna U: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Spim...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Konica \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Your device is most likely a counterfeit!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to\nstart profile"
-        }
+  "languageCode": "SL",
+  "languageLocalName": "Slovenščina",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Calibration\ndone!"
     },
-    "characters": {
-        "SettingRightChar": "D",
-        "SettingLeftChar": "L",
-        "SettingAutoChar": "S",
-        "SettingSlowChar": "P",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "H",
-        "SettingStartSolderingChar": "S",
-        "SettingStartSleepChar": "Z",
-        "SettingStartSleepOffChar": "V",
-        "SettingLockBoostChar": "L",
-        "SettingLockFullChar": "P"
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Power\nsettings",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Nastavitve\nspajkanja",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Način\nspanja",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Uporabniški\nvmesnik",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Napredne\nmožnosti",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Nastavitve \nOK!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Vir\nnapajanja",
-            "description": "Vir napajanja. Nastavi napetost izklopa. (DC 10V) (S 3.3V na celico)"
-        },
-        "MinVolCell": {
-            "displayText": "Minimum\nvoltage",
-            "description": "Minimum allowed voltage per battery cell (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC\nnapetost",
-            "description": "Moč napajalnega vira v vatih [W]"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\ntimeout",
-            "description": "PD negotiation timeout in 100ms steps for compatibility with some QC chargers"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Enables PPS & EPR modes"
-        },
-        "BoostTemperature": {
-            "displayText": "Pospešena\ntemp.",
-            "description": "Temperatura v pospešenem načinu"
-        },
-        "AutoStart": {
-            "displayText": "Samodejni\nzagon",
-            "description": "Samodejno gretje konice ob vklopu (S=spajkanje | Z=spanje | V=spanje na sobni temperaturi)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Kratka sprememba\ntemperature?",
-            "description": "Temperatura se spremeni ob kratkem pritisku na gumb."
-        },
-        "TempChangeLongStep": {
-            "displayText": "Dolga sprememba\ntemperature?",
-            "description": "Temperatura se spremeni ob dolgem pritisku na gumb."
-        },
-        "LockingMode": {
-            "displayText": "Omogoči\nzaklep gumbov",
-            "description": "Za zaklep med spajkanjem drži oba gumba (L=le pospešeno | P=polno)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat\nTemp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat\nSpeed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDuration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDuration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDuration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDuration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDuration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown\nSpeed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Občutljivost\npremikanja",
-            "description": "1=najmanjša | ... | 9=največja"
-        },
-        "SleepTemperature": {
-            "displayText": "Temp. med\nspanjem",
-            "description": "Temperatura med spanjem"
-        },
-        "SleepTimeout": {
-            "displayText": "Čas do\nspanja",
-            "description": "Čas pred spanjem (s=sekunde | m=minute)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Čas do\nizklopa",
-            "description": "Čas do izklopa (m=minute)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Občut.\nHall son",
-            "description": "Občutljivost Hallove sonde za zaznavanje spanja (1=najmanjša | ... | 9=največja)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Enota za\ntemperaturo",
-            "description": "Enota za temperaturo (C=celzij | F=fahrenheit)"
-        },
-        "DisplayRotation": {
-            "displayText": "Orientacija\nzaslona",
-            "description": "D=desničar | L=levičar | S=samodejno"
-        },
-        "CooldownBlink": {
-            "displayText": "Utripanje med\nhlajenjem",
-            "description": "Ko je konica še vroča, utripaj prikaz temperature med hlajenjem."
-        },
-        "ScrollingSpeed": {
-            "displayText": "Hitrost\nbesedila",
-            "description": "Hitrost, s katero se prikazuje besedilo (P=počasi | H=hitro)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Obrni\ntipki + -?",
-            "description": "Zamenjaj funkciji gumbov."
-        },
-        "AnimSpeed": {
-            "displayText": "Anim.\nspeed",
-            "description": "Pace of icon animations in menu (P=slow | M=medium | H=fast)"
-        },
-        "AnimLoop": {
-            "displayText": "Anim.\nloop",
-            "description": "Loop icon animations in main menu"
-        },
-        "Brightness": {
-            "displayText": "Screen\nbrightness",
-            "description": "Adjust the OLED screen brightness"
-        },
-        "ColourInversion": {
-            "displayText": "Invert\nscreen",
-            "description": "Invert the OLED screen colors"
-        },
-        "LOGOTime": {
-            "displayText": "Boot logo\nduration",
-            "description": "Set boot logo duration (s=seconds)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Več info. na\nmir. zaslonu",
-            "description": "Prikaži več informacij z manjšo pisavo na mirovalnem zaslonu."
-        },
-        "AdvancedSoldering": {
-            "displayText": "Več info na\nzaslonu spaj.",
-            "description": "Prikaže več informacij z manjšo pisavo na zaslonu med spajkanjem."
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Enables BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Meja\nmoči",
-            "description": "Največja dovoljena moč v vatih [W]"
-        },
-        "CalibrateCJC": {
-            "displayText": "Calibrate CJC\nat next boot",
-            "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Kalibriram\nvhodno napetost?",
-            "description": "Kalibracija VIN (nastavitve z gumbi, dolg pritisk za izhod)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Pulz\nmoči",
-            "description": "Velikost moči za vzdrževanje budnosti."
-        },
-        "PowerPulseWait": {
-            "displayText": "Power pulse\ndelay",
-            "description": "Delay before keep-awake-pulse is triggered (x 2.5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Power pulse\nduration",
-            "description": "Keep-awake-pulse duration (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Tovarniške\nnastavitve?",
-            "description": "Ponastavitev vseh nastavitev"
-        },
-        "LanguageSwitch": {
-            "displayText": "Jezik:\n SL Slovenščina",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Ni \npospeševalnik"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "Ni USB-PD \nčipa!"
+    },
+    "LockingKeysString": {
+      "message": "ZAKLENJ."
+    },
+    "UnlockingKeysString": {
+      "message": "ODKLENJ."
+    },
+    "WarningKeysLockedString": {
+      "message": "ZAKLENJ."
+    },
+    "WarningThermalRunaway": {
+      "message": "Thermal\nRunaway"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Before rebooting, make sure tip & handle are at room temperature!"
+    },
+    "CJCCalibrating": {
+      "message": "calibrating\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Res želite ponastaviti na privzete nastavitve?"
+    },
+    "UVLOWarningString": {
+      "message": "NIZKA U"
+    },
+    "UndervoltageString": {
+      "message": "Nizka napetost\n"
+    },
+    "InputVoltageString": {
+      "message": "Vhodna U: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Spim...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Konica \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Your device is most likely a counterfeit!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to\nstart profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "D",
+    "SettingLeftChar": "L",
+    "SettingAutoChar": "S",
+    "SettingSlowChar": "P",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "H",
+    "SettingStartSolderingChar": "S",
+    "SettingStartSleepChar": "Z",
+    "SettingStartSleepOffChar": "V",
+    "SettingLockBoostChar": "L",
+    "SettingLockFullChar": "P"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Power\nsettings",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Nastavitve\nspajkanja",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Način\nspanja",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Uporabniški\nvmesnik",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Napredne\nmožnosti",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Vir\nnapajanja",
+      "description": "Vir napajanja. Nastavi napetost izklopa. (DC 10V) (S 3.3V na celico)"
+    },
+    "MinVolCell": {
+      "displayText": "Minimum\nvoltage",
+      "description": "Minimum allowed voltage per battery cell (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC\nnapetost",
+      "description": "Moč napajalnega vira v vatih [W]"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\ntimeout",
+      "description": "PD negotiation timeout in 100ms steps for compatibility with some QC chargers"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Enables PPS & EPR modes"
+    },
+    "BoostTemperature": {
+      "displayText": "Pospešena\ntemp.",
+      "description": "Temperatura v pospešenem načinu"
+    },
+    "AutoStart": {
+      "displayText": "Samodejni\nzagon",
+      "description": "Samodejno gretje konice ob vklopu (S=spajkanje | Z=spanje | V=spanje na sobni temperaturi)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Kratka sprememba\ntemperature?",
+      "description": "Temperatura se spremeni ob kratkem pritisku na gumb."
+    },
+    "TempChangeLongStep": {
+      "displayText": "Dolga sprememba\ntemperature?",
+      "description": "Temperatura se spremeni ob dolgem pritisku na gumb."
+    },
+    "LockingMode": {
+      "displayText": "Omogoči\nzaklep gumbov",
+      "description": "Za zaklep med spajkanjem drži oba gumba (L=le pospešeno | P=polno)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat\nTemp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat\nSpeed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDuration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDuration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDuration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDuration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDuration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown\nSpeed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Občutljivost\npremikanja",
+      "description": "1=najmanjša | ... | 9=največja"
+    },
+    "SleepTemperature": {
+      "displayText": "Temp. med\nspanjem",
+      "description": "Temperatura med spanjem"
+    },
+    "SleepTimeout": {
+      "displayText": "Čas do\nspanja",
+      "description": "Čas pred spanjem (s=sekunde | m=minute)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Čas do\nizklopa",
+      "description": "Čas do izklopa (m=minute)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Občut.\nHall son",
+      "description": "Občutljivost Hallove sonde za zaznavanje spanja (1=najmanjša | ... | 9=največja)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Enota za\ntemperaturo",
+      "description": "Enota za temperaturo (C=celzij | F=fahrenheit)"
+    },
+    "DisplayRotation": {
+      "displayText": "Orientacija\nzaslona",
+      "description": "D=desničar | L=levičar | S=samodejno"
+    },
+    "CooldownBlink": {
+      "displayText": "Utripanje med\nhlajenjem",
+      "description": "Ko je konica še vroča, utripaj prikaz temperature med hlajenjem."
+    },
+    "ScrollingSpeed": {
+      "displayText": "Hitrost\nbesedila",
+      "description": "Hitrost, s katero se prikazuje besedilo (P=počasi | H=hitro)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Obrni\ntipki + -?",
+      "description": "Zamenjaj funkciji gumbov."
+    },
+    "AnimSpeed": {
+      "displayText": "Anim.\nspeed",
+      "description": "Pace of icon animations in menu (P=slow | M=medium | H=fast)"
+    },
+    "AnimLoop": {
+      "displayText": "Anim.\nloop",
+      "description": "Loop icon animations in main menu"
+    },
+    "Brightness": {
+      "displayText": "Screen\nbrightness",
+      "description": "Adjust the OLED screen brightness"
+    },
+    "ColourInversion": {
+      "displayText": "Invert\nscreen",
+      "description": "Invert the OLED screen colors"
+    },
+    "LOGOTime": {
+      "displayText": "Boot logo\nduration",
+      "description": "Set boot logo duration (s=seconds)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Več info. na\nmir. zaslonu",
+      "description": "Prikaži več informacij z manjšo pisavo na mirovalnem zaslonu."
+    },
+    "AdvancedSoldering": {
+      "displayText": "Več info na\nzaslonu spaj.",
+      "description": "Prikaže več informacij z manjšo pisavo na zaslonu med spajkanjem."
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Enables BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Meja\nmoči",
+      "description": "Največja dovoljena moč v vatih [W]"
+    },
+    "CalibrateCJC": {
+      "displayText": "Calibrate CJC\nat next boot",
+      "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Kalibriram\nvhodno napetost?",
+      "description": "Kalibracija VIN (nastavitve z gumbi, dolg pritisk za izhod)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Pulz\nmoči",
+      "description": "Velikost moči za vzdrževanje budnosti."
+    },
+    "PowerPulseWait": {
+      "displayText": "Power pulse\ndelay",
+      "description": "Delay before keep-awake-pulse is triggered (x 2.5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Power pulse\nduration",
+      "description": "Keep-awake-pulse duration (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Tovarniške\nnastavitve?",
+      "description": "Ponastavitev vseh nastavitev"
+    },
+    "LanguageSwitch": {
+      "displayText": "Jezik:\n SL Slovenščina",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_SR_CYRL.json
+++ b/Translations/translation_SR_CYRL.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "SR_CYRL",
-    "languageLocalName": "Српски",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Calibration\ndone!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Certain settings\nwere changed!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "No accelerometer\ndetected!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "No USB-PD IC\ndetected!"
-        },
-        "LockingKeysString": {
-            "message": "LOCKED"
-        },
-        "UnlockingKeysString": {
-            "message": "UNLOCKED"
-        },
-        "WarningKeysLockedString": {
-            "message": "!LOCKED!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Thermal\nRunaway"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Before rebooting, make sure tip & handle are at room temperature!"
-        },
-        "CJCCalibrating": {
-            "message": "calibrating\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Да ли заиста желите да вратите поставке на фабричке вредности?"
-        },
-        "UVLOWarningString": {
-            "message": "НИЗ.НАП."
-        },
-        "UndervoltageString": {
-            "message": "ПРЕНИЗАК НАПОН\n"
-        },
-        "InputVoltageString": {
-            "message": "Ул. напон: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Спавање...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Врх: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Your device is most likely a counterfeit!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to\nstart profile"
-        }
+  "languageCode": "SR_CYRL",
+  "languageLocalName": "Српски",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Calibration\ndone!"
     },
-    "characters": {
-        "SettingRightChar": "Д",
-        "SettingLeftChar": "Л",
-        "SettingAutoChar": "А",
-        "SettingSlowChar": "С",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "Б",
-        "SettingStartSolderingChar": "Л",
-        "SettingStartSleepChar": "С",
-        "SettingStartSleepOffChar": "X",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "F"
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Power\nsettings",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Поставке\nлемљења",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Уштеда\nенергије",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Корисничко\nсучеље",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Напредне\nпоставке",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Certain settings\nwere changed!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Врста\nнапајања",
-            "description": "Тип напајања; одређује најнижи радни напон. (DC=адаптер [10V] | S=батерија [3,3V по ћелији])"
-        },
-        "MinVolCell": {
-            "displayText": "Minimum\nvoltage",
-            "description": "Minimum allowed voltage per battery cell (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Улазна\nснага",
-            "description": "Снага напајања у ватима."
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\ntimeout",
-            "description": "PD negotiation timeout in 100ms steps for compatibility with some QC chargers"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Enables PPS & EPR modes"
-        },
-        "BoostTemperature": {
-            "displayText": "Темп.\nпојачања",
-            "description": "Температура врха лемилице у току појачања."
-        },
-        "AutoStart": {
-            "displayText": "Врући\nстарт",
-            "description": "Лемилица одмах по покретању прелази у режим лемљења и греје се. (Л=лемљење | С=спавати | X=спавати собна температура)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Temp change\nshort",
-            "description": "Temperature-change-increment on short button press"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Temp change\nlong",
-            "description": "Temperature-change-increment on long button press"
-        },
-        "LockingMode": {
-            "displayText": "Allow locking\nbuttons",
-            "description": "While soldering, hold down both buttons to toggle locking them (B=boost mode only | F=full locking)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat\nTemp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat\nSpeed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDuration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDuration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDuration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDuration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDuration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown\nSpeed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Осетљивост\nна покрет",
-            "description": "Осетљивост сензора покрета. (1=најмање осетљиво | ... | 9=најосетљивије)"
-        },
-        "SleepTemperature": {
-            "displayText": "Темп.\nспавања",
-            "description": "Температура на коју се спушта лемилица након одређеног времена мировања. (C | F)"
-        },
-        "SleepTimeout": {
-            "displayText": "Време до\nспавања",
-            "description": "Време мировања након кога лемилица спушта температуру. (m=минути | s=секунде)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Време до\nгашења",
-            "description": "Време мировања након кога се лемилица гаси. (m=минути)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Hall sensor\nsensitivity",
-            "description": "Sensitivity to magnets (1=најмање осетљиво | ... | 9=најосетљивије)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Јединица\nтемпературе",
-            "description": "Јединице у којима се приказује температура. (C=целзијус | F=фаренхајт)"
-        },
-        "DisplayRotation": {
-            "displayText": "Оријентација\nекрана",
-            "description": "Како је окренут екран. (Д=за десноруке | Л=за леворуке | А=аутоматски)"
-        },
-        "CooldownBlink": {
-            "displayText": "Упозорење\nпри хлађењу",
-            "description": "Приказ температуре трепће приликом хлађења докле год је врх и даље врућ."
-        },
-        "ScrollingSpeed": {
-            "displayText": "Брзина\nпорука",
-            "description": "Брзина кретања описних порука попут ове. (С=споро | Б=брзо)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Swap\n+ - keys",
-            "description": "Reverse assignment of buttons for temperature adjustment"
-        },
-        "AnimSpeed": {
-            "displayText": "Anim.\nspeed",
-            "description": "Pace of icon animations in menu (С=slow | M=medium | Б=fast)"
-        },
-        "AnimLoop": {
-            "displayText": "Anim.\nloop",
-            "description": "Loop icon animations in main menu"
-        },
-        "Brightness": {
-            "displayText": "Screen\nbrightness",
-            "description": "Adjust the OLED screen brightness"
-        },
-        "ColourInversion": {
-            "displayText": "Invert\nscreen",
-            "description": "Invert the OLED screen colors"
-        },
-        "LOGOTime": {
-            "displayText": "Boot logo\nduration",
-            "description": "Set boot logo duration (s=seconds)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Детаљи током\nмировања",
-            "description": "Приказивање детаљних информација на екрану током мировања."
-        },
-        "AdvancedSoldering": {
-            "displayText": "Детаљи током\nлемљења",
-            "description": "Приказивање детаљних информација на екрану током лемљења."
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Enables BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Power\nlimit",
-            "description": "Average maximum power the iron can use (W=watt)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Calibrate CJC\nat next boot",
-            "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5 C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Калибрација\nулазног напона",
-            "description": "Калибрисање улазног напона. Подешава се на тастере; дуги притисак за крај."
-        },
-        "PowerPulsePower": {
-            "displayText": "Power\npulse",
-            "description": "Intensity of power of keep-awake-pulse (W=watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Power pulse\ndelay",
-            "description": "Delay before keep-awake-pulse is triggered (x 2.5с)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Power pulse\nduration",
-            "description": "Keep-awake-pulse duration (x 250мс)"
-        },
-        "SettingsReset": {
-            "displayText": "Фабричке\nпоставке",
-            "description": "Враћање свих поставки на фабричке вредности."
-        },
-        "LanguageSwitch": {
-            "displayText": "Jезик:\n SR      Српски",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "No accelerometer\ndetected!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "No USB-PD IC\ndetected!"
+    },
+    "LockingKeysString": {
+      "message": "LOCKED"
+    },
+    "UnlockingKeysString": {
+      "message": "UNLOCKED"
+    },
+    "WarningKeysLockedString": {
+      "message": "!LOCKED!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Thermal\nRunaway"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Before rebooting, make sure tip & handle are at room temperature!"
+    },
+    "CJCCalibrating": {
+      "message": "calibrating\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Да ли заиста желите да вратите поставке на фабричке вредности?"
+    },
+    "UVLOWarningString": {
+      "message": "НИЗ.НАП."
+    },
+    "UndervoltageString": {
+      "message": "ПРЕНИЗАК НАПОН\n"
+    },
+    "InputVoltageString": {
+      "message": "Ул. напон: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Спавање...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Врх: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Your device is most likely a counterfeit!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to\nstart profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "Д",
+    "SettingLeftChar": "Л",
+    "SettingAutoChar": "А",
+    "SettingSlowChar": "С",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "Б",
+    "SettingStartSolderingChar": "Л",
+    "SettingStartSleepChar": "С",
+    "SettingStartSleepOffChar": "X",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "F"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Power\nsettings",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Поставке\nлемљења",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Уштеда\nенергије",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Корисничко\nсучеље",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Напредне\nпоставке",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Врста\nнапајања",
+      "description": "Тип напајања; одређује најнижи радни напон. (DC=адаптер [10V] | S=батерија [3,3V по ћелији])"
+    },
+    "MinVolCell": {
+      "displayText": "Minimum\nvoltage",
+      "description": "Minimum allowed voltage per battery cell (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Улазна\nснага",
+      "description": "Снага напајања у ватима."
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\ntimeout",
+      "description": "PD negotiation timeout in 100ms steps for compatibility with some QC chargers"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Enables PPS & EPR modes"
+    },
+    "BoostTemperature": {
+      "displayText": "Темп.\nпојачања",
+      "description": "Температура врха лемилице у току појачања."
+    },
+    "AutoStart": {
+      "displayText": "Врући\nстарт",
+      "description": "Лемилица одмах по покретању прелази у режим лемљења и греје се. (Л=лемљење | С=спавати | X=спавати собна температура)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Temp change\nshort",
+      "description": "Temperature-change-increment on short button press"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Temp change\nlong",
+      "description": "Temperature-change-increment on long button press"
+    },
+    "LockingMode": {
+      "displayText": "Allow locking\nbuttons",
+      "description": "While soldering, hold down both buttons to toggle locking them (B=boost mode only | F=full locking)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat\nTemp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat\nSpeed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDuration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDuration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDuration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDuration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDuration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown\nSpeed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Осетљивост\nна покрет",
+      "description": "Осетљивост сензора покрета. (1=најмање осетљиво | ... | 9=најосетљивије)"
+    },
+    "SleepTemperature": {
+      "displayText": "Темп.\nспавања",
+      "description": "Температура на коју се спушта лемилица након одређеног времена мировања. (C | F)"
+    },
+    "SleepTimeout": {
+      "displayText": "Време до\nспавања",
+      "description": "Време мировања након кога лемилица спушта температуру. (m=минути | s=секунде)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Време до\nгашења",
+      "description": "Време мировања након кога се лемилица гаси. (m=минути)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Hall sensor\nsensitivity",
+      "description": "Sensitivity to magnets (1=најмање осетљиво | ... | 9=најосетљивије)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Јединица\nтемпературе",
+      "description": "Јединице у којима се приказује температура. (C=целзијус | F=фаренхајт)"
+    },
+    "DisplayRotation": {
+      "displayText": "Оријентација\nекрана",
+      "description": "Како је окренут екран. (Д=за десноруке | Л=за леворуке | А=аутоматски)"
+    },
+    "CooldownBlink": {
+      "displayText": "Упозорење\nпри хлађењу",
+      "description": "Приказ температуре трепће приликом хлађења докле год је врх и даље врућ."
+    },
+    "ScrollingSpeed": {
+      "displayText": "Брзина\nпорука",
+      "description": "Брзина кретања описних порука попут ове. (С=споро | Б=брзо)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Swap\n+ - keys",
+      "description": "Reverse assignment of buttons for temperature adjustment"
+    },
+    "AnimSpeed": {
+      "displayText": "Anim.\nspeed",
+      "description": "Pace of icon animations in menu (С=slow | M=medium | Б=fast)"
+    },
+    "AnimLoop": {
+      "displayText": "Anim.\nloop",
+      "description": "Loop icon animations in main menu"
+    },
+    "Brightness": {
+      "displayText": "Screen\nbrightness",
+      "description": "Adjust the OLED screen brightness"
+    },
+    "ColourInversion": {
+      "displayText": "Invert\nscreen",
+      "description": "Invert the OLED screen colors"
+    },
+    "LOGOTime": {
+      "displayText": "Boot logo\nduration",
+      "description": "Set boot logo duration (s=seconds)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Детаљи током\nмировања",
+      "description": "Приказивање детаљних информација на екрану током мировања."
+    },
+    "AdvancedSoldering": {
+      "displayText": "Детаљи током\nлемљења",
+      "description": "Приказивање детаљних информација на екрану током лемљења."
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Enables BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Power\nlimit",
+      "description": "Average maximum power the iron can use (W=watt)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Calibrate CJC\nat next boot",
+      "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5 C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Калибрација\nулазног напона",
+      "description": "Калибрисање улазног напона. Подешава се на тастере; дуги притисак за крај."
+    },
+    "PowerPulsePower": {
+      "displayText": "Power\npulse",
+      "description": "Intensity of power of keep-awake-pulse (W=watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Power pulse\ndelay",
+      "description": "Delay before keep-awake-pulse is triggered (x 2.5с)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Power pulse\nduration",
+      "description": "Keep-awake-pulse duration (x 250мс)"
+    },
+    "SettingsReset": {
+      "displayText": "Фабричке\nпоставке",
+      "description": "Враћање свих поставки на фабричке вредности."
+    },
+    "LanguageSwitch": {
+      "displayText": "Jезик:\n SR      Српски",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_SR_CYRL.json
+++ b/Translations/translation_SR_CYRL.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Врста\nнапајања",
@@ -123,8 +134,8 @@
       "description": "PD negotiation timeout in 100ms steps for compatibility with some QC chargers"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
-      "description": "Enables PPS & EPR modes"
+      "displayText": "PD\nMode",
+      "description": "No Dynamic disables EPR & PPS, Safe mode does not use padding resistance"
     },
     "BoostTemperature": {
       "displayText": "Темп.\nпојачања",

--- a/Translations/translation_SR_LATN.json
+++ b/Translations/translation_SR_LATN.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Vrsta\nnapajanja",
@@ -123,8 +134,8 @@
       "description": "PD negotiation timeout in 100ms steps for compatibility with some QC chargers"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
-      "description": "Enables PPS & EPR modes"
+      "displayText": "PD\nMode",
+      "description": "No Dynamic disables EPR & PPS, Safe mode does not use padding resistance"
     },
     "BoostTemperature": {
       "displayText": "Temp.\npojačanja",

--- a/Translations/translation_SR_LATN.json
+++ b/Translations/translation_SR_LATN.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "SR_LATN",
-    "languageLocalName": "Srpski",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Calibration\ndone!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Certain settings\nwere changed!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "No accelerometer\ndetected!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "No USB-PD IC\ndetected!"
-        },
-        "LockingKeysString": {
-            "message": "LOCKED"
-        },
-        "UnlockingKeysString": {
-            "message": "UNLOCKED"
-        },
-        "WarningKeysLockedString": {
-            "message": "!LOCKED!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Thermal\nRunaway"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Before rebooting, make sure tip & handle are at room temperature!"
-        },
-        "CJCCalibrating": {
-            "message": "calibrating\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Da li zaista želite da vratite postavke na fabričke vrednosti?"
-        },
-        "UVLOWarningString": {
-            "message": "NIZ.NAP."
-        },
-        "UndervoltageString": {
-            "message": "PRENIZAK NAPON\n"
-        },
-        "InputVoltageString": {
-            "message": "Ul. napon: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Spavanje...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Vrh: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Your device is most likely a counterfeit!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to\nstart profile"
-        }
+  "languageCode": "SR_LATN",
+  "languageLocalName": "Srpski",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Calibration\ndone!"
     },
-    "characters": {
-        "SettingRightChar": "D",
-        "SettingLeftChar": "L",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "S",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "B",
-        "SettingStartSolderingChar": "L",
-        "SettingStartSleepChar": "S",
-        "SettingStartSleepOffChar": "X",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "F"
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Power\nsettings",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Postavke\nlemljenja",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Ušteda\nenergije",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Korisničko\nsučelje",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Napredne\npostavke",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Certain settings\nwere changed!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Vrsta\nnapajanja",
-            "description": "Tip napajanja; određuje najniži radni napon. (DC=adapter [10V], S=baterija [3,3V po ćeliji])"
-        },
-        "MinVolCell": {
-            "displayText": "Minimum\nvoltage",
-            "description": "Minimum allowed voltage per battery cell (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Ulazna\nsnaga",
-            "description": "Snaga napajanja u vatima."
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\ntimeout",
-            "description": "PD negotiation timeout in 100ms steps for compatibility with some QC chargers"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Enables PPS & EPR modes"
-        },
-        "BoostTemperature": {
-            "displayText": "Temp.\npojačanja",
-            "description": "Temperatura vrha lemilice u toku pojačanja."
-        },
-        "AutoStart": {
-            "displayText": "Vrući\nstart",
-            "description": "Lemilica odmah po pokretanju prelazi u režim lemljenja i greje se. (L=lemljenje | S=spavati | X=spavati sobna temperatura)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Temp change\nshort",
-            "description": "Temperature-change-increment on short button press"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Temp change\nlong",
-            "description": "Temperature-change-increment on long button press"
-        },
-        "LockingMode": {
-            "displayText": "Allow locking\nbuttons",
-            "description": "While soldering, hold down both buttons to toggle locking them (B=boost mode only | F=full locking)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat\nTemp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat\nSpeed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDuration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDuration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDuration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDuration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDuration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown\nSpeed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Osetljivost\nna pokret",
-            "description": "Osetljivost senzora pokreta. (1=najmanje osetljivo | ... | 9=najosetljivije)"
-        },
-        "SleepTemperature": {
-            "displayText": "Temp.\nspavanja",
-            "description": "Temperatura na koju se spušta lemilica nakon određenog vremena mirovanja. (C | F)"
-        },
-        "SleepTimeout": {
-            "displayText": "Vreme do\nspavanja",
-            "description": "Vreme mirovanja nakon koga lemilica spušta temperaturu. (m=minuti | s=sekunde)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Vreme do\ngašenja",
-            "description": "Vreme mirovanja nakon koga se lemilica gasi. (m=minuti)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Hall sensor\nsensitivity",
-            "description": "Sensitivity to magnets (1=najmanje osetljivo | ... | 9=najosetljivije)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Jedinica\ntemperature",
-            "description": "Jedinice u kojima se prikazuje temperatura. (C=celzijus | F=farenhajt)"
-        },
-        "DisplayRotation": {
-            "displayText": "Orijentacija\nekrana",
-            "description": "Kako je okrenut ekran. (D=za desnoruke | L=za levoruke | A=automatski)"
-        },
-        "CooldownBlink": {
-            "displayText": "Upozorenje\npri hlađenju",
-            "description": "Prikaz temperature trepće prilikom hlađenja dokle god je vrh i dalje vruć."
-        },
-        "ScrollingSpeed": {
-            "displayText": "Brzina\nporuka",
-            "description": "Brzina kretanja opisnih poruka poput ove. (S=sporo | B=brzo)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Swap\n+ - keys",
-            "description": "Reverse assignment of buttons for temperature adjustment"
-        },
-        "AnimSpeed": {
-            "displayText": "Anim.\nspeed",
-            "description": "Pace of icon animations in menu (S=slow | M=medium | B=fast)"
-        },
-        "AnimLoop": {
-            "displayText": "Anim.\nloop",
-            "description": "Loop icon animations in main menu"
-        },
-        "Brightness": {
-            "displayText": "Screen\nbrightness",
-            "description": "Adjust the OLED screen brightness"
-        },
-        "ColourInversion": {
-            "displayText": "Invert\nscreen",
-            "description": "Invert the OLED screen colors"
-        },
-        "LOGOTime": {
-            "displayText": "Boot logo\nduration",
-            "description": "Set boot logo duration (s=seconds)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Detalji tokom\nmirovanja",
-            "description": "Prikazivanje detaljnih informacija na ekranu tokom mirovanja."
-        },
-        "AdvancedSoldering": {
-            "displayText": "Detalji tokom\nlemljenja",
-            "description": "Prikazivanje detaljnih informacija na ekranu tokom lemljenja."
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Enables BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Power\nlimit",
-            "description": "Average maximum power the iron can use (W=watt)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Calibrate CJC\nat next boot",
-            "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Kalibracija\nulaznog napona",
-            "description": "Kalibrisanje ulaznog napona. Podešava se na tastere; dugi pritisak za kraj."
-        },
-        "PowerPulsePower": {
-            "displayText": "Power\npulse",
-            "description": "Intensity of power of keep-awake-pulse (W=watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Power pulse\ndelay",
-            "description": "Delay before keep-awake-pulse is triggered (x 2.5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Power pulse\nduration",
-            "description": "Keep-awake-pulse duration (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Fabričke\npostavke",
-            "description": "Vraćanje svih postavki na fabričke vrednosti."
-        },
-        "LanguageSwitch": {
-            "displayText": "Jezik:\n SR      Srpski",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "No accelerometer\ndetected!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "No USB-PD IC\ndetected!"
+    },
+    "LockingKeysString": {
+      "message": "LOCKED"
+    },
+    "UnlockingKeysString": {
+      "message": "UNLOCKED"
+    },
+    "WarningKeysLockedString": {
+      "message": "!LOCKED!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Thermal\nRunaway"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Before rebooting, make sure tip & handle are at room temperature!"
+    },
+    "CJCCalibrating": {
+      "message": "calibrating\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Da li zaista želite da vratite postavke na fabričke vrednosti?"
+    },
+    "UVLOWarningString": {
+      "message": "NIZ.NAP."
+    },
+    "UndervoltageString": {
+      "message": "PRENIZAK NAPON\n"
+    },
+    "InputVoltageString": {
+      "message": "Ul. napon: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Spavanje...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Vrh: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Your device is most likely a counterfeit!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to\nstart profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "D",
+    "SettingLeftChar": "L",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "S",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "B",
+    "SettingStartSolderingChar": "L",
+    "SettingStartSleepChar": "S",
+    "SettingStartSleepOffChar": "X",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "F"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Power\nsettings",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Postavke\nlemljenja",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Ušteda\nenergije",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Korisničko\nsučelje",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Napredne\npostavke",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Vrsta\nnapajanja",
+      "description": "Tip napajanja; određuje najniži radni napon. (DC=adapter [10V], S=baterija [3,3V po ćeliji])"
+    },
+    "MinVolCell": {
+      "displayText": "Minimum\nvoltage",
+      "description": "Minimum allowed voltage per battery cell (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Ulazna\nsnaga",
+      "description": "Snaga napajanja u vatima."
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\ntimeout",
+      "description": "PD negotiation timeout in 100ms steps for compatibility with some QC chargers"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Enables PPS & EPR modes"
+    },
+    "BoostTemperature": {
+      "displayText": "Temp.\npojačanja",
+      "description": "Temperatura vrha lemilice u toku pojačanja."
+    },
+    "AutoStart": {
+      "displayText": "Vrući\nstart",
+      "description": "Lemilica odmah po pokretanju prelazi u režim lemljenja i greje se. (L=lemljenje | S=spavati | X=spavati sobna temperatura)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Temp change\nshort",
+      "description": "Temperature-change-increment on short button press"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Temp change\nlong",
+      "description": "Temperature-change-increment on long button press"
+    },
+    "LockingMode": {
+      "displayText": "Allow locking\nbuttons",
+      "description": "While soldering, hold down both buttons to toggle locking them (B=boost mode only | F=full locking)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat\nTemp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat\nSpeed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDuration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDuration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDuration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDuration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDuration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown\nSpeed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Osetljivost\nna pokret",
+      "description": "Osetljivost senzora pokreta. (1=najmanje osetljivo | ... | 9=najosetljivije)"
+    },
+    "SleepTemperature": {
+      "displayText": "Temp.\nspavanja",
+      "description": "Temperatura na koju se spušta lemilica nakon određenog vremena mirovanja. (C | F)"
+    },
+    "SleepTimeout": {
+      "displayText": "Vreme do\nspavanja",
+      "description": "Vreme mirovanja nakon koga lemilica spušta temperaturu. (m=minuti | s=sekunde)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Vreme do\ngašenja",
+      "description": "Vreme mirovanja nakon koga se lemilica gasi. (m=minuti)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Hall sensor\nsensitivity",
+      "description": "Sensitivity to magnets (1=najmanje osetljivo | ... | 9=najosetljivije)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Jedinica\ntemperature",
+      "description": "Jedinice u kojima se prikazuje temperatura. (C=celzijus | F=farenhajt)"
+    },
+    "DisplayRotation": {
+      "displayText": "Orijentacija\nekrana",
+      "description": "Kako je okrenut ekran. (D=za desnoruke | L=za levoruke | A=automatski)"
+    },
+    "CooldownBlink": {
+      "displayText": "Upozorenje\npri hlađenju",
+      "description": "Prikaz temperature trepće prilikom hlađenja dokle god je vrh i dalje vruć."
+    },
+    "ScrollingSpeed": {
+      "displayText": "Brzina\nporuka",
+      "description": "Brzina kretanja opisnih poruka poput ove. (S=sporo | B=brzo)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Swap\n+ - keys",
+      "description": "Reverse assignment of buttons for temperature adjustment"
+    },
+    "AnimSpeed": {
+      "displayText": "Anim.\nspeed",
+      "description": "Pace of icon animations in menu (S=slow | M=medium | B=fast)"
+    },
+    "AnimLoop": {
+      "displayText": "Anim.\nloop",
+      "description": "Loop icon animations in main menu"
+    },
+    "Brightness": {
+      "displayText": "Screen\nbrightness",
+      "description": "Adjust the OLED screen brightness"
+    },
+    "ColourInversion": {
+      "displayText": "Invert\nscreen",
+      "description": "Invert the OLED screen colors"
+    },
+    "LOGOTime": {
+      "displayText": "Boot logo\nduration",
+      "description": "Set boot logo duration (s=seconds)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Detalji tokom\nmirovanja",
+      "description": "Prikazivanje detaljnih informacija na ekranu tokom mirovanja."
+    },
+    "AdvancedSoldering": {
+      "displayText": "Detalji tokom\nlemljenja",
+      "description": "Prikazivanje detaljnih informacija na ekranu tokom lemljenja."
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Enables BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Power\nlimit",
+      "description": "Average maximum power the iron can use (W=watt)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Calibrate CJC\nat next boot",
+      "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Kalibracija\nulaznog napona",
+      "description": "Kalibrisanje ulaznog napona. Podešava se na tastere; dugi pritisak za kraj."
+    },
+    "PowerPulsePower": {
+      "displayText": "Power\npulse",
+      "description": "Intensity of power of keep-awake-pulse (W=watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Power pulse\ndelay",
+      "description": "Delay before keep-awake-pulse is triggered (x 2.5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Power pulse\nduration",
+      "description": "Keep-awake-pulse duration (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Fabričke\npostavke",
+      "description": "Vraćanje svih postavki na fabričke vrednosti."
+    },
+    "LanguageSwitch": {
+      "displayText": "Jezik:\n SR      Srpski",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_SV.json
+++ b/Translations/translation_SV.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "SV",
-    "languageLocalName": "Svenska",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Kalibrering\nfärdig!"
-        },
-        "ResetOKMessage": {
-            "message": "Återställning\nOK"
-        },
-        "SettingsResetMessage": {
-            "message": "Inställningar\nåterställda"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Ingen\naccelerometer"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "Ingen USB-PD IC\nhittades!"
-        },
-        "LockingKeysString": {
-            "message": "LÅST"
-        },
-        "UnlockingKeysString": {
-            "message": "UPPLÅST"
-        },
-        "WarningKeysLockedString": {
-            "message": "!LÅST!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Termisk\nFlykt"
-        },
-        "WarningTipShorted": {
-            "message": "!Spets Kortsluten!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Före omstart, säkerställ att spetsen och handtaget är i rumstemperatur!"
-        },
-        "CJCCalibrating": {
-            "message": "kalibrerar\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Är du säker på att du vill återställa inställningarna?"
-        },
-        "UVLOWarningString": {
-            "message": "DC LÅG"
-        },
-        "UndervoltageString": {
-            "message": "Underspänning\n"
-        },
-        "InputVoltageString": {
-            "message": "Inspän. V: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Viloläge...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Spets: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Förvärmning\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Nedkyldning\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Din enhet är sannerligen oäkta!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "För varm för att\nstarta profilen!"
-        }
+  "languageCode": "SV",
+  "languageLocalName": "Svenska",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Kalibrering\nfärdig!"
     },
-    "characters": {
-        "SettingRightChar": "H",
-        "SettingLeftChar": "V",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "L",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "S",
-        "SettingStartSolderingChar": "L",
-        "SettingStartSleepChar": "V",
-        "SettingStartSleepOffChar": "R",
-        "SettingLockBoostChar": "T",
-        "SettingLockFullChar": "F"
+    "ResetOKMessage": {
+      "message": "Återställning\nOK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Effekt-\ninställning",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Lödnings-\ninställning",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Vilo-\nläge",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Användar-\ngränssnitt",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Avancerade\nalternativ",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Inställningar\nåterställda"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Ström-\nkälla",
-            "description": "Strömkälla. Anger lägsta spänning. (DC 10V) (S 3.3V per cell)"
-        },
-        "MinVolCell": {
-            "displayText": "Minimim-\nspänning",
-            "description": "Minimumspänning per cell (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC\nspänning",
-            "description": "Maximal QC-spänning enheten skall efterfråga"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\npauser",
-            "description": "PD förhandlings pauser i 100ms steg för kompatibilitet med vissa PD laddare"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Slår på PPS & EPR lägen"
-        },
-        "BoostTemperature": {
-            "displayText": "Turbo-\ntemp",
-            "description": "Temperatur i \"turbo-läge\""
-        },
-        "AutoStart": {
-            "displayText": "Auto\nstart",
-            "description": "Startar automatiskt lödpennan vid uppstart. (L=Lödning | V=Viloläge | R=Viloläge Rumstemperatur)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Temp.just\nkorttryck",
-            "description": "Temperaturjustering vid kort knapptryckning"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Temp.just\nlångtryck",
-            "description": "Temperaturjustering vid lång knapptryckning"
-        },
-        "LockingMode": {
-            "displayText": "Tillåt lås\nvia knappar",
-            "description": "Vid lödning, håll nere bägge knappar för att slå på lås (T=Bara turbo | F=Fullt lås)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profil-\nfaser",
-            "description": "Antal faser i profil läge"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Förvärmnings-\ntemp",
-            "description": "Förvärm till denna temperatur i början av provil läget"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Förvärmnings-\nhastighet",
-            "description": "Förvärm enligt denna hastighet (grader per sekund)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Fas 1\nTemp",
-            "description": "Måltemperatur i slutet av denna fas"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Fas 1\nTidslängd",
-            "description": "Mållängd av denna fasen (sekunder)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Fas 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Fas 2\nTidslängd",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Fas 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Fas 3\nTidslängd",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Fas 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Fas 4\nTidslängd",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Fas 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Fas 5\nTidslängd",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Nedkylnings-\nhastighet",
-            "description": "Kyl ned i denna hastighet i slutet av profilen (grader per sekund)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Rörelse-\nkänslighet",
-            "description": "Rörelsekänslighet (1=minst känslig | ... | 9=mest känslig)"
-        },
-        "SleepTemperature": {
-            "displayText": "Vilo-\ntemp",
-            "description": "Vilotemperatur (C)"
-        },
-        "SleepTimeout": {
-            "displayText": "Vilo-\ntimeout",
-            "description": "Vilo-timeout (m=Minuter | s=Sekunder)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Avstängn.\ntimeout",
-            "description": "Avstängnings-timeout (Minuter)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Sensor-\nkänslght",
-            "description": "Känslighet för halleffekt-sensorn för viloläges-detektering (1=minst känslig | ... | 9=mest känslig)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Temperatur-\nenheter",
-            "description": "Temperaturenhet (C=Celsius | F=Fahrenheit)"
-        },
-        "DisplayRotation": {
-            "displayText": "Visnings\nläge",
-            "description": "Visningsläge (H=Högerhänt | V=Vänsterhänt | A=Automatisk)"
-        },
-        "CooldownBlink": {
-            "displayText": "Nedkylnings-\nblink",
-            "description": "Blinka temperaturen medan spetsen kyls av och fortfarande är varm."
-        },
-        "ScrollingSpeed": {
-            "displayText": "Beskrivning\nrullhast.",
-            "description": "Hastighet som den här texten rullar i"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Omvända\n+- knappar",
-            "description": "Omvänd ordning för temperaturjustering via plus/minus knapparna"
-        },
-        "AnimSpeed": {
-            "displayText": "Anim.-\nhastighet",
-            "description": "Animationshastighet för ikoner i menyer (L=långsam | M=medel | S=snabb)"
-        },
-        "AnimLoop": {
-            "displayText": "Anim.\nloop",
-            "description": "Loopa animationer i huvudmeny"
-        },
-        "Brightness": {
-            "displayText": "Skärmens\nLjusstyrka",
-            "description": "Justera OLED skärmens ljusstyrka"
-        },
-        "ColourInversion": {
-            "displayText": "Invertera\nskärm",
-            "description": "Invertera OLED skärmens färger"
-        },
-        "LOGOTime": {
-            "displayText": "Start logo\nTidslängd",
-            "description": "Sätt uppstartslogotypens tidslängd (s=sekunder)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Detaljerad\nvid inaktiv",
-            "description": "Visa detaljerad information i mindre typsnitt när inaktiv."
-        },
-        "AdvancedSoldering": {
-            "displayText": "Detaljerad\nlödng.skärm",
-            "description": "Visa detaljerad information vid lödning"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Tillåter BLE" 
-        },
-        "PowerLimit": {
-            "displayText": "Max-\neffekt",
-            "description": "Maximal effekt som enheten kan använda (Watt)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Kalibrera CJC\nnästa uppstart",
-            "description": "Vid nästa uppstart kommer spets Cold Junction Compensation kalibreras (ej nödvändigt om Delta T är < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Kalibrera\ninspänning?",
-            "description": "Inspänningskalibrering. Knapparna justerar, håll inne för avslut"
-        },
-        "PowerPulsePower": {
-            "displayText": "Effekt\npuls",
-            "description": "Intensiteten av effekt för håll-vaken-puls (W=watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Effekt puls\nfördröjning",
-            "description": "Fördröjning innan håll-vaken-pulsen skickas (x 2.5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Effekt puls\ntidsmängd",
-            "description": "Håll-vaken-puls varaktighet (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Fabriks-\ninställ?",
-            "description": "Återställ alla inställningar"
-        },
-        "LanguageSwitch": {
-            "displayText": "Språk:\n SV     Svenska",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Ingen\naccelerometer"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "Ingen USB-PD IC\nhittades!"
+    },
+    "LockingKeysString": {
+      "message": "LÅST"
+    },
+    "UnlockingKeysString": {
+      "message": "UPPLÅST"
+    },
+    "WarningKeysLockedString": {
+      "message": "!LÅST!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Termisk\nFlykt"
+    },
+    "WarningTipShorted": {
+      "message": "!Spets Kortsluten!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Före omstart, säkerställ att spetsen och handtaget är i rumstemperatur!"
+    },
+    "CJCCalibrating": {
+      "message": "kalibrerar\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Är du säker på att du vill återställa inställningarna?"
+    },
+    "UVLOWarningString": {
+      "message": "DC LÅG"
+    },
+    "UndervoltageString": {
+      "message": "Underspänning\n"
+    },
+    "InputVoltageString": {
+      "message": "Inspän. V: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Viloläge...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Spets: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Förvärmning\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Nedkyldning\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Din enhet är sannerligen oäkta!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "För varm för att\nstarta profilen!"
     }
+  },
+  "characters": {
+    "SettingRightChar": "H",
+    "SettingLeftChar": "V",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "L",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "S",
+    "SettingStartSolderingChar": "L",
+    "SettingStartSleepChar": "V",
+    "SettingStartSleepOffChar": "R",
+    "SettingLockBoostChar": "T",
+    "SettingLockFullChar": "F"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Effekt-\ninställning",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Lödnings-\ninställning",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Vilo-\nläge",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Användar-\ngränssnitt",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Avancerade\nalternativ",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Ström-\nkälla",
+      "description": "Strömkälla. Anger lägsta spänning. (DC 10V) (S 3.3V per cell)"
+    },
+    "MinVolCell": {
+      "displayText": "Minimim-\nspänning",
+      "description": "Minimumspänning per cell (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC\nspänning",
+      "description": "Maximal QC-spänning enheten skall efterfråga"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\npauser",
+      "description": "PD förhandlings pauser i 100ms steg för kompatibilitet med vissa PD laddare"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Slår på PPS & EPR lägen"
+    },
+    "BoostTemperature": {
+      "displayText": "Turbo-\ntemp",
+      "description": "Temperatur i \"turbo-läge\""
+    },
+    "AutoStart": {
+      "displayText": "Auto\nstart",
+      "description": "Startar automatiskt lödpennan vid uppstart. (L=Lödning | V=Viloläge | R=Viloläge Rumstemperatur)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Temp.just\nkorttryck",
+      "description": "Temperaturjustering vid kort knapptryckning"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Temp.just\nlångtryck",
+      "description": "Temperaturjustering vid lång knapptryckning"
+    },
+    "LockingMode": {
+      "displayText": "Tillåt lås\nvia knappar",
+      "description": "Vid lödning, håll nere bägge knappar för att slå på lås (T=Bara turbo | F=Fullt lås)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profil-\nfaser",
+      "description": "Antal faser i profil läge"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Förvärmnings-\ntemp",
+      "description": "Förvärm till denna temperatur i början av provil läget"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Förvärmnings-\nhastighet",
+      "description": "Förvärm enligt denna hastighet (grader per sekund)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Fas 1\nTemp",
+      "description": "Måltemperatur i slutet av denna fas"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Fas 1\nTidslängd",
+      "description": "Mållängd av denna fasen (sekunder)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Fas 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Fas 2\nTidslängd",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Fas 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Fas 3\nTidslängd",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Fas 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Fas 4\nTidslängd",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Fas 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Fas 5\nTidslängd",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Nedkylnings-\nhastighet",
+      "description": "Kyl ned i denna hastighet i slutet av profilen (grader per sekund)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Rörelse-\nkänslighet",
+      "description": "Rörelsekänslighet (1=minst känslig | ... | 9=mest känslig)"
+    },
+    "SleepTemperature": {
+      "displayText": "Vilo-\ntemp",
+      "description": "Vilotemperatur (C)"
+    },
+    "SleepTimeout": {
+      "displayText": "Vilo-\ntimeout",
+      "description": "Vilo-timeout (m=Minuter | s=Sekunder)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Avstängn.\ntimeout",
+      "description": "Avstängnings-timeout (Minuter)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Sensor-\nkänslght",
+      "description": "Känslighet för halleffekt-sensorn för viloläges-detektering (1=minst känslig | ... | 9=mest känslig)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Temperatur-\nenheter",
+      "description": "Temperaturenhet (C=Celsius | F=Fahrenheit)"
+    },
+    "DisplayRotation": {
+      "displayText": "Visnings\nläge",
+      "description": "Visningsläge (H=Högerhänt | V=Vänsterhänt | A=Automatisk)"
+    },
+    "CooldownBlink": {
+      "displayText": "Nedkylnings-\nblink",
+      "description": "Blinka temperaturen medan spetsen kyls av och fortfarande är varm."
+    },
+    "ScrollingSpeed": {
+      "displayText": "Beskrivning\nrullhast.",
+      "description": "Hastighet som den här texten rullar i"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Omvända\n+- knappar",
+      "description": "Omvänd ordning för temperaturjustering via plus/minus knapparna"
+    },
+    "AnimSpeed": {
+      "displayText": "Anim.-\nhastighet",
+      "description": "Animationshastighet för ikoner i menyer (L=långsam | M=medel | S=snabb)"
+    },
+    "AnimLoop": {
+      "displayText": "Anim.\nloop",
+      "description": "Loopa animationer i huvudmeny"
+    },
+    "Brightness": {
+      "displayText": "Skärmens\nLjusstyrka",
+      "description": "Justera OLED skärmens ljusstyrka"
+    },
+    "ColourInversion": {
+      "displayText": "Invertera\nskärm",
+      "description": "Invertera OLED skärmens färger"
+    },
+    "LOGOTime": {
+      "displayText": "Start logo\nTidslängd",
+      "description": "Sätt uppstartslogotypens tidslängd (s=sekunder)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Detaljerad\nvid inaktiv",
+      "description": "Visa detaljerad information i mindre typsnitt när inaktiv."
+    },
+    "AdvancedSoldering": {
+      "displayText": "Detaljerad\nlödng.skärm",
+      "description": "Visa detaljerad information vid lödning"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Tillåter BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Max-\neffekt",
+      "description": "Maximal effekt som enheten kan använda (Watt)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Kalibrera CJC\nnästa uppstart",
+      "description": "Vid nästa uppstart kommer spets Cold Junction Compensation kalibreras (ej nödvändigt om Delta T är < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Kalibrera\ninspänning?",
+      "description": "Inspänningskalibrering. Knapparna justerar, håll inne för avslut"
+    },
+    "PowerPulsePower": {
+      "displayText": "Effekt\npuls",
+      "description": "Intensiteten av effekt för håll-vaken-puls (W=watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Effekt puls\nfördröjning",
+      "description": "Fördröjning innan håll-vaken-pulsen skickas (x 2.5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Effekt puls\ntidsmängd",
+      "description": "Håll-vaken-puls varaktighet (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Fabriks-\ninställ?",
+      "description": "Återställ alla inställningar"
+    },
+    "LanguageSwitch": {
+      "displayText": "Språk:\n SV     Svenska",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_SV.json
+++ b/Translations/translation_SV.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Ström-\nkälla",
@@ -123,7 +134,7 @@
       "description": "PD förhandlings pauser i 100ms steg för kompatibilitet med vissa PD laddare"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "Slår på PPS & EPR lägen"
     },
     "BoostTemperature": {

--- a/Translations/translation_TR.json
+++ b/Translations/translation_TR.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "GÇKYN\n",
@@ -123,7 +134,7 @@
       "description": "Bazı QC şarj cihazlarıyla uyumluluk için 100ms adımlarında PD pazarlık zaman aşımı"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "PPS & EPR modlarını etkinleştirir"
     },
     "BoostTemperature": {

--- a/Translations/translation_TR.json
+++ b/Translations/translation_TR.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "TR",
-    "languageLocalName": "Türkçe",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Kalibrasyon\ntamam!"
-        },
-        "ResetOKMessage": {
-            "message": "Sıfırlama Tamam"
-        },
-        "SettingsResetMessage": {
-            "message": "Ayarlar\nSıfırlandı"
-        },
-        "NoAccelerometerMessage": {
-            "message": "İvme sensörü\ntespit edilmedi!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "USB-PD IC\ntespit edilmedi!"
-        },
-        "LockingKeysString": {
-            "message": "KİLİTLİ"
-        },
-        "UnlockingKeysString": {
-            "message": "KİLİT AÇIK"
-        },
-        "WarningKeysLockedString": {
-            "message": "!KİLİTLİ!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Termal\nKaçak"
-        },
-        "WarningTipShorted": {
-            "message": "!Uç Kısa Devre!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Yeniden başlatmadan önce uç ve sapın oda sıcaklığında olduğundan emin olun!"
-        },
-        "CJCCalibrating": {
-            "message": "kalibre ediliyor\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Ayarları varsayılan değerlere sıfırlamak istediğinizden emin misiniz?"
-        },
-        "UVLOWarningString": {
-            "message": "Güç Az"
-        },
-        "UndervoltageString": {
-            "message": "Düşük Voltaj\n"
-        },
-        "InputVoltageString": {
-            "message": "Giriş V: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Bekleme Modu...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Uç: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Ön Isıtma\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Soğuma\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Cihazınız büyük olasılıkla sahte!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Profil başlatmak için\nçok sıcak"
-        }
+  "languageCode": "TR",
+  "languageLocalName": "Türkçe",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Kalibrasyon\ntamam!"
     },
-    "characters": {
-        "SettingRightChar": "R",
-        "SettingLeftChar": "L",
-        "SettingAutoChar": "O",
-        "SettingSlowChar": "Y",
-        "SettingMediumChar": "O",
-        "SettingFastChar": "H",
-        "SettingStartSolderingChar": "L",
-        "SettingStartSleepChar": "U",
-        "SettingStartSleepOffChar": "S",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "F"
+    "ResetOKMessage": {
+      "message": "Sıfırlama Tamam"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Güç\nAyarları",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Lehimleme\nAyarları",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Uyku\nModları",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Kullanıcı\nArayüzü",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Gelişmiş\nAyarlar",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Ayarlar\nSıfırlandı"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "GÇKYN\n",
-            "description": "\"Güç Kaynağı\". En düşük çalışma voltajını ayarlar. (DC 10V) (S 3.3V hücre başına)"
-        },
-        "MinVolCell": {
-            "displayText": "Minimum\nVoltaj",
-            "description": "Pil hücresi başına izin verilen minimum voltaj (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC\nvoltajı",
-            "description": "Max istenecek QC voltajı"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\nTimeout",
-            "description": "Bazı QC şarj cihazlarıyla uyumluluk için 100ms adımlarında PD pazarlık zaman aşımı"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "PPS & EPR modlarını etkinleştirir"
-        },
-        "BoostTemperature": {
-            "displayText": "YKSC\n",
-            "description": "Yüksek Performans Modu Sıcaklığı"
-        },
-        "AutoStart": {
-            "displayText": "OTOBAŞ\n",
-            "description": "Güç verildiğinde otomatik olarak lehimleme modunda başlat. (L=Lehimleme Modu | U=Uyku Modu | S=Uyku Modu Oda Sıcaklığı)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Sıcaklık değişimi\nkısa",
-            "description": "Kısa basışlardaki sıcaklık derecesi atlama oranı"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Sıcaklık değişimi\nuzun",
-            "description": "Uzun başışlardaki sıcaklık derecesi atlama oranı"
-        },
-        "LockingMode": {
-            "displayText": "Kilitleme\nİzni",
-            "description": "Lehimleme sırasında, her iki düğmeye basılı tutarak kilitleme modunu değiştirin (B=Sadece performans modu | F=tam kilit)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profil\nAşamaları",
-            "description": "Profil modundaki aşamaların sayısı"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Ön Isıtma\nSıcaklık",
-            "description": "Profil modunun başlangıcında bu sıcaklığa kadar ön ısıtma yapar"
-        },
-        "ProfilePreheatSpeed": {
-        "displayText": "Ön Isıtma\nHızı",
-        "description": "Bu hızda ön ısıtma yapın (saniye başına derece)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Aşama 1\nSıcaklık",
-            "description": "Bu aşamanın sonunda hedeflenen sıcaklık"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Aşama 1\nSüre",
-            "description": "Bu aşamanın hedef süresi (saniye)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Aşama 2\nSıcaklık",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Aşama 2\nSüre",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Aşama 3\nSıcaklık",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Aşama 3\nSüre",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Aşama 4\nSıcaklık",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Aşama 4\nSüre",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Aşama 5\nSıcaklık",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Aşama 5\nSüre",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-          "displayText": "Soğuma\nHızı",
-          "description": "Profil modunun sonunda bu hızda soğuma yapın (saniye başına derece)"
-        },
-        "MotionSensitivity": {
-            "displayText": "HARHAS\n",
-            "description": "Hareket Hassasiyeti (1=En az duyarlı | ... | 9=En duyarlı)"
-        },
-        "SleepTemperature": {
-            "displayText": "BKSC\n",
-            "description": "Bekleme Modu Sıcaklığı (C)"
-        },
-        "SleepTimeout": {
-            "displayText": "BMZA\n",
-            "description": "Bekleme Modu Zaman Aşımı (Dakika | Saniye)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "KPTZA\n",
-            "description": "Kapatma Zaman Aşımı (Dakika)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Hall Sensör\nHassasiyeti",
-            "description": "Mıknatıslara duyarlılık (1=En az duyarlı | ... | 9=En duyarlı)"
-        },
-        "TemperatureUnit": {
-            "displayText": "SCKBRM\n",
-            "description": "Sıcaklık Birimi (C=Celsius | F=Fahrenheit)"
-        },
-        "DisplayRotation": {
-            "displayText": "GRNYÖN\n",
-            "description": "Görüntü Yönlendirme (R=Sağlak | L=Solak | O=Otomatik)"
-        },
-        "CooldownBlink": {
-            "displayText": "SĞGÖST\n",
-            "description": "Soğutma ekranında uç hala sıcakken derece gösterilsin."
-        },
-        "ScrollingSpeed": {
-            "displayText": "YZKYHZ\n",
-            "description": "Bu yazının kayma hızı (Y=Yavaş | H=Hızlı)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Düğme Yerleri\nRotasyonu",
-            "description": "\"Düğme Yerleri Rotasyonu\" Sıcaklık ayar düğmelerinin yerini değiştirin"
-        },
-        "AnimSpeed": {
-             "displayText": "Animasyon\nHızı",
-             "description": "Menüdeki simge animasyonlarının hızı (Y=Yavaş | O=Orta | H=Hızlı)"
-        },
-        "AnimLoop": {
-            "displayText": "Animasyon\nDöngüsü",
-            "description": "Ana menüde simge animasyonlarının döngüsü"
-        },
-        "Brightness": {
-            "displayText": "Ekran\nparlaklığı",
-            "description": "OLED ekran parlaklığını ayarlar"
-        },
-        "ColourInversion": {
-            "displayText": "Ekran\nRenkleri",
-            "description": "OLED ekran renklerini ters çevir"
-        },
-        "LOGOTime": {
-            "displayText": "Boot Logo\nSüresi",
-            "description": "Boot logo süresi (s=saniye)"
-        },
-        "AdvancedIdle": {
-            "displayText": "AYRBİL\n",
-            "description": "Boş ekranda ayrıntılı bilgileri daha küçük bir yazı tipi ile göster."
-        },
-        "AdvancedSoldering": {
-            "displayText": "GELLHM\n",
-            "description": "\"Gelişmiş Lehimleme\" Lehimleme yaparken detaylı bilgi göster"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Bluetooth LE'yi etkinleştirir"
-        },
-        "PowerLimit": {
-            "displayText": "Güç\nlimiti",
-            "description": "Havyanın kullanacağı en yüksek güç (W=Watts)"
-        },
-        "CalibrateCJC": {
-            "displayText": "CJC Kalibrasyonu\nSonraki Boot'ta",
-            "description": "Sonraki boot'ta uç Soğuk Nokta Kompansasyonu kalibre edilecek (Delta T < 5°C ise gerekmez)"
-        },
-        "VoltageCalibration": {
-            "displayText": "VOL KAL?\n",
-            "description": "Voltaj Girişi Kalibrasyonu. Düğmeler ayarlar, çıkmak için uzun bas."
-        },
-        "PowerPulsePower": {
-            "displayText": "Güç\nDarbeleri",
-            "description": "Güç girişi voltajı ölçüm yoğunluğunu sık tut."
-        },
-        "PowerPulseWait": {
-            "displayText": "Güç Darbesi\nGecikmesi",
-            "description": "Uyanık tutma darbesinin tetiklenmeden önceki gecikme süresi (x 2.5s)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Güç Darbesi\nSüresi",
-            "description": "Uyanık tutma darbesi süresi (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "SIFIRLA?\n",
-            "description": "Bütün ayarları sıfırlar"
-        },
-        "LanguageSwitch": {
-            "displayText": "Dil:\n TR      Türkçe",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "İvme sensörü\ntespit edilmedi!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "USB-PD IC\ntespit edilmedi!"
+    },
+    "LockingKeysString": {
+      "message": "KİLİTLİ"
+    },
+    "UnlockingKeysString": {
+      "message": "KİLİT AÇIK"
+    },
+    "WarningKeysLockedString": {
+      "message": "!KİLİTLİ!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Termal\nKaçak"
+    },
+    "WarningTipShorted": {
+      "message": "!Uç Kısa Devre!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Yeniden başlatmadan önce uç ve sapın oda sıcaklığında olduğundan emin olun!"
+    },
+    "CJCCalibrating": {
+      "message": "kalibre ediliyor\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Ayarları varsayılan değerlere sıfırlamak istediğinizden emin misiniz?"
+    },
+    "UVLOWarningString": {
+      "message": "Güç Az"
+    },
+    "UndervoltageString": {
+      "message": "Düşük Voltaj\n"
+    },
+    "InputVoltageString": {
+      "message": "Giriş V: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Bekleme Modu...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Uç: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Ön Isıtma\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Soğuma\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Cihazınız büyük olasılıkla sahte!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Profil başlatmak için\nçok sıcak"
     }
+  },
+  "characters": {
+    "SettingRightChar": "R",
+    "SettingLeftChar": "L",
+    "SettingAutoChar": "O",
+    "SettingSlowChar": "Y",
+    "SettingMediumChar": "O",
+    "SettingFastChar": "H",
+    "SettingStartSolderingChar": "L",
+    "SettingStartSleepChar": "U",
+    "SettingStartSleepOffChar": "S",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "F"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Güç\nAyarları",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Lehimleme\nAyarları",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Uyku\nModları",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Kullanıcı\nArayüzü",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Gelişmiş\nAyarlar",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "GÇKYN\n",
+      "description": "\"Güç Kaynağı\". En düşük çalışma voltajını ayarlar. (DC 10V) (S 3.3V hücre başına)"
+    },
+    "MinVolCell": {
+      "displayText": "Minimum\nVoltaj",
+      "description": "Pil hücresi başına izin verilen minimum voltaj (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC\nvoltajı",
+      "description": "Max istenecek QC voltajı"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\nTimeout",
+      "description": "Bazı QC şarj cihazlarıyla uyumluluk için 100ms adımlarında PD pazarlık zaman aşımı"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "PPS & EPR modlarını etkinleştirir"
+    },
+    "BoostTemperature": {
+      "displayText": "YKSC\n",
+      "description": "Yüksek Performans Modu Sıcaklığı"
+    },
+    "AutoStart": {
+      "displayText": "OTOBAŞ\n",
+      "description": "Güç verildiğinde otomatik olarak lehimleme modunda başlat. (L=Lehimleme Modu | U=Uyku Modu | S=Uyku Modu Oda Sıcaklığı)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Sıcaklık değişimi\nkısa",
+      "description": "Kısa basışlardaki sıcaklık derecesi atlama oranı"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Sıcaklık değişimi\nuzun",
+      "description": "Uzun başışlardaki sıcaklık derecesi atlama oranı"
+    },
+    "LockingMode": {
+      "displayText": "Kilitleme\nİzni",
+      "description": "Lehimleme sırasında, her iki düğmeye basılı tutarak kilitleme modunu değiştirin (B=Sadece performans modu | F=tam kilit)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profil\nAşamaları",
+      "description": "Profil modundaki aşamaların sayısı"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Ön Isıtma\nSıcaklık",
+      "description": "Profil modunun başlangıcında bu sıcaklığa kadar ön ısıtma yapar"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Ön Isıtma\nHızı",
+      "description": "Bu hızda ön ısıtma yapın (saniye başına derece)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Aşama 1\nSıcaklık",
+      "description": "Bu aşamanın sonunda hedeflenen sıcaklık"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Aşama 1\nSüre",
+      "description": "Bu aşamanın hedef süresi (saniye)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Aşama 2\nSıcaklık",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Aşama 2\nSüre",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Aşama 3\nSıcaklık",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Aşama 3\nSüre",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Aşama 4\nSıcaklık",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Aşama 4\nSüre",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Aşama 5\nSıcaklık",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Aşama 5\nSüre",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Soğuma\nHızı",
+      "description": "Profil modunun sonunda bu hızda soğuma yapın (saniye başına derece)"
+    },
+    "MotionSensitivity": {
+      "displayText": "HARHAS\n",
+      "description": "Hareket Hassasiyeti (1=En az duyarlı | ... | 9=En duyarlı)"
+    },
+    "SleepTemperature": {
+      "displayText": "BKSC\n",
+      "description": "Bekleme Modu Sıcaklığı (C)"
+    },
+    "SleepTimeout": {
+      "displayText": "BMZA\n",
+      "description": "Bekleme Modu Zaman Aşımı (Dakika | Saniye)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "KPTZA\n",
+      "description": "Kapatma Zaman Aşımı (Dakika)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Hall Sensör\nHassasiyeti",
+      "description": "Mıknatıslara duyarlılık (1=En az duyarlı | ... | 9=En duyarlı)"
+    },
+    "TemperatureUnit": {
+      "displayText": "SCKBRM\n",
+      "description": "Sıcaklık Birimi (C=Celsius | F=Fahrenheit)"
+    },
+    "DisplayRotation": {
+      "displayText": "GRNYÖN\n",
+      "description": "Görüntü Yönlendirme (R=Sağlak | L=Solak | O=Otomatik)"
+    },
+    "CooldownBlink": {
+      "displayText": "SĞGÖST\n",
+      "description": "Soğutma ekranında uç hala sıcakken derece gösterilsin."
+    },
+    "ScrollingSpeed": {
+      "displayText": "YZKYHZ\n",
+      "description": "Bu yazının kayma hızı (Y=Yavaş | H=Hızlı)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Düğme Yerleri\nRotasyonu",
+      "description": "\"Düğme Yerleri Rotasyonu\" Sıcaklık ayar düğmelerinin yerini değiştirin"
+    },
+    "AnimSpeed": {
+      "displayText": "Animasyon\nHızı",
+      "description": "Menüdeki simge animasyonlarının hızı (Y=Yavaş | O=Orta | H=Hızlı)"
+    },
+    "AnimLoop": {
+      "displayText": "Animasyon\nDöngüsü",
+      "description": "Ana menüde simge animasyonlarının döngüsü"
+    },
+    "Brightness": {
+      "displayText": "Ekran\nparlaklığı",
+      "description": "OLED ekran parlaklığını ayarlar"
+    },
+    "ColourInversion": {
+      "displayText": "Ekran\nRenkleri",
+      "description": "OLED ekran renklerini ters çevir"
+    },
+    "LOGOTime": {
+      "displayText": "Boot Logo\nSüresi",
+      "description": "Boot logo süresi (s=saniye)"
+    },
+    "AdvancedIdle": {
+      "displayText": "AYRBİL\n",
+      "description": "Boş ekranda ayrıntılı bilgileri daha küçük bir yazı tipi ile göster."
+    },
+    "AdvancedSoldering": {
+      "displayText": "GELLHM\n",
+      "description": "\"Gelişmiş Lehimleme\" Lehimleme yaparken detaylı bilgi göster"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Bluetooth LE'yi etkinleştirir"
+    },
+    "PowerLimit": {
+      "displayText": "Güç\nlimiti",
+      "description": "Havyanın kullanacağı en yüksek güç (W=Watts)"
+    },
+    "CalibrateCJC": {
+      "displayText": "CJC Kalibrasyonu\nSonraki Boot'ta",
+      "description": "Sonraki boot'ta uç Soğuk Nokta Kompansasyonu kalibre edilecek (Delta T < 5°C ise gerekmez)"
+    },
+    "VoltageCalibration": {
+      "displayText": "VOL KAL?\n",
+      "description": "Voltaj Girişi Kalibrasyonu. Düğmeler ayarlar, çıkmak için uzun bas."
+    },
+    "PowerPulsePower": {
+      "displayText": "Güç\nDarbeleri",
+      "description": "Güç girişi voltajı ölçüm yoğunluğunu sık tut."
+    },
+    "PowerPulseWait": {
+      "displayText": "Güç Darbesi\nGecikmesi",
+      "description": "Uyanık tutma darbesinin tetiklenmeden önceki gecikme süresi (x 2.5s)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Güç Darbesi\nSüresi",
+      "description": "Uyanık tutma darbesi süresi (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "SIFIRLA?\n",
+      "description": "Bütün ayarları sıfırlar"
+    },
+    "LanguageSwitch": {
+      "displayText": "Dil:\n TR      Türkçe",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_UK.json
+++ b/Translations/translation_UK.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Джерело\nживлення",
@@ -123,7 +134,7 @@
       "description": "Затримка у 100мс інкрементах для PD для сумісності з деякими QC зарядними пристроями (0: вимкнено)"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
+      "displayText": "PD\nMode",
       "description": "Вмикає режими PPS & EPR."
     },
     "BoostTemperature": {

--- a/Translations/translation_UK.json
+++ b/Translations/translation_UK.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "UK",
-    "languageLocalName": "Українська",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "КХС\nвідкалібровано!"
-        },
-        "ResetOKMessage": {
-            "message": "Скид. OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Налаштування\nскинуті!"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Акселерометр\nне виявлено!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "USB-PD IC\nне виявлено!"
-        },
-        "LockingKeysString": {
-            "message": "ЗАБЛОК."
-        },
-        "UnlockingKeysString": {
-            "message": "РОЗБЛОК."
-        },
-        "WarningKeysLockedString": {
-            "message": "!ЗАБЛОК!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Некерований\nрозігрів"
-        },
-        "WarningTipShorted": {
-            "message": "!Жало закорочено!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Під час наступного завантаження переконайтеся, що жало і ручка мають кімнатну температуру!"
-        },
-        "CJCCalibrating": {
-            "message": "калібрування\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Ви дійсно хочете скинути налаштування до значень за замовчуванням? (A=Так, В=Ні)"
-        },
-        "UVLOWarningString": {
-            "message": "АККУМ--"
-        },
-        "UndervoltageString": {
-            "message": "Низька напруга\n"
-        },
-        "InputVoltageString": {
-            "message": "Жив.(B): \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Очікування...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Жало: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Попередній\nрозігрів"
-        },
-        "ProfileCooldownString": {
-            "message": "Охолодження\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Вірогідно ваш пристрій підробний!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Занадто гараче для\nзміни профілів"
-        }
+  "languageCode": "UK",
+  "languageLocalName": "Українська",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "КХС\nвідкалібровано!"
     },
-    "characters": {
-        "SettingRightChar": "П",
-        "SettingLeftChar": "Л",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "Н",
-        "SettingMediumChar": "С",
-        "SettingFastChar": "М",
-        "SettingStartSolderingChar": "П",
-        "SettingStartSleepChar": "О",
-        "SettingStartSleepOffChar": "К",
-        "SettingLockBoostChar": "Т",
-        "SettingLockFullChar": "П"
+    "ResetOKMessage": {
+      "message": "Скид. OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Параметри\nживлення",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Параметри\nпайки",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Режим\nсну",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Параметри\nінтерфейсу",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Додаткові\nпараметри",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Налаштування\nскинуті!"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Джерело\nживлення",
-            "description": "Встановлює напругу відсічки. (DC - 10V) (3S - 9.9V | 4S - 13.2V | 5S - 16.5V | 6S - 19.8V)"
-        },
-        "MinVolCell": {
-            "displayText": "Мін.\nнапруга",
-            "description": "Мінімальна дозволена напруга на комірку (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "Потужність\nдж. живлення",
-            "description": "Потужність джерела живлення в Ватах"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\nзатримка",
-            "description": "Затримка у 100мс інкрементах для PD для сумісності з деякими QC зарядними пристроями (0: вимкнено)"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Вмикає режими PPS & EPR."
-        },
-        "BoostTemperature": {
-            "displayText": "Темпер.\nТурбо",
-            "description": "Температура в \"Турбо\" режимі"
-        },
-        "AutoStart": {
-            "displayText": "Гарячий\nстарт",
-            "description": "Режим в якому запускається паяльник при ввімкненні (П=Пайка | О=Очікування | К=Очікування при кімн. темп.)"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Зміна темп.\nкоротко?",
-            "description": "Змінювати температуру при короткому натисканні!"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Зміна темп.\nдовго?",
-            "description": "Змінювати температуру при довгому натисканні!"
-        },
-        "LockingMode": {
-            "displayText": "Дозволити\nблок. кнопок",
-            "description": "Під час пайки тривале натискання обох кнопок заблокує їх (Т=Тільки турбо | П=Повне)"
-        },
-        "ProfilePhases": {
-            "displayText": "Етапи\nпрофілів",
-            "description": "Кількість етапів в режимі профілів"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Температура\nПоп.Розігріву",
-            "description": "Попередньо розігріти до цієї температури на початку режимку профілів"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Швидкість\nПоп.Розігріву",
-            "description": "Розігрівати з такою швидкістю (градусів в секунду)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Етап 1\nТемпература",
-            "description": "Температура в кінці цього етапу"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Етап 1\nТривалість",
-            "description": "Тривалість цього етапу (секунд)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Етап 2\nТемпература",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Етап 2\nТривалість",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Етап 3\nТемпература",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Етап 3\nТривалість",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Етап 4\nТемпература",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Етап 4\nТривалість",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Етап 5\nТемпература",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Етап 5\nТривалість",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Швидкість\nОхолодження",
-            "description": "Швидкість охолодження в кінці режиму профілів (градусів в секунду)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Чутливість\nсенсору руху",
-            "description": "Акселерометр (1=мін. чутливості | ... | 9=макс. чутливості)"
-        },
-        "SleepTemperature": {
-            "displayText": "Темпер.\nсну",
-            "description": "Температура режиму очікування (C° | F°)"
-        },
-        "SleepTimeout": {
-            "displayText": "Тайм-аут\nсну",
-            "description": "Час до переходу в режим очікування (Хвилини | Секунди)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Часу до\nвимкнення",
-            "description": "Час до вимкнення (Хвилини)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Чутливість\nЕфекту Холла",
-            "description": "Чутливість датчика ефекту Холла при виявленні сну (1=мін. чутливості | ... | 9=макс. чутливості)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Формат темпе-\nратури(C°/F°)",
-            "description": "Одиниця виміру температури (C=Цельсій | F=Фаренгейт)"
-        },
-        "DisplayRotation": {
-            "displayText": "Автоповорот\nекрану",
-            "description": "Орієнтація дисплея (П=Правша | Л=Лівша | A=Автоповорот)"
-        },
-        "CooldownBlink": {
-            "displayText": "Показ t° при\nохолодженні",
-            "description": "Показувати температуру на екрані охолодження, поки жало залишається гарячим, при цьому екран моргає"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Швидкість\nтексту",
-            "description": "Швидкість прокрутки тексту (Н=Низькa | М=Максимальна)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Інвертувати\nкнопки +-?",
-            "description": "Інвертувати кнопки зміни температури."
-        },
-        "AnimSpeed": {
-            "displayText": "Швидкість\nанімації",
-            "description": "Швидкість анімації іконок у головному меню (Н=Низькa | С=Середня | М=Максимальна)"
-        },
-        "AnimLoop": {
-            "displayText": "Циклічна\nанімація",
-            "description": "Циклічна анімація іконок в головному меню"
-        },
-        "Brightness": {
-            "displayText": "Яскравість\nекрану",
-            "description": "Налаштування контрасту/яскравості OLED екрану"
-        },
-        "ColourInversion": {
-            "displayText": "Інверт\nекрану",
-            "description": "Інвертувати кольори на OLED екрані"
-        },
-        "LOGOTime": {
-            "displayText": "Тривалість\nлоготипу завантаження",
-            "description": "Встановити тривалість показу лого при завантаженні (с=секунд)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Детальний ре-\nжим очікуван.",
-            "description": "Показувати детальну інформацію маленьким шрифтом на домашньому екрані"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Детальний\nрежим пайки",
-            "description": "Показувати детальну інформацію при пайці."
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Увімкнути BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Макс.\nпотуж.",
-            "description": "Макс. потужність, яку може використовувати паяльник (Ват)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Калібрувати КХС\nпри наступному завантаженні",
-            "description": "При наступному завантаження буде відкалібровано Компенсацію Холодного Спаю жала (непотрібне при різниці температур < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Калібрування\nнапруги",
-            "description": "Калібрування напруги входу. Налаштувати кнопками, натиснути і утримати щоб завершити."
-        },
-        "PowerPulsePower": {
-            "displayText": "Пульс.\nНавантаж.",
-            "description": "Деякі PowerBank-и з часом вимк. живлення, якщо пристрій споживає дуже мало енергії)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Час між імп.\nнапруги",
-            "description": "Час між імпульсами напруги яка не дає PowerBank-у заснути (x 2.5с)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Тривалість\nімп. напруги",
-            "description": "Тривалість імпульсу напруги яка не дає PowerBank-у заснути (x 250мс)"
-        },
-        "SettingsReset": {
-            "displayText": "Скинути всі\nналаштування?",
-            "description": "Скидання всіх параметрів до стандартних значень."
-        },
-        "LanguageSwitch": {
-            "displayText": "Мова:\n UK  Українська",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Акселерометр\nне виявлено!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "USB-PD IC\nне виявлено!"
+    },
+    "LockingKeysString": {
+      "message": "ЗАБЛОК."
+    },
+    "UnlockingKeysString": {
+      "message": "РОЗБЛОК."
+    },
+    "WarningKeysLockedString": {
+      "message": "!ЗАБЛОК!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Некерований\nрозігрів"
+    },
+    "WarningTipShorted": {
+      "message": "!Жало закорочено!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Під час наступного завантаження переконайтеся, що жало і ручка мають кімнатну температуру!"
+    },
+    "CJCCalibrating": {
+      "message": "калібрування\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Ви дійсно хочете скинути налаштування до значень за замовчуванням? (A=Так, В=Ні)"
+    },
+    "UVLOWarningString": {
+      "message": "АККУМ--"
+    },
+    "UndervoltageString": {
+      "message": "Низька напруга\n"
+    },
+    "InputVoltageString": {
+      "message": "Жив.(B): \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Очікування...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Жало: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Попередній\nрозігрів"
+    },
+    "ProfileCooldownString": {
+      "message": "Охолодження\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Вірогідно ваш пристрій підробний!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Занадто гараче для\nзміни профілів"
     }
+  },
+  "characters": {
+    "SettingRightChar": "П",
+    "SettingLeftChar": "Л",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "Н",
+    "SettingMediumChar": "С",
+    "SettingFastChar": "М",
+    "SettingStartSolderingChar": "П",
+    "SettingStartSleepChar": "О",
+    "SettingStartSleepOffChar": "К",
+    "SettingLockBoostChar": "Т",
+    "SettingLockFullChar": "П"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Параметри\nживлення",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Параметри\nпайки",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Режим\nсну",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Параметри\nінтерфейсу",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Додаткові\nпараметри",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Джерело\nживлення",
+      "description": "Встановлює напругу відсічки. (DC - 10V) (3S - 9.9V | 4S - 13.2V | 5S - 16.5V | 6S - 19.8V)"
+    },
+    "MinVolCell": {
+      "displayText": "Мін.\nнапруга",
+      "description": "Мінімальна дозволена напруга на комірку (3S: 3 - 3.7V | 4-6S: 2.4 - 3.7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "Потужність\nдж. живлення",
+      "description": "Потужність джерела живлення в Ватах"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\nзатримка",
+      "description": "Затримка у 100мс інкрементах для PD для сумісності з деякими QC зарядними пристроями (0: вимкнено)"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Вмикає режими PPS & EPR."
+    },
+    "BoostTemperature": {
+      "displayText": "Темпер.\nТурбо",
+      "description": "Температура в \"Турбо\" режимі"
+    },
+    "AutoStart": {
+      "displayText": "Гарячий\nстарт",
+      "description": "Режим в якому запускається паяльник при ввімкненні (П=Пайка | О=Очікування | К=Очікування при кімн. темп.)"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Зміна темп.\nкоротко?",
+      "description": "Змінювати температуру при короткому натисканні!"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Зміна темп.\nдовго?",
+      "description": "Змінювати температуру при довгому натисканні!"
+    },
+    "LockingMode": {
+      "displayText": "Дозволити\nблок. кнопок",
+      "description": "Під час пайки тривале натискання обох кнопок заблокує їх (Т=Тільки турбо | П=Повне)"
+    },
+    "ProfilePhases": {
+      "displayText": "Етапи\nпрофілів",
+      "description": "Кількість етапів в режимі профілів"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Температура\nПоп.Розігріву",
+      "description": "Попередньо розігріти до цієї температури на початку режимку профілів"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Швидкість\nПоп.Розігріву",
+      "description": "Розігрівати з такою швидкістю (градусів в секунду)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Етап 1\nТемпература",
+      "description": "Температура в кінці цього етапу"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Етап 1\nТривалість",
+      "description": "Тривалість цього етапу (секунд)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Етап 2\nТемпература",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Етап 2\nТривалість",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Етап 3\nТемпература",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Етап 3\nТривалість",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Етап 4\nТемпература",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Етап 4\nТривалість",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Етап 5\nТемпература",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Етап 5\nТривалість",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Швидкість\nОхолодження",
+      "description": "Швидкість охолодження в кінці режиму профілів (градусів в секунду)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Чутливість\nсенсору руху",
+      "description": "Акселерометр (1=мін. чутливості | ... | 9=макс. чутливості)"
+    },
+    "SleepTemperature": {
+      "displayText": "Темпер.\nсну",
+      "description": "Температура режиму очікування (C° | F°)"
+    },
+    "SleepTimeout": {
+      "displayText": "Тайм-аут\nсну",
+      "description": "Час до переходу в режим очікування (Хвилини | Секунди)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Часу до\nвимкнення",
+      "description": "Час до вимкнення (Хвилини)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Чутливість\nЕфекту Холла",
+      "description": "Чутливість датчика ефекту Холла при виявленні сну (1=мін. чутливості | ... | 9=макс. чутливості)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Формат темпе-\nратури(C°/F°)",
+      "description": "Одиниця виміру температури (C=Цельсій | F=Фаренгейт)"
+    },
+    "DisplayRotation": {
+      "displayText": "Автоповорот\nекрану",
+      "description": "Орієнтація дисплея (П=Правша | Л=Лівша | A=Автоповорот)"
+    },
+    "CooldownBlink": {
+      "displayText": "Показ t° при\nохолодженні",
+      "description": "Показувати температуру на екрані охолодження, поки жало залишається гарячим, при цьому екран моргає"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Швидкість\nтексту",
+      "description": "Швидкість прокрутки тексту (Н=Низькa | М=Максимальна)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Інвертувати\nкнопки +-?",
+      "description": "Інвертувати кнопки зміни температури."
+    },
+    "AnimSpeed": {
+      "displayText": "Швидкість\nанімації",
+      "description": "Швидкість анімації іконок у головному меню (Н=Низькa | С=Середня | М=Максимальна)"
+    },
+    "AnimLoop": {
+      "displayText": "Циклічна\nанімація",
+      "description": "Циклічна анімація іконок в головному меню"
+    },
+    "Brightness": {
+      "displayText": "Яскравість\nекрану",
+      "description": "Налаштування контрасту/яскравості OLED екрану"
+    },
+    "ColourInversion": {
+      "displayText": "Інверт\nекрану",
+      "description": "Інвертувати кольори на OLED екрані"
+    },
+    "LOGOTime": {
+      "displayText": "Тривалість\nлоготипу завантаження",
+      "description": "Встановити тривалість показу лого при завантаженні (с=секунд)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Детальний ре-\nжим очікуван.",
+      "description": "Показувати детальну інформацію маленьким шрифтом на домашньому екрані"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Детальний\nрежим пайки",
+      "description": "Показувати детальну інформацію при пайці."
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Увімкнути BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Макс.\nпотуж.",
+      "description": "Макс. потужність, яку може використовувати паяльник (Ват)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Калібрувати КХС\nпри наступному завантаженні",
+      "description": "При наступному завантаження буде відкалібровано Компенсацію Холодного Спаю жала (непотрібне при різниці температур < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Калібрування\nнапруги",
+      "description": "Калібрування напруги входу. Налаштувати кнопками, натиснути і утримати щоб завершити."
+    },
+    "PowerPulsePower": {
+      "displayText": "Пульс.\nНавантаж.",
+      "description": "Деякі PowerBank-и з часом вимк. живлення, якщо пристрій споживає дуже мало енергії)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Час між імп.\nнапруги",
+      "description": "Час між імпульсами напруги яка не дає PowerBank-у заснути (x 2.5с)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Тривалість\nімп. напруги",
+      "description": "Тривалість імпульсу напруги яка не дає PowerBank-у заснути (x 250мс)"
+    },
+    "SettingsReset": {
+      "displayText": "Скинути всі\nналаштування?",
+      "description": "Скидання всіх параметрів до стандартних значень."
+    },
+    "LanguageSwitch": {
+      "displayText": "Мова:\n UK  Українська",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_VI.json
+++ b/Translations/translation_VI.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Nguon\nđien",
@@ -123,8 +134,8 @@
       "description": "Thoi gian cho đàm phán PD trong các buoc 100ms đe tuong thích voi mot so bo sac QC"
     },
     "USBPDMode": {
-      "displayText": "PD\nVPDO",
-      "description": "Enables PPS & EPR modes"
+      "displayText": "PD\nMode",
+      "description": "No Dynamic disables EPR & PPS, Safe mode does not use padding resistance"
     },
     "BoostTemperature": {
       "displayText": "Tăng\nnhiet đo",

--- a/Translations/translation_VI.json
+++ b/Translations/translation_VI.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "VI",
-    "languageLocalName": "Tieng Viet",
-    "tempUnitFahrenheit": false,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Calibration\ndone!"
-        },
-        "ResetOKMessage": {
-            "message": "Reset OK"
-        },
-        "SettingsResetMessage": {
-            "message": "Mot so cài đat\nđã thay đoi"
-        },
-        "NoAccelerometerMessage": {
-            "message": "Không phát hien\ngia toc ke!"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "Không phát hien\nUSB-PD IC!"
-        },
-        "LockingKeysString": {
-            "message": "Đã khóa"
-        },
-        "UnlockingKeysString": {
-            "message": "Mo khóa"
-        },
-        "WarningKeysLockedString": {
-            "message": "Đã khóa!"
-        },
-        "WarningThermalRunaway": {
-            "message": "Nhiet\nTat gia nhiet"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Before rebooting, make sure tip & handle are at room temperature!"
-        },
-        "CJCCalibrating": {
-            "message": "calibrating\n"
-        },
-        "SettingsResetWarning": {
-            "message": "Ban chac chan muon khôi phuc tat ca cài đat ve mac đinh?"
-        },
-        "UVLOWarningString": {
-            "message": "DC thap"
-        },
-        "UndervoltageString": {
-            "message": "Đien áp thap\n"
-        },
-        "InputVoltageString": {
-            "message": "Đau vào V: \n"
-        },
-        "SleepingAdvancedString": {
-            "message": "Đang ngu...\n"
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Meo: \n"
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat\n"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown\n"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "Your device is most likely a counterfeit!"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to\nstart profile"
-        }
+  "languageCode": "VI",
+  "languageLocalName": "Tieng Viet",
+  "tempUnitFahrenheit": false,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Calibration\ndone!"
     },
-    "characters": {
-        "SettingRightChar": "R",
-        "SettingLeftChar": "L",
-        "SettingAutoChar": "A",
-        "SettingSlowChar": "S",
-        "SettingMediumChar": "M",
-        "SettingFastChar": "F",
-        "SettingStartSolderingChar": "S",
-        "SettingStartSleepChar": "Z",
-        "SettingStartSleepOffChar": "R",
-        "SettingLockBoostChar": "B",
-        "SettingLockFullChar": "F"
+    "ResetOKMessage": {
+      "message": "Reset OK"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "Cài đat\nnguon đien",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "Cài đat\ntay hàn",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "Che đo\nngu",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "Giao dien\nnguoi dùng",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "Cài đat\nnâng cao",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "Mot so cài đat\nđã thay đoi"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "Nguon\nđien",
-            "description": "Nguon đien, đat đien áp giam. (DC 10V) (S 3.3V moi cell, tat gioi han công suat)"
-        },
-        "MinVolCell": {
-            "displayText": "Voltage\ntoi thieu",
-            "description": "Đien áp toi thieu cho phép trên moi cell (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC\nvoltage",
-            "description": "Đien áp QC toi đa mà tay hàn yêu cau"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD\nsau",
-            "description": "Thoi gian cho đàm phán PD trong các buoc 100ms đe tuong thích voi mot so bo sac QC"
-        },
-        "PDVpdo": {
-            "displayText": "PD\nVPDO",
-            "description": "Enables PPS & EPR modes"
-        },
-        "BoostTemperature": {
-            "displayText": "Tăng\nnhiet đo",
-            "description": "Nhiet đo dùng trong che đo \"tăng cuong\""
-        },
-        "AutoStart": {
-            "displayText": "Nhiet đo\nđang tăng",
-            "description": "S=nhiet đo hàn | Z=cho o nhiet đo ngu đen khi cu đong | R=cho mà không gia nhiet đen khi cu đong"
-        },
-        "TempChangeShortStep": {
-            "displayText": "Thay đoi n.đo\nan nút nhanh",
-            "description": "Biên đo tăng/giam nhiet đo khi an nút nhanh"
-        },
-        "TempChangeLongStep": {
-            "displayText": "Thay đoi n.đo\nan nút lâu",
-            "description": "Biên đo tăng/giam nhiet đo khi an nút lâu"
-        },
-        "LockingMode": {
-            "displayText": "Cho phép khóa\ncác nút",
-            "description": "Trong khi hàn, giu ca 2 nút đe khóa (B=chi che đo tăng cuong | F=khóa hoàn toàn)"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile\nPhases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat\nTemp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat\nSpeed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1\nTemp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1\nDuration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2\nTemp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2\nDuration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3\nTemp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3\nDuration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4\nTemp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4\nDuration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5\nTemp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5\nDuration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown\nSpeed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "Cam bien\ncu đong",
-            "description": "1=đo nhay thap nhat| ... | 9=đo nhay cao nhat"
-        },
-        "SleepTemperature": {
-            "displayText": "Nhiet đo\nkhi ngu",
-            "description": "Giam nhiet đo khi o \"Che đo ngu\""
-        },
-        "SleepTimeout": {
-            "displayText": "Ngu\nsau",
-            "description": "thoi gian truoc khi \"Che đo ngu\" bat đau (s=giây | m=phút)"
-        },
-        "ShutdownTimeout": {
-            "displayText": "Tat\nsau",
-            "description": "khoang thoi gian truoc khi tay hàn tat (m=phút)"
-        },
-        "HallEffSensitivity": {
-            "displayText": "Hall\nđo nhay",
-            "description": "Đo nhay cam bien Hall đe phát hien che đo ngu (1=ít nhay nhat |...| 9=nhay nhat)"
-        },
-        "TemperatureUnit": {
-            "displayText": "Đon vi\nnhiet đo",
-            "description": "C= Đo C | F= Đo F"
-        },
-        "DisplayRotation": {
-            "displayText": "Huong\nhien thi",
-            "description": "R=huong tay phai | L=huong tay trái | A=tu đong"
-        },
-        "CooldownBlink": {
-            "displayText": "Nguoi đi\nchop mat",
-            "description": "Nhap nháy nhiet đo sau khi viec gia nhiet tam dung trong khi mui hàn van nóng"
-        },
-        "ScrollingSpeed": {
-            "displayText": "Toc đo\ncuon",
-            "description": "Toc đo cuon văn ban(S=cham | F=nhanh)"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "Đao nguoc\nnút + -",
-            "description": "Đao nguoc chuc năng các nút đieu chinh nhiet đo"
-        },
-        "AnimSpeed": {
-            "displayText": "Toc đo\nhoat anh",
-            "description": "Toc đo cua hoat anh menu (S=cham | M=trung bình | F=nhanh)"
-        },
-        "AnimLoop": {
-            "displayText": "Hoat anh\nlap lai",
-            "description": "Lap lai các hoat anh trong màn hình chính"
-        },
-        "Brightness": {
-            "displayText": "Đo tuong phan\nmàn hình",
-            "description": "Đieu chinh đo sáng màn hình OLED"
-        },
-        "ColourInversion": {
-            "displayText": "Đao nguoc màu\nmàn hình",
-            "description": "Đao nguoc màu màn hình OLED"
-        },
-        "LOGOTime": {
-            "displayText": "Boot logo\nduration",
-            "description": "Set boot logo duration (s=seconds)"
-        },
-        "AdvancedIdle": {
-            "displayText": "Chi tiet\nmàn hình cho",
-            "description": "hien thi thông tin chi tiet bang phông chu nho hon trên màn hình cho"
-        },
-        "AdvancedSoldering": {
-            "displayText": "Chi tiet\nmàn hình hàn",
-            "description": "Hien thi thông tin bang phông chu nho hon trên màn hình hàn"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth\n",
-            "description": "Enables BLE"
-        },
-        "PowerLimit": {
-            "displayText": "Công suat\ngioi han",
-            "description": "Công suat toi đa mà tay hàn có the su dung (W=watt)"
-        },
-        "CalibrateCJC": {
-            "displayText": "Calibrate CJC\nat next boot",
-            "description": "Calbrate Cold Junction Compensation at next boot (not required if Delta T is < 5°C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "Hieu chinh\nđien áp đau vào?",
-            "description": "bat đau hieu chuan VIN (nhan và giu đe thoát)"
-        },
-        "PowerPulsePower": {
-            "displayText": "Công suat\nkích nguon",
-            "description": "Cuong đo công suat kích nguon (watt)"
-        },
-        "PowerPulseWait": {
-            "displayText": "Trì hoãn\nđien áp kích",
-            "description": "Trì hoãn truoc khi kích hoat kích nguon(x 2,5 giây)"
-        },
-        "PowerPulseDuration": {
-            "displayText": "Thoi luong\nkích nguon",
-            "description": "thoi luong kích nguon (x 250ms)"
-        },
-        "SettingsReset": {
-            "displayText": "Khôi phuc\ncài đat goc?",
-            "description": "đat lai tat ca cài đat ve mac đinh"
-        },
-        "LanguageSwitch": {
-            "displayText": "Ngôn ngu:\n VI  Tieng Viet",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "Không phát hien\ngia toc ke!"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "Không phát hien\nUSB-PD IC!"
+    },
+    "LockingKeysString": {
+      "message": "Đã khóa"
+    },
+    "UnlockingKeysString": {
+      "message": "Mo khóa"
+    },
+    "WarningKeysLockedString": {
+      "message": "Đã khóa!"
+    },
+    "WarningThermalRunaway": {
+      "message": "Nhiet\nTat gia nhiet"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Before rebooting, make sure tip & handle are at room temperature!"
+    },
+    "CJCCalibrating": {
+      "message": "calibrating\n"
+    },
+    "SettingsResetWarning": {
+      "message": "Ban chac chan muon khôi phuc tat ca cài đat ve mac đinh?"
+    },
+    "UVLOWarningString": {
+      "message": "DC thap"
+    },
+    "UndervoltageString": {
+      "message": "Đien áp thap\n"
+    },
+    "InputVoltageString": {
+      "message": "Đau vào V: \n"
+    },
+    "SleepingAdvancedString": {
+      "message": "Đang ngu...\n"
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Meo: \n"
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat\n"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown\n"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "Your device is most likely a counterfeit!"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to\nstart profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "R",
+    "SettingLeftChar": "L",
+    "SettingAutoChar": "A",
+    "SettingSlowChar": "S",
+    "SettingMediumChar": "M",
+    "SettingFastChar": "F",
+    "SettingStartSolderingChar": "S",
+    "SettingStartSleepChar": "Z",
+    "SettingStartSleepOffChar": "R",
+    "SettingLockBoostChar": "B",
+    "SettingLockFullChar": "F"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "Cài đat\nnguon đien",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "Cài đat\ntay hàn",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "Che đo\nngu",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "Giao dien\nnguoi dùng",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "Cài đat\nnâng cao",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "Nguon\nđien",
+      "description": "Nguon đien, đat đien áp giam. (DC 10V) (S 3.3V moi cell, tat gioi han công suat)"
+    },
+    "MinVolCell": {
+      "displayText": "Voltage\ntoi thieu",
+      "description": "Đien áp toi thieu cho phép trên moi cell (3S: 3 - 3,7V | 4-6S: 2,4 - 3,7V)"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC\nvoltage",
+      "description": "Đien áp QC toi đa mà tay hàn yêu cau"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD\nsau",
+      "description": "Thoi gian cho đàm phán PD trong các buoc 100ms đe tuong thích voi mot so bo sac QC"
+    },
+    "USBPDMode": {
+      "displayText": "PD\nVPDO",
+      "description": "Enables PPS & EPR modes"
+    },
+    "BoostTemperature": {
+      "displayText": "Tăng\nnhiet đo",
+      "description": "Nhiet đo dùng trong che đo \"tăng cuong\""
+    },
+    "AutoStart": {
+      "displayText": "Nhiet đo\nđang tăng",
+      "description": "S=nhiet đo hàn | Z=cho o nhiet đo ngu đen khi cu đong | R=cho mà không gia nhiet đen khi cu đong"
+    },
+    "TempChangeShortStep": {
+      "displayText": "Thay đoi n.đo\nan nút nhanh",
+      "description": "Biên đo tăng/giam nhiet đo khi an nút nhanh"
+    },
+    "TempChangeLongStep": {
+      "displayText": "Thay đoi n.đo\nan nút lâu",
+      "description": "Biên đo tăng/giam nhiet đo khi an nút lâu"
+    },
+    "LockingMode": {
+      "displayText": "Cho phép khóa\ncác nút",
+      "description": "Trong khi hàn, giu ca 2 nút đe khóa (B=chi che đo tăng cuong | F=khóa hoàn toàn)"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile\nPhases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat\nTemp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat\nSpeed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1\nTemp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1\nDuration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2\nTemp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2\nDuration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3\nTemp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3\nDuration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4\nTemp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4\nDuration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5\nTemp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5\nDuration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown\nSpeed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "Cam bien\ncu đong",
+      "description": "1=đo nhay thap nhat| ... | 9=đo nhay cao nhat"
+    },
+    "SleepTemperature": {
+      "displayText": "Nhiet đo\nkhi ngu",
+      "description": "Giam nhiet đo khi o \"Che đo ngu\""
+    },
+    "SleepTimeout": {
+      "displayText": "Ngu\nsau",
+      "description": "thoi gian truoc khi \"Che đo ngu\" bat đau (s=giây | m=phút)"
+    },
+    "ShutdownTimeout": {
+      "displayText": "Tat\nsau",
+      "description": "khoang thoi gian truoc khi tay hàn tat (m=phút)"
+    },
+    "HallEffSensitivity": {
+      "displayText": "Hall\nđo nhay",
+      "description": "Đo nhay cam bien Hall đe phát hien che đo ngu (1=ít nhay nhat |...| 9=nhay nhat)"
+    },
+    "TemperatureUnit": {
+      "displayText": "Đon vi\nnhiet đo",
+      "description": "C= Đo C | F= Đo F"
+    },
+    "DisplayRotation": {
+      "displayText": "Huong\nhien thi",
+      "description": "R=huong tay phai | L=huong tay trái | A=tu đong"
+    },
+    "CooldownBlink": {
+      "displayText": "Nguoi đi\nchop mat",
+      "description": "Nhap nháy nhiet đo sau khi viec gia nhiet tam dung trong khi mui hàn van nóng"
+    },
+    "ScrollingSpeed": {
+      "displayText": "Toc đo\ncuon",
+      "description": "Toc đo cuon văn ban(S=cham | F=nhanh)"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "Đao nguoc\nnút + -",
+      "description": "Đao nguoc chuc năng các nút đieu chinh nhiet đo"
+    },
+    "AnimSpeed": {
+      "displayText": "Toc đo\nhoat anh",
+      "description": "Toc đo cua hoat anh menu (S=cham | M=trung bình | F=nhanh)"
+    },
+    "AnimLoop": {
+      "displayText": "Hoat anh\nlap lai",
+      "description": "Lap lai các hoat anh trong màn hình chính"
+    },
+    "Brightness": {
+      "displayText": "Đo tuong phan\nmàn hình",
+      "description": "Đieu chinh đo sáng màn hình OLED"
+    },
+    "ColourInversion": {
+      "displayText": "Đao nguoc màu\nmàn hình",
+      "description": "Đao nguoc màu màn hình OLED"
+    },
+    "LOGOTime": {
+      "displayText": "Boot logo\nduration",
+      "description": "Set boot logo duration (s=seconds)"
+    },
+    "AdvancedIdle": {
+      "displayText": "Chi tiet\nmàn hình cho",
+      "description": "hien thi thông tin chi tiet bang phông chu nho hon trên màn hình cho"
+    },
+    "AdvancedSoldering": {
+      "displayText": "Chi tiet\nmàn hình hàn",
+      "description": "Hien thi thông tin bang phông chu nho hon trên màn hình hàn"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth\n",
+      "description": "Enables BLE"
+    },
+    "PowerLimit": {
+      "displayText": "Công suat\ngioi han",
+      "description": "Công suat toi đa mà tay hàn có the su dung (W=watt)"
+    },
+    "CalibrateCJC": {
+      "displayText": "Calibrate CJC\nat next boot",
+      "description": "Calbrate Cold Junction Compensation at next boot (not required if Delta T is < 5°C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "Hieu chinh\nđien áp đau vào?",
+      "description": "bat đau hieu chuan VIN (nhan và giu đe thoát)"
+    },
+    "PowerPulsePower": {
+      "displayText": "Công suat\nkích nguon",
+      "description": "Cuong đo công suat kích nguon (watt)"
+    },
+    "PowerPulseWait": {
+      "displayText": "Trì hoãn\nđien áp kích",
+      "description": "Trì hoãn truoc khi kích hoat kích nguon(x 2,5 giây)"
+    },
+    "PowerPulseDuration": {
+      "displayText": "Thoi luong\nkích nguon",
+      "description": "thoi luong kích nguon (x 250ms)"
+    },
+    "SettingsReset": {
+      "displayText": "Khôi phuc\ncài đat goc?",
+      "description": "đat lai tat ca cài đat ve mac đinh"
+    },
+    "LanguageSwitch": {
+      "displayText": "Ngôn ngu:\n VI  Tieng Viet",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_YUE_HK.json
+++ b/Translations/translation_YUE_HK.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "電源",
@@ -124,7 +135,7 @@
     },
     "USBPDMode": {
       "displayText": "PD VPDO",
-      "description": "Enables PPS & EPR modes"
+      "description": "No Dynamic disables EPR & PPS, Safe mode does not use padding resistance"
     },
     "BoostTemperature": {
       "displayText": "增熱温度",

--- a/Translations/translation_YUE_HK.json
+++ b/Translations/translation_YUE_HK.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "YUE_HK",
-    "languageLocalName": "廣東話 (香港)",
-    "tempUnitFahrenheit": true,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "Calibration done!"
-        },
-        "ResetOKMessage": {
-            "message": "已重設！"
-        },
-        "SettingsResetMessage": {
-            "message": "設定已被重設！"
-        },
-        "NoAccelerometerMessage": {
-            "message": "未能偵測加速度計"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "未能偵測PD晶片"
-        },
-        "LockingKeysString": {
-            "message": "已鎖定"
-        },
-        "UnlockingKeysString": {
-            "message": "已解除鎖定"
-        },
-        "WarningKeysLockedString": {
-            "message": "!撳掣鎖定!"
-        },
-        "WarningThermalRunaway": {
-            "message": "加熱失控"
-        },
-        "WarningTipShorted": {
-            "message": "!Tip Shorted!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "Before rebooting, make sure tip & handle are at room temperature!"
-        },
-        "CJCCalibrating": {
-            "message": "calibrating"
-        },
-        "SettingsResetWarning": {
-            "message": "你係咪確定要將全部設定重設到預設值？"
-        },
-        "UVLOWarningString": {
-            "message": "電壓過低"
-        },
-        "UndervoltageString": {
-            "message": "Undervoltage"
-        },
-        "InputVoltageString": {
-            "message": "Input V: "
-        },
-        "SleepingAdvancedString": {
-            "message": "Sleeping..."
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Tip: "
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "依支焫雞好有可能係冒牌貨！"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to start profile"
-        }
+  "languageCode": "YUE_HK",
+  "languageLocalName": "廣東話 (香港)",
+  "tempUnitFahrenheit": true,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "Calibration done!"
     },
-    "characters": {
-        "SettingRightChar": "右",
-        "SettingLeftChar": "左",
-        "SettingAutoChar": "自",
-        "SettingSlowChar": "慢",
-        "SettingMediumChar": "中",
-        "SettingFastChar": "快",
-        "SettingStartSolderingChar": "焊",
-        "SettingStartSleepChar": "待",
-        "SettingStartSleepOffChar": "室",
-        "SettingLockBoostChar": "增",
-        "SettingLockFullChar": "全"
+    "ResetOKMessage": {
+      "message": "已重設！"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "電源設定",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "焊接設定",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "待機設定",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "使用者介面",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "進階設定",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "設定已被重設！"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "電源",
-            "description": "輸入電源；設定自動停機電壓 <DC 10V> <S 鋰電池，以每粒3.3V計算；依個設定會停用功率限制>"
-        },
-        "MinVolCell": {
-            "displayText": "最低電壓",
-            "description": "每粒電池嘅最低可用電壓 <伏特> <3S: 3.0V - 3.7V, 4/5/6S: 2.4V - 3.7V>"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC電壓",
-            "description": "使用QC電源時請求嘅最高目標電壓"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD逾時",
-            "description": "設定USB PD協定交涉嘅逾時時限；為兼容某啲QC電源而設 <x100ms（亳秒）>"
-        },
-        "PDVpdo": {
-            "displayText": "PD VPDO",
-            "description": "Enables PPS & EPR modes"
-        },
-        "BoostTemperature": {
-            "displayText": "增熱温度",
-            "description": "喺增熱模式時使用嘅温度"
-        },
-        "AutoStart": {
-            "displayText": "自動啓用",
-            "description": "開機時自動啓用 <焊=焊接模式 | 待=待機模式 | 室=室温待機>"
-        },
-        "TempChangeShortStep": {
-            "displayText": "温度調整 短",
-            "description": "調校温度時短撳一下嘅温度變幅"
-        },
-        "TempChangeLongStep": {
-            "displayText": "温度調整 長",
-            "description": "調校温度時長撳嘅温度變幅"
-        },
-        "LockingMode": {
-            "displayText": "撳掣鎖定",
-            "description": "喺焊接模式時，同時長撳兩粒掣啓用撳掣鎖定 <增=淨係容許增熱模式 | 全=鎖定全部>"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile Phases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat Temp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat Speed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1 Temp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1 Duration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2 Temp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2 Duration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3 Temp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3 Duration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4 Temp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4 Duration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5 Temp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5 Duration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown Speed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "動作敏感度",
-            "description": "1=最低敏感度 | ... | 9=最高敏感度"
-        },
-        "SleepTemperature": {
-            "displayText": "待機温度",
-            "description": "喺待機模式時嘅焫雞咀温度"
-        },
-        "SleepTimeout": {
-            "displayText": "待機延時",
-            "description": "自動進入待機模式前嘅閒置等候時間 <s=秒 | m=分鐘>"
-        },
-        "ShutdownTimeout": {
-            "displayText": "自動熄機",
-            "description": "自動熄機前嘅閒置等候時間 <m=分鐘>"
-        },
-        "HallEffSensitivity": {
-            "displayText": "磁場敏感度",
-            "description": "磁場感應器用嚟啓動待機模式嘅敏感度 <1=最低敏感度 | ... | 9=最高敏感度>"
-        },
-        "TemperatureUnit": {
-            "displayText": "温度單位",
-            "description": "C=攝氏 | F=華氏"
-        },
-        "DisplayRotation": {
-            "displayText": "畫面方向",
-            "description": "右=使用右手 | 左=使用左手 | 自=自動"
-        },
-        "CooldownBlink": {
-            "displayText": "降温時閃爍",
-            "description": "停止加熱之後，當焫雞咀仲係熱嗰陣閃爍畫面"
-        },
-        "ScrollingSpeed": {
-            "displayText": "捲動速度",
-            "description": "解說文字嘅捲動速度"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "反轉加減掣",
-            "description": "反轉調校温度時加減掣嘅方向"
-        },
-        "AnimSpeed": {
-            "displayText": "動畫速度",
-            "description": "功能表圖示動畫嘅速度 <慢=慢速 | 中=中速 | 快=快速>"
-        },
-        "AnimLoop": {
-            "displayText": "動畫循環",
-            "description": "循環顯示功能表圖示動畫"
-        },
-        "Brightness": {
-            "displayText": "熒幕亮度",
-            "description": "設定OLED熒幕嘅亮度"
-        },
-        "ColourInversion": {
-            "displayText": "熒幕反轉色",
-            "description": "反轉OLED熒幕嘅黑白色"
-        },
-        "LOGOTime": {
-            "displayText": "開機畫面",
-            "description": "設定開機畫面顯示時長 <s=秒>"
-        },
-        "AdvancedIdle": {
-            "displayText": "詳細閒置畫面",
-            "description": "喺閒置畫面以英文細字顯示詳細嘅資料"
-        },
-        "AdvancedSoldering": {
-            "displayText": "詳細焊接畫面",
-            "description": "喺焊接模式畫面以英文細字顯示詳細嘅資料"
-        },
-        "BluetoothLE": {
-            "displayText": "Bluetooth",
-            "description": "Enables BLE"
-        },
-        "PowerLimit": {
-            "displayText": "功率限制",
-            "description": "限制焫雞可用嘅最大功率 <W=watt（火）>"
-        },
-        "CalibrateCJC": {
-            "displayText": "校正CJC",
-            "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5 C)"
-        },
-        "VoltageCalibration": {
-            "displayText": "輸入電壓校正？",
-            "description": "開始校正VIN輸入電壓 <長撳以退出>"
-        },
-        "PowerPulsePower": {
-            "displayText": "電源脈衝",
-            "description": "為保持電源喚醒而通電所用嘅功率 <watt（火）>"
-        },
-        "PowerPulseWait": {
-            "displayText": "電源脈衝間隔",
-            "description": "為保持電源喚醒，每次通電之間嘅間隔時間 <x2.5s（秒）>"
-        },
-        "PowerPulseDuration": {
-            "displayText": "電源脈衝時長",
-            "description": "為保持電源喚醒，每次通電脈衝嘅時間長度 <x250ms（亳秒）>"
-        },
-        "SettingsReset": {
-            "displayText": "全部重設？",
-            "description": "將所有設定重設到預設值"
-        },
-        "LanguageSwitch": {
-            "displayText": "語言： 廣東話",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "未能偵測加速度計"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "未能偵測PD晶片"
+    },
+    "LockingKeysString": {
+      "message": "已鎖定"
+    },
+    "UnlockingKeysString": {
+      "message": "已解除鎖定"
+    },
+    "WarningKeysLockedString": {
+      "message": "!撳掣鎖定!"
+    },
+    "WarningThermalRunaway": {
+      "message": "加熱失控"
+    },
+    "WarningTipShorted": {
+      "message": "!Tip Shorted!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "Before rebooting, make sure tip & handle are at room temperature!"
+    },
+    "CJCCalibrating": {
+      "message": "calibrating"
+    },
+    "SettingsResetWarning": {
+      "message": "你係咪確定要將全部設定重設到預設值？"
+    },
+    "UVLOWarningString": {
+      "message": "電壓過低"
+    },
+    "UndervoltageString": {
+      "message": "Undervoltage"
+    },
+    "InputVoltageString": {
+      "message": "Input V: "
+    },
+    "SleepingAdvancedString": {
+      "message": "Sleeping..."
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Tip: "
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "依支焫雞好有可能係冒牌貨！"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to start profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "右",
+    "SettingLeftChar": "左",
+    "SettingAutoChar": "自",
+    "SettingSlowChar": "慢",
+    "SettingMediumChar": "中",
+    "SettingFastChar": "快",
+    "SettingStartSolderingChar": "焊",
+    "SettingStartSleepChar": "待",
+    "SettingStartSleepOffChar": "室",
+    "SettingLockBoostChar": "增",
+    "SettingLockFullChar": "全"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "電源設定",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "焊接設定",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "待機設定",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "使用者介面",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "進階設定",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "電源",
+      "description": "輸入電源；設定自動停機電壓 <DC 10V> <S 鋰電池，以每粒3.3V計算；依個設定會停用功率限制>"
+    },
+    "MinVolCell": {
+      "displayText": "最低電壓",
+      "description": "每粒電池嘅最低可用電壓 <伏特> <3S: 3.0V - 3.7V, 4/5/6S: 2.4V - 3.7V>"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC電壓",
+      "description": "使用QC電源時請求嘅最高目標電壓"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD逾時",
+      "description": "設定USB PD協定交涉嘅逾時時限；為兼容某啲QC電源而設 <x100ms（亳秒）>"
+    },
+    "USBPDMode": {
+      "displayText": "PD VPDO",
+      "description": "Enables PPS & EPR modes"
+    },
+    "BoostTemperature": {
+      "displayText": "增熱温度",
+      "description": "喺增熱模式時使用嘅温度"
+    },
+    "AutoStart": {
+      "displayText": "自動啓用",
+      "description": "開機時自動啓用 <焊=焊接模式 | 待=待機模式 | 室=室温待機>"
+    },
+    "TempChangeShortStep": {
+      "displayText": "温度調整 短",
+      "description": "調校温度時短撳一下嘅温度變幅"
+    },
+    "TempChangeLongStep": {
+      "displayText": "温度調整 長",
+      "description": "調校温度時長撳嘅温度變幅"
+    },
+    "LockingMode": {
+      "displayText": "撳掣鎖定",
+      "description": "喺焊接模式時，同時長撳兩粒掣啓用撳掣鎖定 <增=淨係容許增熱模式 | 全=鎖定全部>"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile Phases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat Temp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat Speed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1 Temp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1 Duration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2 Temp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2 Duration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3 Temp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3 Duration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4 Temp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4 Duration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5 Temp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5 Duration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown Speed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "動作敏感度",
+      "description": "1=最低敏感度 | ... | 9=最高敏感度"
+    },
+    "SleepTemperature": {
+      "displayText": "待機温度",
+      "description": "喺待機模式時嘅焫雞咀温度"
+    },
+    "SleepTimeout": {
+      "displayText": "待機延時",
+      "description": "自動進入待機模式前嘅閒置等候時間 <s=秒 | m=分鐘>"
+    },
+    "ShutdownTimeout": {
+      "displayText": "自動熄機",
+      "description": "自動熄機前嘅閒置等候時間 <m=分鐘>"
+    },
+    "HallEffSensitivity": {
+      "displayText": "磁場敏感度",
+      "description": "磁場感應器用嚟啓動待機模式嘅敏感度 <1=最低敏感度 | ... | 9=最高敏感度>"
+    },
+    "TemperatureUnit": {
+      "displayText": "温度單位",
+      "description": "C=攝氏 | F=華氏"
+    },
+    "DisplayRotation": {
+      "displayText": "畫面方向",
+      "description": "右=使用右手 | 左=使用左手 | 自=自動"
+    },
+    "CooldownBlink": {
+      "displayText": "降温時閃爍",
+      "description": "停止加熱之後，當焫雞咀仲係熱嗰陣閃爍畫面"
+    },
+    "ScrollingSpeed": {
+      "displayText": "捲動速度",
+      "description": "解說文字嘅捲動速度"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "反轉加減掣",
+      "description": "反轉調校温度時加減掣嘅方向"
+    },
+    "AnimSpeed": {
+      "displayText": "動畫速度",
+      "description": "功能表圖示動畫嘅速度 <慢=慢速 | 中=中速 | 快=快速>"
+    },
+    "AnimLoop": {
+      "displayText": "動畫循環",
+      "description": "循環顯示功能表圖示動畫"
+    },
+    "Brightness": {
+      "displayText": "熒幕亮度",
+      "description": "設定OLED熒幕嘅亮度"
+    },
+    "ColourInversion": {
+      "displayText": "熒幕反轉色",
+      "description": "反轉OLED熒幕嘅黑白色"
+    },
+    "LOGOTime": {
+      "displayText": "開機畫面",
+      "description": "設定開機畫面顯示時長 <s=秒>"
+    },
+    "AdvancedIdle": {
+      "displayText": "詳細閒置畫面",
+      "description": "喺閒置畫面以英文細字顯示詳細嘅資料"
+    },
+    "AdvancedSoldering": {
+      "displayText": "詳細焊接畫面",
+      "description": "喺焊接模式畫面以英文細字顯示詳細嘅資料"
+    },
+    "BluetoothLE": {
+      "displayText": "Bluetooth",
+      "description": "Enables BLE"
+    },
+    "PowerLimit": {
+      "displayText": "功率限制",
+      "description": "限制焫雞可用嘅最大功率 <W=watt（火）>"
+    },
+    "CalibrateCJC": {
+      "displayText": "校正CJC",
+      "description": "At next boot tip Cold Junction Compensation will be calibrated (not required if Delta T is < 5 C)"
+    },
+    "VoltageCalibration": {
+      "displayText": "輸入電壓校正？",
+      "description": "開始校正VIN輸入電壓 <長撳以退出>"
+    },
+    "PowerPulsePower": {
+      "displayText": "電源脈衝",
+      "description": "為保持電源喚醒而通電所用嘅功率 <watt（火）>"
+    },
+    "PowerPulseWait": {
+      "displayText": "電源脈衝間隔",
+      "description": "為保持電源喚醒，每次通電之間嘅間隔時間 <x2.5s（秒）>"
+    },
+    "PowerPulseDuration": {
+      "displayText": "電源脈衝時長",
+      "description": "為保持電源喚醒，每次通電脈衝嘅時間長度 <x250ms（亳秒）>"
+    },
+    "SettingsReset": {
+      "displayText": "全部重設？",
+      "description": "將所有設定重設到預設值"
+    },
+    "LanguageSwitch": {
+      "displayText": "語言： 廣東話",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_ZH_CN.json
+++ b/Translations/translation_ZH_CN.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "ZH_CN",
-    "languageLocalName": "简体中文",
-    "tempUnitFahrenheit": true,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "校正完成！"
-        },
-        "ResetOKMessage": {
-            "message": "已重置！"
-        },
-        "SettingsResetMessage": {
-            "message": "设定已被重置！"
-        },
-        "NoAccelerometerMessage": {
-            "message": "未检测到加速度计"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "未检测到PD电路"
-        },
-        "LockingKeysString": {
-            "message": "已锁定"
-        },
-        "UnlockingKeysString": {
-            "message": "已解锁"
-        },
-        "WarningKeysLockedString": {
-            "message": "!按键锁定!"
-        },
-        "WarningThermalRunaway": {
-            "message": "加热失控"
-        },
-        "WarningTipShorted": {
-            "message": "!烙铁头短路!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "在重启前请确认烙铁头及本体已完全冷却！"
-        },
-        "CJCCalibrating": {
-            "message": "校正中"
-        },
-        "SettingsResetWarning": {
-            "message": "你是否确定要将全部设定重置为默认值？"
-        },
-        "UVLOWarningString": {
-            "message": "电压过低"
-        },
-        "UndervoltageString": {
-            "message": "Undervoltage"
-        },
-        "InputVoltageString": {
-            "message": "VIN: "
-        },
-        "SleepingAdvancedString": {
-            "message": "Zzzz..."
-        },
-        "SleepingTipAdvancedString": {
-            "message": "<--- "
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "这支电烙铁很有可能是冒牌货！"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to start profile"
-        }
+  "languageCode": "ZH_CN",
+  "languageLocalName": "简体中文",
+  "tempUnitFahrenheit": true,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "校正完成！"
     },
-    "characters": {
-        "SettingRightChar": "右",
-        "SettingLeftChar": "左",
-        "SettingAutoChar": "自",
-        "SettingSlowChar": "慢",
-        "SettingMediumChar": "中",
-        "SettingFastChar": "快",
-        "SettingStartSolderingChar": "焊",
-        "SettingStartSleepChar": "待",
-        "SettingStartSleepOffChar": "室",
-        "SettingLockBoostChar": "增",
-        "SettingLockFullChar": "全"
+    "ResetOKMessage": {
+      "message": "已重置！"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "电源设置",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "焊接设置",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "待机设置",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "用户界面",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "高级设置",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "设定已被重置！"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "下限电压",
-            "description": "设置自动停机电压 <DC=10V | S=（串）每节锂电池3.3V；此设置会禁用功率限制>"
-        },
-        "MinVolCell": {
-            "displayText": "最低电压",
-            "description": "每节电池的最低允许电压 <V（伏特）> <3S: 3.0V - 3.7V, 4/5/6S: 2.4V - 3.7V>"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC电压",
-            "description": "使用QC电源时请求的最高目标电压"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD超时",
-            "description": "设定USB-PD协议交涉的超时时限；为兼容某些QC电源而设 <x100ms（亳秒）>"
-        },
-        "PDVpdo": {
-            "displayText": "PD VPDO",
-            "description": "启用PPS和EPR快充支持"
-        },
-        "BoostTemperature": {
-            "displayText": "增热温度",
-            "description": "增热模式时使用的温度"
-        },
-        "AutoStart": {
-            "displayText": "自动启动",
-            "description": "开机时自动启动 <焊=焊接模式 | 待=待机模式 | 室=室温待机>"
-        },
-        "TempChangeShortStep": {
-            "displayText": "短按温度调整",
-            "description": "调校温度时短按按键的温度变幅"
-        },
-        "TempChangeLongStep": {
-            "displayText": "长按温度调整",
-            "description": "调校温度时长按按键的温度变幅"
-        },
-        "LockingMode": {
-            "displayText": "按键锁定",
-            "description": "焊接模式时，同时长按两个按键启用按键锁定 <增=只容许增热模式 | 全=完全锁定>"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile Phases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat Temp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat Speed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1 Temp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1 Duration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2 Temp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2 Duration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3 Temp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3 Duration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4 Temp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4 Duration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5 Temp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5 Duration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown Speed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "动作灵敏度",
-            "description": "1=最低灵敏度 | ... | 9=最高灵敏度"
-        },
-        "SleepTemperature": {
-            "displayText": "待机温度",
-            "description": "待机模式时的烙铁头温度"
-        },
-        "SleepTimeout": {
-            "displayText": "待机超时",
-            "description": "自动进入待机模式前的等候时间 <s=秒 | m=分钟>"
-        },
-        "ShutdownTimeout": {
-            "displayText": "自动关机",
-            "description": "自动关机前的等候时间 <m=分钟>"
-        },
-        "HallEffSensitivity": {
-            "displayText": "磁场灵敏度",
-            "description": "霍尔效应传感器用作启动待机模式的灵敏度 <1=最低灵敏度 | ... | 9=最高灵敏度>"
-        },
-        "TemperatureUnit": {
-            "displayText": "温度单位",
-            "description": "C=摄氏 | F=华氏"
-        },
-        "DisplayRotation": {
-            "displayText": "显示方向",
-            "description": "右=右手 | 左=左手 | 自=自动"
-        },
-        "CooldownBlink": {
-            "displayText": "降温时闪显",
-            "description": "停止加热之后，闪动温度显示提醒烙铁头仍处于高温状态"
-        },
-        "ScrollingSpeed": {
-            "displayText": "滚动速度",
-            "description": "解说文字的滚动速度"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "调换加减键",
-            "description": "调校温度时更换加减键的方向"
-        },
-        "AnimSpeed": {
-            "displayText": "动画速度",
-            "description": "主菜单中功能图标动画的播放速度 <慢=慢速 | 中=中速 | 快=快速>"
-        },
-        "AnimLoop": {
-            "displayText": "动画循环",
-            "description": "主菜单中循环播放功能图标动画"
-        },
-        "Brightness": {
-            "displayText": "屏幕亮度",
-            "description": "调整OLED屏幕的亮度"
-        },
-        "ColourInversion": {
-            "displayText": "反转屏幕颜色",
-            "description": "反转OLED黑/白屏幕"
-        },
-        "LOGOTime": {
-            "displayText": "开机画面",
-            "description": "设定开机画面显示时长 <s=秒>"
-        },
-        "AdvancedIdle": {
-            "displayText": "闲置画面详情",
-            "description": "闲置画面以英语小字体显示详情"
-        },
-        "AdvancedSoldering": {
-            "displayText": "焊接画面详情",
-            "description": "焊接模式画面以英语小字体显示详请"
-        },
-        "BluetoothLE": {
-            "displayText": "蓝牙",
-            "description": "启用蓝牙支持"
-        },
-        "PowerLimit": {
-            "displayText": "功率限制",
-            "description": "限制烙铁可用的最大功率 <W=瓦特>"
-        },
-        "CalibrateCJC": {
-            "displayText": "校正CJC",
-            "description": "在下次重启时校正烙铁头热电偶冷接点补偿值（CJC）（温差小于5摄氏度时无需校正）"
-        },
-        "VoltageCalibration": {
-            "displayText": "输入电压校正？",
-            "description": "开始校正输入电压（VIN）<长按以退出>"
-        },
-        "PowerPulsePower": {
-            "displayText": "电源脉冲",
-            "description": "为保持电源处于唤醒状态所用的功率 <Watt（瓦特）>"
-        },
-        "PowerPulseWait": {
-            "displayText": "电源脉冲间隔",
-            "description": "为保持电源处于唤醒状态，每次通电之间的间隔时间 <x2.5s（秒）>"
-        },
-        "PowerPulseDuration": {
-            "displayText": "电源脉冲时长",
-            "description": "为保持电源处于唤醒状态，每次通电脉冲的时间长度 <x250ms（亳秒）>"
-        },
-        "SettingsReset": {
-            "displayText": "全部重置？",
-            "description": "将所有设定重置为默认值"
-        },
-        "LanguageSwitch": {
-            "displayText": "语言：简体中文",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "未检测到加速度计"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "未检测到PD电路"
+    },
+    "LockingKeysString": {
+      "message": "已锁定"
+    },
+    "UnlockingKeysString": {
+      "message": "已解锁"
+    },
+    "WarningKeysLockedString": {
+      "message": "!按键锁定!"
+    },
+    "WarningThermalRunaway": {
+      "message": "加热失控"
+    },
+    "WarningTipShorted": {
+      "message": "!烙铁头短路!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "在重启前请确认烙铁头及本体已完全冷却！"
+    },
+    "CJCCalibrating": {
+      "message": "校正中"
+    },
+    "SettingsResetWarning": {
+      "message": "你是否确定要将全部设定重置为默认值？"
+    },
+    "UVLOWarningString": {
+      "message": "电压过低"
+    },
+    "UndervoltageString": {
+      "message": "Undervoltage"
+    },
+    "InputVoltageString": {
+      "message": "VIN: "
+    },
+    "SleepingAdvancedString": {
+      "message": "Zzzz..."
+    },
+    "SleepingTipAdvancedString": {
+      "message": "<--- "
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "这支电烙铁很有可能是冒牌货！"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to start profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "右",
+    "SettingLeftChar": "左",
+    "SettingAutoChar": "自",
+    "SettingSlowChar": "慢",
+    "SettingMediumChar": "中",
+    "SettingFastChar": "快",
+    "SettingStartSolderingChar": "焊",
+    "SettingStartSleepChar": "待",
+    "SettingStartSleepOffChar": "室",
+    "SettingLockBoostChar": "增",
+    "SettingLockFullChar": "全"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "电源设置",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "焊接设置",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "待机设置",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "用户界面",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "高级设置",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "下限电压",
+      "description": "设置自动停机电压 <DC=10V | S=（串）每节锂电池3.3V；此设置会禁用功率限制>"
+    },
+    "MinVolCell": {
+      "displayText": "最低电压",
+      "description": "每节电池的最低允许电压 <V（伏特）> <3S: 3.0V - 3.7V, 4/5/6S: 2.4V - 3.7V>"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC电压",
+      "description": "使用QC电源时请求的最高目标电压"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD超时",
+      "description": "设定USB-PD协议交涉的超时时限；为兼容某些QC电源而设 <x100ms（亳秒）>"
+    },
+    "USBPDMode": {
+      "displayText": "PD VPDO",
+      "description": "启用PPS和EPR快充支持"
+    },
+    "BoostTemperature": {
+      "displayText": "增热温度",
+      "description": "增热模式时使用的温度"
+    },
+    "AutoStart": {
+      "displayText": "自动启动",
+      "description": "开机时自动启动 <焊=焊接模式 | 待=待机模式 | 室=室温待机>"
+    },
+    "TempChangeShortStep": {
+      "displayText": "短按温度调整",
+      "description": "调校温度时短按按键的温度变幅"
+    },
+    "TempChangeLongStep": {
+      "displayText": "长按温度调整",
+      "description": "调校温度时长按按键的温度变幅"
+    },
+    "LockingMode": {
+      "displayText": "按键锁定",
+      "description": "焊接模式时，同时长按两个按键启用按键锁定 <增=只容许增热模式 | 全=完全锁定>"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile Phases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat Temp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat Speed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1 Temp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1 Duration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2 Temp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2 Duration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3 Temp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3 Duration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4 Temp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4 Duration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5 Temp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5 Duration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown Speed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "动作灵敏度",
+      "description": "1=最低灵敏度 | ... | 9=最高灵敏度"
+    },
+    "SleepTemperature": {
+      "displayText": "待机温度",
+      "description": "待机模式时的烙铁头温度"
+    },
+    "SleepTimeout": {
+      "displayText": "待机超时",
+      "description": "自动进入待机模式前的等候时间 <s=秒 | m=分钟>"
+    },
+    "ShutdownTimeout": {
+      "displayText": "自动关机",
+      "description": "自动关机前的等候时间 <m=分钟>"
+    },
+    "HallEffSensitivity": {
+      "displayText": "磁场灵敏度",
+      "description": "霍尔效应传感器用作启动待机模式的灵敏度 <1=最低灵敏度 | ... | 9=最高灵敏度>"
+    },
+    "TemperatureUnit": {
+      "displayText": "温度单位",
+      "description": "C=摄氏 | F=华氏"
+    },
+    "DisplayRotation": {
+      "displayText": "显示方向",
+      "description": "右=右手 | 左=左手 | 自=自动"
+    },
+    "CooldownBlink": {
+      "displayText": "降温时闪显",
+      "description": "停止加热之后，闪动温度显示提醒烙铁头仍处于高温状态"
+    },
+    "ScrollingSpeed": {
+      "displayText": "滚动速度",
+      "description": "解说文字的滚动速度"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "调换加减键",
+      "description": "调校温度时更换加减键的方向"
+    },
+    "AnimSpeed": {
+      "displayText": "动画速度",
+      "description": "主菜单中功能图标动画的播放速度 <慢=慢速 | 中=中速 | 快=快速>"
+    },
+    "AnimLoop": {
+      "displayText": "动画循环",
+      "description": "主菜单中循环播放功能图标动画"
+    },
+    "Brightness": {
+      "displayText": "屏幕亮度",
+      "description": "调整OLED屏幕的亮度"
+    },
+    "ColourInversion": {
+      "displayText": "反转屏幕颜色",
+      "description": "反转OLED黑/白屏幕"
+    },
+    "LOGOTime": {
+      "displayText": "开机画面",
+      "description": "设定开机画面显示时长 <s=秒>"
+    },
+    "AdvancedIdle": {
+      "displayText": "闲置画面详情",
+      "description": "闲置画面以英语小字体显示详情"
+    },
+    "AdvancedSoldering": {
+      "displayText": "焊接画面详情",
+      "description": "焊接模式画面以英语小字体显示详请"
+    },
+    "BluetoothLE": {
+      "displayText": "蓝牙",
+      "description": "启用蓝牙支持"
+    },
+    "PowerLimit": {
+      "displayText": "功率限制",
+      "description": "限制烙铁可用的最大功率 <W=瓦特>"
+    },
+    "CalibrateCJC": {
+      "displayText": "校正CJC",
+      "description": "在下次重启时校正烙铁头热电偶冷接点补偿值（CJC）（温差小于5摄氏度时无需校正）"
+    },
+    "VoltageCalibration": {
+      "displayText": "输入电压校正？",
+      "description": "开始校正输入电压（VIN）<长按以退出>"
+    },
+    "PowerPulsePower": {
+      "displayText": "电源脉冲",
+      "description": "为保持电源处于唤醒状态所用的功率 <Watt（瓦特）>"
+    },
+    "PowerPulseWait": {
+      "displayText": "电源脉冲间隔",
+      "description": "为保持电源处于唤醒状态，每次通电之间的间隔时间 <x2.5s（秒）>"
+    },
+    "PowerPulseDuration": {
+      "displayText": "电源脉冲时长",
+      "description": "为保持电源处于唤醒状态，每次通电脉冲的时间长度 <x250ms（亳秒）>"
+    },
+    "SettingsReset": {
+      "displayText": "全部重置？",
+      "description": "将所有设定重置为默认值"
+    },
+    "LanguageSwitch": {
+      "displayText": "语言：简体中文",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translation_ZH_CN.json
+++ b/Translations/translation_ZH_CN.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "下限电压",

--- a/Translations/translation_ZH_TW.json
+++ b/Translations/translation_ZH_TW.json
@@ -105,6 +105,17 @@
       "description": ""
     }
   },
+  "menuValues": {
+    "USBPDModeDefault": {
+      "displayText": "Default\nMode"
+    },
+    "USBPDModeNoDynamic": {
+      "displayText": "No\nDynamic"
+    },
+    "USBPDModeSafe": {
+      "displayText": "Safe\nMode"
+    }
+  },
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "電源",

--- a/Translations/translation_ZH_TW.json
+++ b/Translations/translation_ZH_TW.json
@@ -1,310 +1,310 @@
 {
-    "languageCode": "ZH_TW",
-    "languageLocalName": "正體中文",
-    "tempUnitFahrenheit": true,
-    "messagesWarn": {
-        "CalibrationDone": {
-            "message": "校正完成！"
-        },
-        "ResetOKMessage": {
-            "message": "已重設！"
-        },
-        "SettingsResetMessage": {
-            "message": "設定已被重設！"
-        },
-        "NoAccelerometerMessage": {
-            "message": "未能偵測加速度計"
-        },
-        "NoPowerDeliveryMessage": {
-            "message": "未能偵測PD晶片"
-        },
-        "LockingKeysString": {
-            "message": "已鎖定"
-        },
-        "UnlockingKeysString": {
-            "message": "已解除鎖定"
-        },
-        "WarningKeysLockedString": {
-            "message": "!按鍵鎖定!"
-        },
-        "WarningThermalRunaway": {
-            "message": "加熱失控"
-        },
-        "WarningTipShorted": {
-            "message": "!烙鐵頭短路!"
-        },
-        "SettingsCalibrationWarning": {
-            "message": "在重啟前請確認烙鐵頭及本體已完全冷卻！"
-        },
-        "CJCCalibrating": {
-            "message": "校正中"
-        },
-        "SettingsResetWarning": {
-            "message": "你是否確定要將全部設定重設到預設值？"
-        },
-        "UVLOWarningString": {
-            "message": "電壓過低"
-        },
-        "UndervoltageString": {
-            "message": "Undervoltage"
-        },
-        "InputVoltageString": {
-            "message": "Input V: "
-        },
-        "SleepingAdvancedString": {
-            "message": "Sleeping..."
-        },
-        "SleepingTipAdvancedString": {
-            "message": "Tip: "
-        },
-        "ProfilePreheatString": {
-            "message": "Preheat"
-        },
-        "ProfileCooldownString": {
-            "message": "Cooldown"
-        },
-        "DeviceFailedValidationWarning": {
-            "message": "這支電烙鐵很有可能是冒牌貨！"
-        },
-        "TooHotToStartProfileWarning": {
-            "message": "Too hot to start profile"
-        }
+  "languageCode": "ZH_TW",
+  "languageLocalName": "正體中文",
+  "tempUnitFahrenheit": true,
+  "messagesWarn": {
+    "CalibrationDone": {
+      "message": "校正完成！"
     },
-    "characters": {
-        "SettingRightChar": "右",
-        "SettingLeftChar": "左",
-        "SettingAutoChar": "自",
-        "SettingSlowChar": "慢",
-        "SettingMediumChar": "中",
-        "SettingFastChar": "快",
-        "SettingStartSolderingChar": "焊",
-        "SettingStartSleepChar": "待",
-        "SettingStartSleepOffChar": "室",
-        "SettingLockBoostChar": "增",
-        "SettingLockFullChar": "全"
+    "ResetOKMessage": {
+      "message": "已重設！"
     },
-    "menuGroups": {
-        "PowerMenu": {
-            "displayText": "電源設定",
-            "description": ""
-        },
-        "SolderingMenu": {
-            "displayText": "焊接設定",
-            "description": ""
-        },
-        "PowerSavingMenu": {
-            "displayText": "待機設定",
-            "description": ""
-        },
-        "UIMenu": {
-            "displayText": "使用者介面",
-            "description": ""
-        },
-        "AdvancedMenu": {
-            "displayText": "進階設定",
-            "description": ""
-        }
+    "SettingsResetMessage": {
+      "message": "設定已被重設！"
     },
-    "menuOptions": {
-        "DCInCutoff": {
-            "displayText": "電源",
-            "description": "輸入電源；設定自動停機電壓 <DC 10V> <S 鋰電池，以每顆3.3V計算；此設定會停用功率限制>"
-        },
-        "MinVolCell": {
-            "displayText": "最低電壓",
-            "description": "每顆電池的最低可用電壓 <伏特> <3S: 3.0V - 3.7V, 4/5/6S: 2.4V - 3.7V>"
-        },
-        "QCMaxVoltage": {
-            "displayText": "QC電壓",
-            "description": "使用QC電源時請求的最高目標電壓"
-        },
-        "PDNegTimeout": {
-            "displayText": "PD逾時",
-            "description": "設定USB PD協定交涉的逾時時限；為兼容某些QC電源而設 <x100ms（亳秒）>"
-        },
-        "PDVpdo": {
-            "displayText": "PD VPDO",
-            "description": "開啟PPS及EPR支援"
-        },
-        "BoostTemperature": {
-            "displayText": "增熱溫度",
-            "description": "於增熱模式時使用的溫度"
-        },
-        "AutoStart": {
-            "displayText": "自動啟用",
-            "description": "開機時自動啟用 <焊=焊接模式 | 待=待機模式 | 室=室溫待機>"
-        },
-        "TempChangeShortStep": {
-            "displayText": "溫度調整 短",
-            "description": "調校溫度時短按一下的溫度變幅"
-        },
-        "TempChangeLongStep": {
-            "displayText": "溫度調整 長",
-            "description": "調校溫度時長按按鍵的溫度變幅"
-        },
-        "LockingMode": {
-            "displayText": "按鍵鎖定",
-            "description": "於焊接模式時，同時長按兩個按鍵啟用按鍵鎖定 <增=只容許增熱模式 | 全=鎖定全部>"
-        },
-        "ProfilePhases": {
-            "displayText": "Profile Phases",
-            "description": "Number of phases in profile mode"
-        },
-        "ProfilePreheatTemp": {
-            "displayText": "Preheat Temp",
-            "description": "Preheat to this temperature at the start of profile mode"
-        },
-        "ProfilePreheatSpeed": {
-            "displayText": "Preheat Speed",
-            "description": "Preheat at this rate (degrees per second)"
-        },
-        "ProfilePhase1Temp": {
-            "displayText": "Phase 1 Temp",
-            "description": "Target temperature for the end of this phase"
-        },
-        "ProfilePhase1Duration": {
-            "displayText": "Phase 1 Duration",
-            "description": "Target duration of this phase (seconds)"
-        },
-        "ProfilePhase2Temp": {
-            "displayText": "Phase 2 Temp",
-            "description": ""
-        },
-        "ProfilePhase2Duration": {
-            "displayText": "Phase 2 Duration",
-            "description": ""
-        },
-        "ProfilePhase3Temp": {
-            "displayText": "Phase 3 Temp",
-            "description": ""
-        },
-        "ProfilePhase3Duration": {
-            "displayText": "Phase 3 Duration",
-            "description": ""
-        },
-        "ProfilePhase4Temp": {
-            "displayText": "Phase 4 Temp",
-            "description": ""
-        },
-        "ProfilePhase4Duration": {
-            "displayText": "Phase 4 Duration",
-            "description": ""
-        },
-        "ProfilePhase5Temp": {
-            "displayText": "Phase 5 Temp",
-            "description": ""
-        },
-        "ProfilePhase5Duration": {
-            "displayText": "Phase 5 Duration",
-            "description": ""
-        },
-        "ProfileCooldownSpeed": {
-            "displayText": "Cooldown Speed",
-            "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
-        },
-        "MotionSensitivity": {
-            "displayText": "動作敏感度",
-            "description": "1=最低敏感度 | ... | 9=最高敏感度"
-        },
-        "SleepTemperature": {
-            "displayText": "待機溫度",
-            "description": "於待機模式時的烙鐵頭溫度"
-        },
-        "SleepTimeout": {
-            "displayText": "待機延時",
-            "description": "自動進入待機模式前的閒置等候時間 <s=秒 | m=分鐘>"
-        },
-        "ShutdownTimeout": {
-            "displayText": "自動關機",
-            "description": "自動關機前的閒置等候時間 <m=分鐘>"
-        },
-        "HallEffSensitivity": {
-            "displayText": "磁場敏感度",
-            "description": "磁場感應器用作啟動待機模式的敏感度 <1=最低敏感度 | ... | 9=最高敏感度>"
-        },
-        "TemperatureUnit": {
-            "displayText": "溫標",
-            "description": "C=攝氏 | F=華氏"
-        },
-        "DisplayRotation": {
-            "displayText": "畫面方向",
-            "description": "右=使用右手 | 左=使用左手 | 自=自動"
-        },
-        "CooldownBlink": {
-            "displayText": "降溫時閃爍",
-            "description": "停止加熱之後，當烙鐵頭仍處於高溫時閃爍畫面"
-        },
-        "ScrollingSpeed": {
-            "displayText": "捲動速度",
-            "description": "解說文字的捲動速度"
-        },
-        "ReverseButtonTempChange": {
-            "displayText": "調換加減鍵",
-            "description": "調校溫度時調換加減鍵的方向"
-        },
-        "AnimSpeed": {
-            "displayText": "動畫速度",
-            "description": "功能表圖示動畫的速度 <慢=慢速 | 中=中速 | 快=快速>"
-        },
-        "AnimLoop": {
-            "displayText": "動畫循環",
-            "description": "循環顯示功能表圖示動畫"
-        },
-        "Brightness": {
-            "displayText": "螢幕亮度",
-            "description": "設定OLED螢幕的亮度"
-        },
-        "ColourInversion": {
-            "displayText": "螢幕反轉色",
-            "description": "反轉OLED螢幕的黑白色彩"
-        },
-        "LOGOTime": {
-            "displayText": "開機畫面",
-            "description": "設定開機畫面顯示時長 <s=秒>"
-        },
-        "AdvancedIdle": {
-            "displayText": "詳細閒置畫面",
-            "description": "於閒置畫面以英文小字型顯示詳細資料"
-        },
-        "AdvancedSoldering": {
-            "displayText": "詳細焊接畫面",
-            "description": "於焊接模式畫面以英文小字型顯示詳細資料"
-        },
-        "BluetoothLE": {
-            "displayText": "藍牙",
-            "description": "開啟藍牙支援"
-        },
-        "PowerLimit": {
-            "displayText": "功率限制",
-            "description": "限制烙鐵可用的最大功率 <W=watt（瓦特）>"
-        },
-        "CalibrateCJC": {
-            "displayText": "校正CJC",
-            "description": "在下次重啟時校正烙鐵頭熱電偶冷接點補償值（CJC）（溫差小於5攝氏度時無需校正）"
-        },
-        "VoltageCalibration": {
-            "displayText": "輸入電壓校正？",
-            "description": "開始校正VIN輸入電壓 <長按以退出>"
-        },
-        "PowerPulsePower": {
-            "displayText": "電源脈衝",
-            "description": "為保持電源喚醒而通電所用的功率 <watt（瓦特）>"
-        },
-        "PowerPulseWait": {
-            "displayText": "電源脈衝間隔",
-            "description": "為保持電源喚醒，每次通電之間的間隔時間 <x2.5s（秒）>"
-        },
-        "PowerPulseDuration": {
-            "displayText": "電源脈衝時長",
-            "description": "為保持電源喚醒，每次通電脈衝的時間長度 <x250ms（亳秒）>"
-        },
-        "SettingsReset": {
-            "displayText": "全部重設？",
-            "description": "將所有設定重設到預設值"
-        },
-        "LanguageSwitch": {
-            "displayText": "語言：正體中文",
-            "description": ""
-        }
+    "NoAccelerometerMessage": {
+      "message": "未能偵測加速度計"
+    },
+    "NoPowerDeliveryMessage": {
+      "message": "未能偵測PD晶片"
+    },
+    "LockingKeysString": {
+      "message": "已鎖定"
+    },
+    "UnlockingKeysString": {
+      "message": "已解除鎖定"
+    },
+    "WarningKeysLockedString": {
+      "message": "!按鍵鎖定!"
+    },
+    "WarningThermalRunaway": {
+      "message": "加熱失控"
+    },
+    "WarningTipShorted": {
+      "message": "!烙鐵頭短路!"
+    },
+    "SettingsCalibrationWarning": {
+      "message": "在重啟前請確認烙鐵頭及本體已完全冷卻！"
+    },
+    "CJCCalibrating": {
+      "message": "校正中"
+    },
+    "SettingsResetWarning": {
+      "message": "你是否確定要將全部設定重設到預設值？"
+    },
+    "UVLOWarningString": {
+      "message": "電壓過低"
+    },
+    "UndervoltageString": {
+      "message": "Undervoltage"
+    },
+    "InputVoltageString": {
+      "message": "Input V: "
+    },
+    "SleepingAdvancedString": {
+      "message": "Sleeping..."
+    },
+    "SleepingTipAdvancedString": {
+      "message": "Tip: "
+    },
+    "ProfilePreheatString": {
+      "message": "Preheat"
+    },
+    "ProfileCooldownString": {
+      "message": "Cooldown"
+    },
+    "DeviceFailedValidationWarning": {
+      "message": "這支電烙鐵很有可能是冒牌貨！"
+    },
+    "TooHotToStartProfileWarning": {
+      "message": "Too hot to start profile"
     }
+  },
+  "characters": {
+    "SettingRightChar": "右",
+    "SettingLeftChar": "左",
+    "SettingAutoChar": "自",
+    "SettingSlowChar": "慢",
+    "SettingMediumChar": "中",
+    "SettingFastChar": "快",
+    "SettingStartSolderingChar": "焊",
+    "SettingStartSleepChar": "待",
+    "SettingStartSleepOffChar": "室",
+    "SettingLockBoostChar": "增",
+    "SettingLockFullChar": "全"
+  },
+  "menuGroups": {
+    "PowerMenu": {
+      "displayText": "電源設定",
+      "description": ""
+    },
+    "SolderingMenu": {
+      "displayText": "焊接設定",
+      "description": ""
+    },
+    "PowerSavingMenu": {
+      "displayText": "待機設定",
+      "description": ""
+    },
+    "UIMenu": {
+      "displayText": "使用者介面",
+      "description": ""
+    },
+    "AdvancedMenu": {
+      "displayText": "進階設定",
+      "description": ""
+    }
+  },
+  "menuOptions": {
+    "DCInCutoff": {
+      "displayText": "電源",
+      "description": "輸入電源；設定自動停機電壓 <DC 10V> <S 鋰電池，以每顆3.3V計算；此設定會停用功率限制>"
+    },
+    "MinVolCell": {
+      "displayText": "最低電壓",
+      "description": "每顆電池的最低可用電壓 <伏特> <3S: 3.0V - 3.7V, 4/5/6S: 2.4V - 3.7V>"
+    },
+    "QCMaxVoltage": {
+      "displayText": "QC電壓",
+      "description": "使用QC電源時請求的最高目標電壓"
+    },
+    "PDNegTimeout": {
+      "displayText": "PD逾時",
+      "description": "設定USB PD協定交涉的逾時時限；為兼容某些QC電源而設 <x100ms（亳秒）>"
+    },
+    "USBPDMode": {
+      "displayText": "PD VPDO",
+      "description": "開啟PPS及EPR支援"
+    },
+    "BoostTemperature": {
+      "displayText": "增熱溫度",
+      "description": "於增熱模式時使用的溫度"
+    },
+    "AutoStart": {
+      "displayText": "自動啟用",
+      "description": "開機時自動啟用 <焊=焊接模式 | 待=待機模式 | 室=室溫待機>"
+    },
+    "TempChangeShortStep": {
+      "displayText": "溫度調整 短",
+      "description": "調校溫度時短按一下的溫度變幅"
+    },
+    "TempChangeLongStep": {
+      "displayText": "溫度調整 長",
+      "description": "調校溫度時長按按鍵的溫度變幅"
+    },
+    "LockingMode": {
+      "displayText": "按鍵鎖定",
+      "description": "於焊接模式時，同時長按兩個按鍵啟用按鍵鎖定 <增=只容許增熱模式 | 全=鎖定全部>"
+    },
+    "ProfilePhases": {
+      "displayText": "Profile Phases",
+      "description": "Number of phases in profile mode"
+    },
+    "ProfilePreheatTemp": {
+      "displayText": "Preheat Temp",
+      "description": "Preheat to this temperature at the start of profile mode"
+    },
+    "ProfilePreheatSpeed": {
+      "displayText": "Preheat Speed",
+      "description": "Preheat at this rate (degrees per second)"
+    },
+    "ProfilePhase1Temp": {
+      "displayText": "Phase 1 Temp",
+      "description": "Target temperature for the end of this phase"
+    },
+    "ProfilePhase1Duration": {
+      "displayText": "Phase 1 Duration",
+      "description": "Target duration of this phase (seconds)"
+    },
+    "ProfilePhase2Temp": {
+      "displayText": "Phase 2 Temp",
+      "description": ""
+    },
+    "ProfilePhase2Duration": {
+      "displayText": "Phase 2 Duration",
+      "description": ""
+    },
+    "ProfilePhase3Temp": {
+      "displayText": "Phase 3 Temp",
+      "description": ""
+    },
+    "ProfilePhase3Duration": {
+      "displayText": "Phase 3 Duration",
+      "description": ""
+    },
+    "ProfilePhase4Temp": {
+      "displayText": "Phase 4 Temp",
+      "description": ""
+    },
+    "ProfilePhase4Duration": {
+      "displayText": "Phase 4 Duration",
+      "description": ""
+    },
+    "ProfilePhase5Temp": {
+      "displayText": "Phase 5 Temp",
+      "description": ""
+    },
+    "ProfilePhase5Duration": {
+      "displayText": "Phase 5 Duration",
+      "description": ""
+    },
+    "ProfileCooldownSpeed": {
+      "displayText": "Cooldown Speed",
+      "description": "Cooldown at this rate at the end of profile mode (degrees per second)"
+    },
+    "MotionSensitivity": {
+      "displayText": "動作敏感度",
+      "description": "1=最低敏感度 | ... | 9=最高敏感度"
+    },
+    "SleepTemperature": {
+      "displayText": "待機溫度",
+      "description": "於待機模式時的烙鐵頭溫度"
+    },
+    "SleepTimeout": {
+      "displayText": "待機延時",
+      "description": "自動進入待機模式前的閒置等候時間 <s=秒 | m=分鐘>"
+    },
+    "ShutdownTimeout": {
+      "displayText": "自動關機",
+      "description": "自動關機前的閒置等候時間 <m=分鐘>"
+    },
+    "HallEffSensitivity": {
+      "displayText": "磁場敏感度",
+      "description": "磁場感應器用作啟動待機模式的敏感度 <1=最低敏感度 | ... | 9=最高敏感度>"
+    },
+    "TemperatureUnit": {
+      "displayText": "溫標",
+      "description": "C=攝氏 | F=華氏"
+    },
+    "DisplayRotation": {
+      "displayText": "畫面方向",
+      "description": "右=使用右手 | 左=使用左手 | 自=自動"
+    },
+    "CooldownBlink": {
+      "displayText": "降溫時閃爍",
+      "description": "停止加熱之後，當烙鐵頭仍處於高溫時閃爍畫面"
+    },
+    "ScrollingSpeed": {
+      "displayText": "捲動速度",
+      "description": "解說文字的捲動速度"
+    },
+    "ReverseButtonTempChange": {
+      "displayText": "調換加減鍵",
+      "description": "調校溫度時調換加減鍵的方向"
+    },
+    "AnimSpeed": {
+      "displayText": "動畫速度",
+      "description": "功能表圖示動畫的速度 <慢=慢速 | 中=中速 | 快=快速>"
+    },
+    "AnimLoop": {
+      "displayText": "動畫循環",
+      "description": "循環顯示功能表圖示動畫"
+    },
+    "Brightness": {
+      "displayText": "螢幕亮度",
+      "description": "設定OLED螢幕的亮度"
+    },
+    "ColourInversion": {
+      "displayText": "螢幕反轉色",
+      "description": "反轉OLED螢幕的黑白色彩"
+    },
+    "LOGOTime": {
+      "displayText": "開機畫面",
+      "description": "設定開機畫面顯示時長 <s=秒>"
+    },
+    "AdvancedIdle": {
+      "displayText": "詳細閒置畫面",
+      "description": "於閒置畫面以英文小字型顯示詳細資料"
+    },
+    "AdvancedSoldering": {
+      "displayText": "詳細焊接畫面",
+      "description": "於焊接模式畫面以英文小字型顯示詳細資料"
+    },
+    "BluetoothLE": {
+      "displayText": "藍牙",
+      "description": "開啟藍牙支援"
+    },
+    "PowerLimit": {
+      "displayText": "功率限制",
+      "description": "限制烙鐵可用的最大功率 <W=watt（瓦特）>"
+    },
+    "CalibrateCJC": {
+      "displayText": "校正CJC",
+      "description": "在下次重啟時校正烙鐵頭熱電偶冷接點補償值（CJC）（溫差小於5攝氏度時無需校正）"
+    },
+    "VoltageCalibration": {
+      "displayText": "輸入電壓校正？",
+      "description": "開始校正VIN輸入電壓 <長按以退出>"
+    },
+    "PowerPulsePower": {
+      "displayText": "電源脈衝",
+      "description": "為保持電源喚醒而通電所用的功率 <watt（瓦特）>"
+    },
+    "PowerPulseWait": {
+      "displayText": "電源脈衝間隔",
+      "description": "為保持電源喚醒，每次通電之間的間隔時間 <x2.5s（秒）>"
+    },
+    "PowerPulseDuration": {
+      "displayText": "電源脈衝時長",
+      "description": "為保持電源喚醒，每次通電脈衝的時間長度 <x250ms（亳秒）>"
+    },
+    "SettingsReset": {
+      "displayText": "全部重設？",
+      "description": "將所有設定重設到預設值"
+    },
+    "LanguageSwitch": {
+      "displayText": "語言：正體中文",
+      "description": ""
+    }
+  }
 }

--- a/Translations/translations_definitions.json
+++ b/Translations/translations_definitions.json
@@ -1,597 +1,547 @@
 {
-    "messagesWarn": [{
-            "id": "CalibrationDone",
-            "description": "Confirmation message indicating calibration is complete."
-        },
-        {
-            "id": "ResetOKMessage",
-            "description": "Shown when the settings are reset to factory defaults by the user."
-        },
-        {
-            "id": "SettingsResetMessage",
-            "description": "Shown when certain settings are reset to factory defaults due to incompatible firmware changes."
-        },
-        {
-            "id": "NoAccelerometerMessage",
-            "description": "No accelerometer could be communicated with. This means that either the device's accelerometer is broken or unknown to IronOS. All motion-based settings are disabled and motion-based features will not work."
-        },
-        {
-            "id": "NoPowerDeliveryMessage",
-            "include": [
-                "POW_PD"
-            ],
-            "description": "The IC required for USB-PD could not be communicated with. This is an error warning that USB-PD WILL NOT FUNCTION. Generally indicative of either a hardware or software issues."
-        },
-        {
-            "id": "LockingKeysString",
-            "description": "Shown when keys are locked"
-        },
-        {
-            "id": "UnlockingKeysString",
-            "description": "Shown when keys are unlocked"
-        },
-        {
-            "id": "WarningKeysLockedString",
-            "description": "Warning that is shown when input is ignored due to the key lock being on"
-        },
-        {
-            "id": "WarningThermalRunaway",
-            "description": "Warning text shown when the software has disabled the heater as a safety precaution as the temperature reading didn't react as expected."
-        },
-        {
-            "id": "WarningTipShorted",
-            "description": "Warning text shown when the software has detected that the users tip is likely shorted."
-        },
-        {
-            "id": "SettingsCalibrationWarning",
-            "description": "Confirmation message shown before performing an offset calibration. Should warn the user to make sure tip and handle are at the same temperature."
-        },
-        {
-            "id": "CJCCalibrating",
-            "description": "Message indicating CJC is being calibrated."
-        },
-        {
-            "id": "SettingsResetWarning",
-            "description": "Confirmation message shown before confirming a settings reset."
-        },
-        {
-            "id": "UVLOWarningString",
-            "maxLen": 8,
-            "include": [
-                "POW_DC"
-            ],
-            "description": "Warning text shown when the unit turns off due to undervoltage in simple mode."
-        },
-        {
-            "id": "UndervoltageString",
-            "maxLen": 15,
-            "include": [
-                "POW_DC"
-            ],
-            "description": "Warning text shown when the unit turns off due to undervoltage in advanced mode."
-        },
-        {
-            "id": "InputVoltageString",
-            "maxLen": 11,
-            "note": "Preferably end with a space",
-            "include": [
-                "POW_DC"
-            ],
-            "description": "Prefix text for 'Input Voltage' shown before showing the input voltage reading."
-        },
-        {
-            "id": "ProfilePreheatString",
-            "maxLen": 9,
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "Shown in profile mode while preheating"
-        },
-        {
-            "id": "ProfileCooldownString",
-            "maxLen": 9,
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "Shown in profile mode while cooling down"
-        },
-        {
-            "id": "SleepingAdvancedString",
-            "maxLen": 15,
-            "exclude": [
-                "NO_SLEEP_MODE"
-            ],
-            "description": "The text shown to indicate the unit is in sleep mode when the advanced view is turned on."
-        },
-        {
-            "id": "SleepingTipAdvancedString",
-            "maxLen": 6,
-            "exclude": [
-                "NO_SLEEP_MODE"
-            ],
-            "description": "The prefix text shown before tip temperature when the unit is sleeping with advanced view on."
-        },
-        {
-            "id": "DeviceFailedValidationWarning",
-            "default": "Device may be\ncounterfeit",
-            "description": "Warning shown if the device may be a clone or counterfeit unit."
-        },
-        {
-            "id": "TooHotToStartProfileWarning",
-            "default": "Too hot to\nstart profile",
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "Shown when profile mode is started while the device is too hot."
-        }
-    ],
-    "characters": [
-        {
-            "id": "SettingRightChar",
-            "len": 1,
-            "description": "Shown for fixed Right-handed display rotation."
-        },
-        {
-            "id": "SettingLeftChar",
-            "len": 1,
-            "description": "Shown for fixed Left-handed display rotation."
-        },
-        {
-            "id": "SettingAutoChar",
-            "len": 1,
-            "description": "Shown for automatic display rotation."
-        },
-        {
-            "id": "SettingSlowChar",
-            "len": 1,
-            "description": "Shown when a setting is set to a slow value i.e. animation speed"
-        },
-        {
-            "id": "SettingMediumChar",
-            "len": 1,
-            "description": "Shown when a setting is set to a medium value i.e. animation speed"
-        },
-        {
-            "id": "SettingFastChar",
-            "len": 1,
-            "description": "Shown when a setting is set to a fast value i.e. animation speed"
-        },
-        {
-            "id": "SettingStartSolderingChar",
-            "len": 1,
-            "description": "Shown when the auto start mode is set to go straight to soldering."
-        },
-        {
-            "id": "SettingStartSleepChar",
-            "len": 1,
-            "description": "Shown when the auto start mode is set to start in sleep mode."
-        },
-        {
-            "id": "SettingStartSleepOffChar",
-            "len": 1,
-            "description": "Shown when the auto start state is set to go to an off state, but on movement wake into soldering mode."
-        },
-        {
-            "id": "SettingLockBoostChar",
-            "len": 1,
-            "default": "B",
-            "description": "Shown when the locking mode is set to lock all buttons except for boost mode."
-        },
-        {
-            "id": "SettingLockFullChar",
-            "len": 1,
-            "default": "F",
-            "description": "Shown when the locking mode is set to lock all buttons."
-        }
-    ],
-    "menuGroups": [
-        {
-            "id": "PowerMenu",
-            "maxLen": 5,
-            "maxLen2": 11,
-            "include": [
-                "POW_DC",
-                "POW_QC"
-            ],
-            "description": "Menu for settings related to power. Main settings to do with the input voltage."
-        },
-        {
-            "id": "SolderingMenu",
-            "maxLen": 5,
-            "maxLen2": 11,
-            "description": "Settings for soldering mode, such as boost temps, the increment used when pressing buttons and if button locking is enabled."
-        },
-        {
-            "id": "PowerSavingMenu",
-            "maxLen": 5,
-            "maxLen2": 11,
-            "description": "Settings to do with power saving, such as sleep mode, sleep temps, and shutdown modes."
-        },
-        {
-            "id": "UIMenu",
-            "maxLen": 5,
-            "maxLen2": 11,
-            "description": "User interface related settings, such as units."
-        },
-        {
-            "id": "AdvancedMenu",
-            "maxLen": 5,
-            "maxLen2": 11,
-            "description": "Advanced settings. Misc catchall for settings that don't fit anywhere else or settings that require some thought before use."
-        }
-    ],
-    "menuOptions": [
-        {
-            "id": "DCInCutoff",
-            "maxLen": 5,
-            "maxLen2": 11,
-            "include": [
-                "POW_DC"
-            ],
-            "description": "When the device is powered by a battery, this adjusts the low voltage threshold for when the unit should turn off the heater to protect the battery."
-        },
-        {
-            "id": "MinVolCell",
-            "maxLen": 4,
-            "maxLen2": 9,
-            "include": [
-                "POW_DC"
-            ],
-            "description": "When powered by a battery, this adjusts the minimum voltage per cell before shutdown. (This is multiplied by the cell count.)"
-        },
-        {
-            "id": "QCMaxVoltage",
-            "maxLen": 8,
-            "maxLen2": 15,
-            "include": [
-                "POW_QC"
-            ],
-            "description": "This adjusts the maximum voltage the QC negotiation will adjust to. Does NOT affect USB-PD. Should be set safely based on the current rating of your power supply."
-        },
-        {
-            "id": "PDNegTimeout",
-            "maxLen": 8,
-            "maxLen2": 15,
-            "include": [
-                "POW_PD"
-            ],
-            "description": "How long until firmware stops trying to negotiate for USB-PD and tries QC instead. Longer times may help dodgy / old PD adapters, faster times move onto PD quickly. Units of 100ms. Recommended to keep small values."
-        },
-        {
-            "id": "PDVpdo",
-            "maxLen": 7,
-            "maxLen2": 15,
-            "include": [
-                "POW_PD"
-            ],
-            "description": "Enabled PPS & EPR modes."
-        },
-        {
-            "id": "BoostTemperature",
-            "maxLen": 4,
-            "maxLen2": 9,
-            "description": "When the unit is in soldering mode. You can hold down the button at the front of the device to temporarily override the soldering temperature to this value. This SETS the temperature, it does not ADD to it."
-        },
-        {
-            "id": "AutoStart",
-            "maxLen": 6,
-            "maxLen2": 13,
-            "description": "When the device powers up, should it enter into a special mode. These settings set it to either start into soldering mode, sleeping mode or auto mode (Enters into soldering mode on the first movement)."
-        },
-        {
-            "id": "TempChangeShortStep",
-            "maxLen": 8,
-            "maxLen2": 15,
-            "description": "Factor by which the temperature is changed with a quick press of the buttons."
-        },
-        {
-            "id": "TempChangeLongStep",
-            "maxLen": 6,
-            "maxLen2": 15,
-            "description": "Factor by which the temperature is changed with a hold of the buttons."
-        },
-        {
-            "id": "LockingMode",
-            "maxLen": 6,
-            "maxLen2": 13,
-            "description": "If locking the buttons against accidental presses is enabled."
-        },
-        {
-            "id": "ProfilePhases",
-            "maxLen": 6,
-            "maxLen2": 13,
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "set the number of phases for profile mode."
-        },
-        {
-            "id": "ProfilePreheatTemp",
-            "maxLen": 4,
-            "maxLen2": 9,
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "Preheat to this temperature at the start of profile mode."
-        },
-        {
-            "id": "ProfilePreheatSpeed",
-            "maxLen": 5,
-            "maxLen2": 11,
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "How fast the temperature is allowed to rise during the preheat phase at the start of profile mode."
-        },
-        {
-            "id": "ProfilePhase1Temp",
-            "maxLen": 4,
-            "maxLen2": 9,
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "Target temperature for the end of phase 1 of profile mode."
-        },
-        {
-            "id": "ProfilePhase1Duration",
-            "maxLen": 4,
-            "maxLen2": 9,
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "Duration of phase 1 of profile mode. The phase might actually take longer if it takes longer to reach the target temperature."
-        },
-        {
-            "id": "ProfilePhase2Temp",
-            "maxLen": 4,
-            "maxLen2": 9,
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "Target temperature for the end of phase 2 of profile mode."
-        },
-        {
-            "id": "ProfilePhase2Duration",
-            "maxLen": 4,
-            "maxLen2": 9,
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "Duration of phase 2 of profile mode. The phase might actually take longer if it takes longer to reach the target temperature."
-        },
-        {
-            "id": "ProfilePhase3Temp",
-            "maxLen": 4,
-            "maxLen2": 9,
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "Target temperature for the end of phase 3 of profile mode."
-        },
-        {
-            "id": "ProfilePhase3Duration",
-            "maxLen": 4,
-            "maxLen2": 9,
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "Duration of phase 3 of profile mode. The phase might actually take longer if it takes longer to reach the target temperature."
-        },
-        {
-            "id": "ProfilePhase4Temp",
-            "maxLen": 4,
-            "maxLen2": 9,
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "Target temperature for the end of phase 5 of profile mode."
-        },
-        {
-            "id": "ProfilePhase4Duration",
-            "maxLen": 4,
-            "maxLen2": 9,
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "Duration of phase 5 of profile mode. The phase might actually take longer if it takes longer to reach the target temperature."
-        },
-        {
-            "id": "ProfilePhase5Temp",
-            "maxLen": 4,
-            "maxLen2": 9,
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "Target temperature for the end of phase 5 of profile mode."
-        },
-        {
-            "id": "ProfilePhase5Duration",
-            "maxLen": 4,
-            "maxLen2": 9,
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "Duration of phase 5 of profile mode. The phase might actually take longer if it takes longer to reach the target temperature."
-        },
-        {
-            "id": "ProfileCooldownSpeed",
-            "maxLen": 5,
-            "maxLen2": 11,
-            "include": [
-                "PROFILE_SUPPORT"
-            ],
-            "description": "How fast the temperature is allowed to drop during the cooldown phase at the end of profile mode."
-        },
-        {
-            "id": "MotionSensitivity",
-            "maxLen": 6,
-            "maxLen2": 13,
-            "description": "Scale of how sensitive the device is to movement. Higher numbers == more sensitive. 0 == motion detection turned off."
-        },
-        {
-            "id": "SleepTemperature",
-            "maxLen": 4,
-            "maxLen2": 9,
-            "exclude": [
-                "NO_SLEEP_MODE"
-            ],
-            "description": "Temperature the device will drop down to while asleep. Typically around halfway between off and soldering temperature."
-        },
-        {
-            "id": "SleepTimeout",
-            "maxLen": 4,
-            "maxLen2": 9,
-            "exclude": [
-                "NO_SLEEP_MODE"
-            ],
-            "description": "How long of a period without movement / button-pressing is required before the device drops down to the sleep temperature."
-        },
-        {
-            "id": "ShutdownTimeout",
-            "maxLen": 5,
-            "maxLen2": 11,
-            "description": "How long of a period without movement / button-pressing is required before the device turns off the tip heater completely and returns to the main idle screen."
-        },
-        {
-            "id": "HallEffSensitivity",
-            "maxLen": 6,
-            "maxLen2": 13,
-            "include": [
-                "HALL_SENSOR"
-            ],
-            "description": "If the unit has a hall effect sensor (Pinecil), this adjusts how sensitive it is at detecting a magnet to put the device into sleep mode."
-        },
-        {
-            "id": "TemperatureUnit",
-            "maxLen": 6,
-            "maxLen2": 13,
-            "description": "If the device shows temperatures in °C or °F."
-        },
-        {
-            "id": "DisplayRotation",
-            "maxLen": 6,
-            "maxLen2": 13,
-            "exclude": [
-                "NO_DISPLAY_ROTATE"
-            ],
-            "description": "If the display should rotate automatically or if it should be fixed for left- or right-handed mode."
-        },
-        {
-            "id": "CooldownBlink",
-            "maxLen": 6,
-            "maxLen2": 13,
-            "description": "If the idle screen should blink the tip temperature for attention while the tip is over 50°C. Intended as a 'tip is still hot' warning."
-        },
-        {
-            "id": "ScrollingSpeed",
-            "maxLen": 6,
-            "maxLen2": 11,
-            "description": "How fast the description text scrolls when hovering on a menu. Faster speeds may induce tearing, but allow reading the whole description faster."
-        },
-        {
-            "id": "ReverseButtonTempChange",
-            "maxLen": 6,
-            "maxLen2": 15,
-            "description": "Swaps which button increments and decrements on temperature change screens."
-        },
-        {
-            "id": "AnimSpeed",
-            "maxLen": 6,
-            "maxLen2": 13,
-            "description": "How fast should the menu animations loop, or if they should not loop at all."
-        },
-        {
-            "id": "AnimLoop",
-            "maxLen": 6,
-            "maxLen2": 13,
-            "description": "Should the menu animations loop. Only visible if the animation speed is not set to \"Off\""
-        },
-        {
-            "id": "Brightness",
-            "maxLen": 7,
-            "maxLen2": 15,
-            "description": "Display brightness. Higher values age the OLED faster due to burn-in. (However, it is notable that most of these screens die from other causes first.)"
-        },
-        {
-            "id": "ColourInversion",
-            "maxLen": 7,
-            "maxLen2": 15,
-            "description": "Inverts the entire OLED."
-        },
-        {
-            "id": "LOGOTime",
-            "maxLen": 7,
-            "maxLen2": 15,
-            "description": "Sets the duration for the boot logo (s=seconds)."
-        },
-        {
-            "id": "AdvancedIdle",
-            "maxLen": 6,
-            "maxLen2": 13,
-            "description": "Should the device show an 'advanced' view on the idle screen. The advanced view uses text to show more details than the typical icons."
-        },
-        {
-            "id": "AdvancedSoldering",
-            "maxLen": 6,
-            "maxLen2": 13,
-            "description": "Should the device show an 'advanced' soldering view. This is a text-based view that shows more information at the cost of no nice graphics."
-        },
-        {
-            "id": "BluetoothLE",
-            "maxLen": 7,
-            "maxLen2": 15,
-            "include": [
-                "BLE_ENABLED"
-            ],
-            "description": "Should BLE be enabled at boot time."
-        },
-        {
-            "id": "PowerLimit",
-            "maxLen": 5,
-            "maxLen2": 11,
-            "description": "Allows setting a custom wattage for the device to aim to keep the AVERAGE power below. The unit can't control its peak power no matter how you set this. (Except for MHP30 which will regulate nicely to this). If USB-PD is in use, the limit will be set to the lower of this and the supplies advertised wattage."
-        },
-        {
-            "id": "CalibrateCJC",
-            "maxLen": 8,
-            "maxLen2": 15,
-            "description": "Used to calibrate the ADC+Op-amp offsets for the tip. This calibration must be performed when the tip temperature and the handle temperature are equal. Generally not required unless your device is reading more than 5°C off target."
-        },
-        {
-            "id": "VoltageCalibration",
-            "maxLen": 8,
-            "maxLen2": 15,
-            "description": "Enters an adjustment mode where you can gradually adjust the measured voltage to compensate for any unit-to-unit variance in the voltage sense resistors."
-        },
-        {
-            "id": "PowerPulsePower",
-            "maxLen": 6,
-            "maxLen2": 15,
-            "description": "Enables and sets the wattage of the power pulse. Power pulse causes the device to briefly turn on the heater to draw power to avoid power banks going to sleep."
-        },
-        {
-            "id": "PowerPulseWait",
-            "maxLen": 6,
-            "maxLen2": 13,
-            "description": "Adjusts the time interval between power pulses. Longer gaps reduce undesired heating of the tip, but needs to be fast enough to keep your power bank awake."
-        },
-        {
-            "id": "PowerPulseDuration",
-            "maxLen": 6,
-            "maxLen2": 13,
-            "description": "How long should the power pulse go for. Some power banks require seeing the power draw be sustained for a certain duration to keep awake. Should be kept as short as possible to avoid wasting power / undesired heating of the tip."
-        },
-        {
-            "id": "SettingsReset",
-            "maxLen": 8,
-            "maxLen2": 15,
-            "description": "Resets all settings and calibrations to factory defaults. Does NOT erase custom user boot up logo's."
-        },
-        {
-            "id": "LanguageSwitch",
-            "maxLen": 7,
-            "maxLen2": 15,
-            "description": "Changes the device language on multi-lingual builds."
-        }
-    ]
+  "messagesWarn": [
+    {
+      "id": "CalibrationDone",
+      "description": "Confirmation message indicating calibration is complete."
+    },
+    {
+      "id": "ResetOKMessage",
+      "description": "Shown when the settings are reset to factory defaults by the user."
+    },
+    {
+      "id": "SettingsResetMessage",
+      "description": "Shown when certain settings are reset to factory defaults due to incompatible firmware changes."
+    },
+    {
+      "id": "NoAccelerometerMessage",
+      "description": "No accelerometer could be communicated with. This means that either the device's accelerometer is broken or unknown to IronOS. All motion-based settings are disabled and motion-based features will not work."
+    },
+    {
+      "id": "NoPowerDeliveryMessage",
+      "include": ["POW_PD"],
+      "description": "The IC required for USB-PD could not be communicated with. This is an error warning that USB-PD WILL NOT FUNCTION. Generally indicative of either a hardware or software issues."
+    },
+    {
+      "id": "LockingKeysString",
+      "description": "Shown when keys are locked"
+    },
+    {
+      "id": "UnlockingKeysString",
+      "description": "Shown when keys are unlocked"
+    },
+    {
+      "id": "WarningKeysLockedString",
+      "description": "Warning that is shown when input is ignored due to the key lock being on"
+    },
+    {
+      "id": "WarningThermalRunaway",
+      "description": "Warning text shown when the software has disabled the heater as a safety precaution as the temperature reading didn't react as expected."
+    },
+    {
+      "id": "WarningTipShorted",
+      "description": "Warning text shown when the software has detected that the users tip is likely shorted."
+    },
+    {
+      "id": "SettingsCalibrationWarning",
+      "description": "Confirmation message shown before performing an offset calibration. Should warn the user to make sure tip and handle are at the same temperature."
+    },
+    {
+      "id": "CJCCalibrating",
+      "description": "Message indicating CJC is being calibrated."
+    },
+    {
+      "id": "SettingsResetWarning",
+      "description": "Confirmation message shown before confirming a settings reset."
+    },
+    {
+      "id": "UVLOWarningString",
+      "maxLen": 8,
+      "include": ["POW_DC"],
+      "description": "Warning text shown when the unit turns off due to undervoltage in simple mode."
+    },
+    {
+      "id": "UndervoltageString",
+      "maxLen": 15,
+      "include": ["POW_DC"],
+      "description": "Warning text shown when the unit turns off due to undervoltage in advanced mode."
+    },
+    {
+      "id": "InputVoltageString",
+      "maxLen": 11,
+      "note": "Preferably end with a space",
+      "include": ["POW_DC"],
+      "description": "Prefix text for 'Input Voltage' shown before showing the input voltage reading."
+    },
+    {
+      "id": "ProfilePreheatString",
+      "maxLen": 9,
+      "include": ["PROFILE_SUPPORT"],
+      "description": "Shown in profile mode while preheating"
+    },
+    {
+      "id": "ProfileCooldownString",
+      "maxLen": 9,
+      "include": ["PROFILE_SUPPORT"],
+      "description": "Shown in profile mode while cooling down"
+    },
+    {
+      "id": "SleepingAdvancedString",
+      "maxLen": 15,
+      "exclude": ["NO_SLEEP_MODE"],
+      "description": "The text shown to indicate the unit is in sleep mode when the advanced view is turned on."
+    },
+    {
+      "id": "SleepingTipAdvancedString",
+      "maxLen": 6,
+      "exclude": ["NO_SLEEP_MODE"],
+      "description": "The prefix text shown before tip temperature when the unit is sleeping with advanced view on."
+    },
+    {
+      "id": "DeviceFailedValidationWarning",
+      "default": "Device may be\ncounterfeit",
+      "description": "Warning shown if the device may be a clone or counterfeit unit."
+    },
+    {
+      "id": "TooHotToStartProfileWarning",
+      "default": "Too hot to\nstart profile",
+      "include": ["PROFILE_SUPPORT"],
+      "description": "Shown when profile mode is started while the device is too hot."
+    }
+  ],
+  "characters": [
+    {
+      "id": "SettingRightChar",
+      "len": 1,
+      "description": "Shown for fixed Right-handed display rotation."
+    },
+    {
+      "id": "SettingLeftChar",
+      "len": 1,
+      "description": "Shown for fixed Left-handed display rotation."
+    },
+    {
+      "id": "SettingAutoChar",
+      "len": 1,
+      "description": "Shown for automatic display rotation."
+    },
+    {
+      "id": "SettingSlowChar",
+      "len": 1,
+      "description": "Shown when a setting is set to a slow value i.e. animation speed"
+    },
+    {
+      "id": "SettingMediumChar",
+      "len": 1,
+      "description": "Shown when a setting is set to a medium value i.e. animation speed"
+    },
+    {
+      "id": "SettingFastChar",
+      "len": 1,
+      "description": "Shown when a setting is set to a fast value i.e. animation speed"
+    },
+    {
+      "id": "SettingStartSolderingChar",
+      "len": 1,
+      "description": "Shown when the auto start mode is set to go straight to soldering."
+    },
+    {
+      "id": "SettingStartSleepChar",
+      "len": 1,
+      "description": "Shown when the auto start mode is set to start in sleep mode."
+    },
+    {
+      "id": "SettingStartSleepOffChar",
+      "len": 1,
+      "description": "Shown when the auto start state is set to go to an off state, but on movement wake into soldering mode."
+    },
+    {
+      "id": "SettingLockBoostChar",
+      "len": 1,
+      "default": "B",
+      "description": "Shown when the locking mode is set to lock all buttons except for boost mode."
+    },
+    {
+      "id": "SettingLockFullChar",
+      "len": 1,
+      "default": "F",
+      "description": "Shown when the locking mode is set to lock all buttons."
+    },
+    {
+      "id": "SettingPDModeDefaultChar",
+      "len": 1,
+      "default": "D",
+      "description": "Shown when the locking mode is set to lock all buttons."
+    },
+    {
+      "id": "SettingPDModeSafeChar",
+      "len": 1,
+      "default": "S",
+      "description": "Shown when the locking mode is set to lock all buttons."
+    },
+    {
+      "id": "SettingPDModeNoDynamicChar",
+      "len": 1,
+      "default": "N",
+      "description": "Shown when the locking mode is set to lock all buttons."
+    }
+  ],
+  "menuGroups": [
+    {
+      "id": "PowerMenu",
+      "maxLen": 5,
+      "maxLen2": 11,
+      "include": ["POW_DC", "POW_QC"],
+      "description": "Menu for settings related to power. Main settings to do with the input voltage."
+    },
+    {
+      "id": "SolderingMenu",
+      "maxLen": 5,
+      "maxLen2": 11,
+      "description": "Settings for soldering mode, such as boost temps, the increment used when pressing buttons and if button locking is enabled."
+    },
+    {
+      "id": "PowerSavingMenu",
+      "maxLen": 5,
+      "maxLen2": 11,
+      "description": "Settings to do with power saving, such as sleep mode, sleep temps, and shutdown modes."
+    },
+    {
+      "id": "UIMenu",
+      "maxLen": 5,
+      "maxLen2": 11,
+      "description": "User interface related settings, such as units."
+    },
+    {
+      "id": "AdvancedMenu",
+      "maxLen": 5,
+      "maxLen2": 11,
+      "description": "Advanced settings. Misc catchall for settings that don't fit anywhere else or settings that require some thought before use."
+    }
+  ],
+  "menuOptions": [
+    {
+      "id": "DCInCutoff",
+      "maxLen": 5,
+      "maxLen2": 11,
+      "include": ["POW_DC"],
+      "description": "When the device is powered by a battery, this adjusts the low voltage threshold for when the unit should turn off the heater to protect the battery."
+    },
+    {
+      "id": "MinVolCell",
+      "maxLen": 4,
+      "maxLen2": 9,
+      "include": ["POW_DC"],
+      "description": "When powered by a battery, this adjusts the minimum voltage per cell before shutdown. (This is multiplied by the cell count.)"
+    },
+    {
+      "id": "QCMaxVoltage",
+      "maxLen": 8,
+      "maxLen2": 15,
+      "include": ["POW_QC"],
+      "description": "This adjusts the maximum voltage the QC negotiation will adjust to. Does NOT affect USB-PD. Should be set safely based on the current rating of your power supply."
+    },
+    {
+      "id": "PDNegTimeout",
+      "maxLen": 8,
+      "maxLen2": 15,
+      "include": ["POW_PD"],
+      "description": "How long until firmware stops trying to negotiate for USB-PD and tries QC instead. Longer times may help dodgy / old PD adapters, faster times move onto PD quickly. Units of 100ms. Recommended to keep small values."
+    },
+    {
+      "id": "USBPDMode",
+      "maxLen": 7,
+      "maxLen2": 15,
+      "include": ["POW_PD"],
+      "description": "Enabled PPS & EPR modes."
+    },
+    {
+      "id": "BoostTemperature",
+      "maxLen": 4,
+      "maxLen2": 9,
+      "description": "When the unit is in soldering mode. You can hold down the button at the front of the device to temporarily override the soldering temperature to this value. This SETS the temperature, it does not ADD to it."
+    },
+    {
+      "id": "AutoStart",
+      "maxLen": 6,
+      "maxLen2": 13,
+      "description": "When the device powers up, should it enter into a special mode. These settings set it to either start into soldering mode, sleeping mode or auto mode (Enters into soldering mode on the first movement)."
+    },
+    {
+      "id": "TempChangeShortStep",
+      "maxLen": 8,
+      "maxLen2": 15,
+      "description": "Factor by which the temperature is changed with a quick press of the buttons."
+    },
+    {
+      "id": "TempChangeLongStep",
+      "maxLen": 6,
+      "maxLen2": 15,
+      "description": "Factor by which the temperature is changed with a hold of the buttons."
+    },
+    {
+      "id": "LockingMode",
+      "maxLen": 6,
+      "maxLen2": 13,
+      "description": "If locking the buttons against accidental presses is enabled."
+    },
+    {
+      "id": "ProfilePhases",
+      "maxLen": 6,
+      "maxLen2": 13,
+      "include": ["PROFILE_SUPPORT"],
+      "description": "set the number of phases for profile mode."
+    },
+    {
+      "id": "ProfilePreheatTemp",
+      "maxLen": 4,
+      "maxLen2": 9,
+      "include": ["PROFILE_SUPPORT"],
+      "description": "Preheat to this temperature at the start of profile mode."
+    },
+    {
+      "id": "ProfilePreheatSpeed",
+      "maxLen": 5,
+      "maxLen2": 11,
+      "include": ["PROFILE_SUPPORT"],
+      "description": "How fast the temperature is allowed to rise during the preheat phase at the start of profile mode."
+    },
+    {
+      "id": "ProfilePhase1Temp",
+      "maxLen": 4,
+      "maxLen2": 9,
+      "include": ["PROFILE_SUPPORT"],
+      "description": "Target temperature for the end of phase 1 of profile mode."
+    },
+    {
+      "id": "ProfilePhase1Duration",
+      "maxLen": 4,
+      "maxLen2": 9,
+      "include": ["PROFILE_SUPPORT"],
+      "description": "Duration of phase 1 of profile mode. The phase might actually take longer if it takes longer to reach the target temperature."
+    },
+    {
+      "id": "ProfilePhase2Temp",
+      "maxLen": 4,
+      "maxLen2": 9,
+      "include": ["PROFILE_SUPPORT"],
+      "description": "Target temperature for the end of phase 2 of profile mode."
+    },
+    {
+      "id": "ProfilePhase2Duration",
+      "maxLen": 4,
+      "maxLen2": 9,
+      "include": ["PROFILE_SUPPORT"],
+      "description": "Duration of phase 2 of profile mode. The phase might actually take longer if it takes longer to reach the target temperature."
+    },
+    {
+      "id": "ProfilePhase3Temp",
+      "maxLen": 4,
+      "maxLen2": 9,
+      "include": ["PROFILE_SUPPORT"],
+      "description": "Target temperature for the end of phase 3 of profile mode."
+    },
+    {
+      "id": "ProfilePhase3Duration",
+      "maxLen": 4,
+      "maxLen2": 9,
+      "include": ["PROFILE_SUPPORT"],
+      "description": "Duration of phase 3 of profile mode. The phase might actually take longer if it takes longer to reach the target temperature."
+    },
+    {
+      "id": "ProfilePhase4Temp",
+      "maxLen": 4,
+      "maxLen2": 9,
+      "include": ["PROFILE_SUPPORT"],
+      "description": "Target temperature for the end of phase 5 of profile mode."
+    },
+    {
+      "id": "ProfilePhase4Duration",
+      "maxLen": 4,
+      "maxLen2": 9,
+      "include": ["PROFILE_SUPPORT"],
+      "description": "Duration of phase 5 of profile mode. The phase might actually take longer if it takes longer to reach the target temperature."
+    },
+    {
+      "id": "ProfilePhase5Temp",
+      "maxLen": 4,
+      "maxLen2": 9,
+      "include": ["PROFILE_SUPPORT"],
+      "description": "Target temperature for the end of phase 5 of profile mode."
+    },
+    {
+      "id": "ProfilePhase5Duration",
+      "maxLen": 4,
+      "maxLen2": 9,
+      "include": ["PROFILE_SUPPORT"],
+      "description": "Duration of phase 5 of profile mode. The phase might actually take longer if it takes longer to reach the target temperature."
+    },
+    {
+      "id": "ProfileCooldownSpeed",
+      "maxLen": 5,
+      "maxLen2": 11,
+      "include": ["PROFILE_SUPPORT"],
+      "description": "How fast the temperature is allowed to drop during the cooldown phase at the end of profile mode."
+    },
+    {
+      "id": "MotionSensitivity",
+      "maxLen": 6,
+      "maxLen2": 13,
+      "description": "Scale of how sensitive the device is to movement. Higher numbers == more sensitive. 0 == motion detection turned off."
+    },
+    {
+      "id": "SleepTemperature",
+      "maxLen": 4,
+      "maxLen2": 9,
+      "exclude": ["NO_SLEEP_MODE"],
+      "description": "Temperature the device will drop down to while asleep. Typically around halfway between off and soldering temperature."
+    },
+    {
+      "id": "SleepTimeout",
+      "maxLen": 4,
+      "maxLen2": 9,
+      "exclude": ["NO_SLEEP_MODE"],
+      "description": "How long of a period without movement / button-pressing is required before the device drops down to the sleep temperature."
+    },
+    {
+      "id": "ShutdownTimeout",
+      "maxLen": 5,
+      "maxLen2": 11,
+      "description": "How long of a period without movement / button-pressing is required before the device turns off the tip heater completely and returns to the main idle screen."
+    },
+    {
+      "id": "HallEffSensitivity",
+      "maxLen": 6,
+      "maxLen2": 13,
+      "include": ["HALL_SENSOR"],
+      "description": "If the unit has a hall effect sensor (Pinecil), this adjusts how sensitive it is at detecting a magnet to put the device into sleep mode."
+    },
+    {
+      "id": "TemperatureUnit",
+      "maxLen": 6,
+      "maxLen2": 13,
+      "description": "If the device shows temperatures in °C or °F."
+    },
+    {
+      "id": "DisplayRotation",
+      "maxLen": 6,
+      "maxLen2": 13,
+      "exclude": ["NO_DISPLAY_ROTATE"],
+      "description": "If the display should rotate automatically or if it should be fixed for left- or right-handed mode."
+    },
+    {
+      "id": "CooldownBlink",
+      "maxLen": 6,
+      "maxLen2": 13,
+      "description": "If the idle screen should blink the tip temperature for attention while the tip is over 50°C. Intended as a 'tip is still hot' warning."
+    },
+    {
+      "id": "ScrollingSpeed",
+      "maxLen": 6,
+      "maxLen2": 11,
+      "description": "How fast the description text scrolls when hovering on a menu. Faster speeds may induce tearing, but allow reading the whole description faster."
+    },
+    {
+      "id": "ReverseButtonTempChange",
+      "maxLen": 6,
+      "maxLen2": 15,
+      "description": "Swaps which button increments and decrements on temperature change screens."
+    },
+    {
+      "id": "AnimSpeed",
+      "maxLen": 6,
+      "maxLen2": 13,
+      "description": "How fast should the menu animations loop, or if they should not loop at all."
+    },
+    {
+      "id": "AnimLoop",
+      "maxLen": 6,
+      "maxLen2": 13,
+      "description": "Should the menu animations loop. Only visible if the animation speed is not set to \"Off\""
+    },
+    {
+      "id": "Brightness",
+      "maxLen": 7,
+      "maxLen2": 15,
+      "description": "Display brightness. Higher values age the OLED faster due to burn-in. (However, it is notable that most of these screens die from other causes first.)"
+    },
+    {
+      "id": "ColourInversion",
+      "maxLen": 7,
+      "maxLen2": 15,
+      "description": "Inverts the entire OLED."
+    },
+    {
+      "id": "LOGOTime",
+      "maxLen": 7,
+      "maxLen2": 15,
+      "description": "Sets the duration for the boot logo (s=seconds)."
+    },
+    {
+      "id": "AdvancedIdle",
+      "maxLen": 6,
+      "maxLen2": 13,
+      "description": "Should the device show an 'advanced' view on the idle screen. The advanced view uses text to show more details than the typical icons."
+    },
+    {
+      "id": "AdvancedSoldering",
+      "maxLen": 6,
+      "maxLen2": 13,
+      "description": "Should the device show an 'advanced' soldering view. This is a text-based view that shows more information at the cost of no nice graphics."
+    },
+    {
+      "id": "BluetoothLE",
+      "maxLen": 7,
+      "maxLen2": 15,
+      "include": ["BLE_ENABLED"],
+      "description": "Should BLE be enabled at boot time."
+    },
+    {
+      "id": "PowerLimit",
+      "maxLen": 5,
+      "maxLen2": 11,
+      "description": "Allows setting a custom wattage for the device to aim to keep the AVERAGE power below. The unit can't control its peak power no matter how you set this. (Except for MHP30 which will regulate nicely to this). If USB-PD is in use, the limit will be set to the lower of this and the supplies advertised wattage."
+    },
+    {
+      "id": "CalibrateCJC",
+      "maxLen": 8,
+      "maxLen2": 15,
+      "description": "Used to calibrate the ADC+Op-amp offsets for the tip. This calibration must be performed when the tip temperature and the handle temperature are equal. Generally not required unless your device is reading more than 5°C off target."
+    },
+    {
+      "id": "VoltageCalibration",
+      "maxLen": 8,
+      "maxLen2": 15,
+      "description": "Enters an adjustment mode where you can gradually adjust the measured voltage to compensate for any unit-to-unit variance in the voltage sense resistors."
+    },
+    {
+      "id": "PowerPulsePower",
+      "maxLen": 6,
+      "maxLen2": 15,
+      "description": "Enables and sets the wattage of the power pulse. Power pulse causes the device to briefly turn on the heater to draw power to avoid power banks going to sleep."
+    },
+    {
+      "id": "PowerPulseWait",
+      "maxLen": 6,
+      "maxLen2": 13,
+      "description": "Adjusts the time interval between power pulses. Longer gaps reduce undesired heating of the tip, but needs to be fast enough to keep your power bank awake."
+    },
+    {
+      "id": "PowerPulseDuration",
+      "maxLen": 6,
+      "maxLen2": 13,
+      "description": "How long should the power pulse go for. Some power banks require seeing the power draw be sustained for a certain duration to keep awake. Should be kept as short as possible to avoid wasting power / undesired heating of the tip."
+    },
+    {
+      "id": "SettingsReset",
+      "maxLen": 8,
+      "maxLen2": 15,
+      "description": "Resets all settings and calibrations to factory defaults. Does NOT erase custom user boot up logo's."
+    },
+    {
+      "id": "LanguageSwitch",
+      "maxLen": 7,
+      "maxLen2": 15,
+      "description": "Changes the device language on multi-lingual builds."
+    }
+  ]
 }

--- a/Translations/translations_definitions.json
+++ b/Translations/translations_definitions.json
@@ -165,24 +165,6 @@
       "len": 1,
       "default": "F",
       "description": "Shown when the locking mode is set to lock all buttons."
-    },
-    {
-      "id": "SettingPDModeDefaultChar",
-      "len": 1,
-      "default": "D",
-      "description": "Shown when the locking mode is set to lock all buttons."
-    },
-    {
-      "id": "SettingPDModeSafeChar",
-      "len": 1,
-      "default": "S",
-      "description": "Shown when the locking mode is set to lock all buttons."
-    },
-    {
-      "id": "SettingPDModeNoDynamicChar",
-      "len": 1,
-      "default": "N",
-      "description": "Shown when the locking mode is set to lock all buttons."
     }
   ],
   "menuGroups": [
@@ -216,6 +198,20 @@
       "maxLen": 5,
       "maxLen2": 11,
       "description": "Advanced settings. Misc catchall for settings that don't fit anywhere else or settings that require some thought before use."
+    }
+  ],
+  "menuValues": [
+    {
+      "id": "USBPDModeDefault",
+      "description": "When in this mode we enable all PD features, and we pad resistance slightly to account for cable and PCB trace loss"
+    },
+    {
+      "id": "USBPDModeNoDynamic",
+      "description": "When in this mode we only enable fixed voltage USB-PD options, and we pad resistance slightly to account for cable and PCB trace loss"
+    },
+    {
+      "id": "USBPDModeSafe",
+      "description": "When in this mode we enable all PD features, but we don't pad resistance slightly to account for cable and PCB trace loss"
     }
   ],
   "menuOptions": [
@@ -252,7 +248,7 @@
       "maxLen": 7,
       "maxLen2": 15,
       "include": ["POW_PD"],
-      "description": "Enabled PPS & EPR modes."
+      "description": "No Dynamic disables EPR & PPS, Safe mode does not use padding resistance"
     },
     {
       "id": "BoostTemperature",

--- a/source/Core/Drivers/FS2711.cpp
+++ b/source/Core/Drivers/FS2711.cpp
@@ -156,10 +156,10 @@ void FS2711::negotiate() {
   int min_resistance_omhsx10 = 0;
 
   // FS2711 uses mV instead of V
-  const uint16_t vmax          = USB_PD_VMAX * 1000;
-  uint8_t        tipResistance = getTipResistanceX10();
+  const uint16_t vmax           = USB_PD_VMAX * 1000;
+  uint8_t        tip_resistance = getTipResistanceX10();
   if (getSettingValue(SettingsOptions::USBPDMode) == 1) {
-    tipResistance += 5;
+    tip_resistance += 5;
   }
 
   uint16_t pdo_min_mv = 0, pdo_max_mv = 0, pdo_max_curr = 0, pdo_type = 0;

--- a/source/Core/Drivers/FS2711.cpp
+++ b/source/Core/Drivers/FS2711.cpp
@@ -156,8 +156,11 @@ void FS2711::negotiate() {
   int min_resistance_omhsx10 = 0;
 
   // FS2711 uses mV instead of V
-  const uint16_t vmax           = USB_PD_VMAX * 1000;
-  const uint8_t  tip_resistance = getTipResistanceX10() + 5;
+  const uint16_t vmax          = USB_PD_VMAX * 1000;
+  uint8_t        tipResistance = getTipResistanceX10();
+  if (getSettingValue(SettingsOptions::PDVpdo) == 1) {
+    tipResistance += 5;
+  }
 
   uint16_t pdo_min_mv = 0, pdo_max_mv = 0, pdo_max_curr = 0, pdo_type = 0;
 

--- a/source/Core/Drivers/FS2711.cpp
+++ b/source/Core/Drivers/FS2711.cpp
@@ -158,7 +158,7 @@ void FS2711::negotiate() {
   // FS2711 uses mV instead of V
   const uint16_t vmax          = USB_PD_VMAX * 1000;
   uint8_t        tipResistance = getTipResistanceX10();
-  if (getSettingValue(SettingsOptions::PDVpdo) == 1) {
+  if (getSettingValue(SettingsOptions::USBPDMode) == 1) {
     tipResistance += 5;
   }
 

--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -160,7 +160,7 @@ void OLED::setFramebuffer(uint8_t *buffer) {
  * UTF font handling is done using the two input chars.
  * Precursor is the command char that is used to select the table.
  */
-void OLED::drawChar(const uint16_t charCode, const FontStyle fontStyle) {
+void OLED::drawChar(const uint16_t charCode, const FontStyle fontStyle, const uint8_t soft_x_limit) {
   const uint8_t *currentFont;
   static uint8_t fontWidth, fontHeight;
   uint16_t       index;
@@ -175,7 +175,7 @@ void OLED::drawChar(const uint16_t charCode, const FontStyle fontStyle) {
   case FontStyle::LARGE:
   default:
     if (charCode == '\x01' && cursor_y == 0) { // 0x01 is used as new line char
-      setCursor(0, 8);
+      setCursor(soft_x_limit, 8);
       return;
     } else if (charCode <= 0x01) {
       return;
@@ -505,7 +505,7 @@ void OLED::setInverseDisplay(bool inverse) {
 }
 
 // print a string to the current cursor location, len chars MAX
-void OLED::print(const char *const str, FontStyle fontStyle, uint8_t len) {
+void OLED::print(const char *const str, FontStyle fontStyle, uint8_t len, const uint8_t soft_x_limit) {
   const uint8_t *next = reinterpret_cast<const uint8_t *>(str);
   if (next[0] == 0x01) {
     fontStyle = FontStyle::LARGE;
@@ -523,7 +523,7 @@ void OLED::print(const char *const str, FontStyle fontStyle, uint8_t len) {
       index = (next[0] - 0xF0) * 0xFF - 15 + next[1];
       next += 2;
     }
-    drawChar(index, fontStyle);
+    drawChar(index, fontStyle, soft_x_limit);
   }
 }
 
@@ -580,7 +580,7 @@ void OLED::drawHex(uint32_t x, FontStyle fontStyle, uint8_t digits) {
   // print number to hex
   for (uint_fast8_t i = 0; i < digits; i++) {
     uint16_t value = (x >> (4 * (7 - i))) & 0b1111;
-    drawChar(value + 2, fontStyle);
+    drawChar(value + 2, fontStyle, 0);
   }
 }
 
@@ -635,7 +635,7 @@ void OLED::debugNumber(int32_t val, FontStyle fontStyle) {
 
 void OLED::drawSymbol(uint8_t symbolID) {
   // draw a symbol to the current cursor location
-  drawChar(symbolID, FontStyle::EXTRAS);
+  drawChar(symbolID, FontStyle::EXTRAS, 0);
 }
 
 // Draw an area, but y must be aligned on 0/8 offset

--- a/source/Core/Drivers/OLED.hpp
+++ b/source/Core/Drivers/OLED.hpp
@@ -78,10 +78,7 @@ enum class FontStyle {
 
 class OLED {
 public:
-  enum DisplayState : bool {
-    OFF = false,
-    ON  = true
-  };
+  enum DisplayState : bool { OFF = false, ON = true };
 
   static void initialize(); // Startup the I2C coms (brings screen out of reset etc)
   static bool isInitDone();
@@ -120,7 +117,7 @@ public:
   static void    setInverseDisplay(bool inverted);
   static int16_t getCursorX() { return cursor_x; }
   // Draw a string to the current location, with selected font; optionally - with MAX length only
-  static void print(const char *string, FontStyle fontStyle, uint8_t length = 255);
+  static void print(const char *string, FontStyle fontStyle, uint8_t length = 255, const uint8_t soft_x_limit = 0);
   static void printWholeScreen(const char *string);
   // Print *F or *C - in font style of Small, Large (by default) or Extra based on input arg
   static void printSymbolDeg(FontStyle fontStyle = FontStyle::LARGE);
@@ -166,7 +163,7 @@ private:
     displayChecksum = hash;
     return result;
   }
-  static void         drawChar(uint16_t charCode, FontStyle fontStyle); // Draw a character to the current cursor location
+  static void         drawChar(uint16_t charCode, FontStyle fontStyle, const uint8_t soft_x_limit); // Draw a character to the current cursor location
   static void         setFramebuffer(uint8_t *buffer);
   static uint8_t     *stripPointers[4]; // Pointers to the strips to allow for buffer having extra content
   static bool         inLeftHandedMode; // Whether the screen is in left or not (used for offsets in GRAM)

--- a/source/Core/Drivers/USBPD.cpp
+++ b/source/Core/Drivers/USBPD.cpp
@@ -136,7 +136,7 @@ bool parseCapabilitiesArray(const uint8_t numCaps, uint8_t *bestIndex, uint16_t 
 
   // Fudge of 0.5 ohms to round up a little to account for us always having off periods in PWM
   uint8_t tipResistance = getTipResistanceX10();
-  if (getSettingValue(SettingsOptions::PDVpdo) == 1) {
+  if (getSettingValue(SettingsOptions::USBPDMode) == 1) {
     tipResistance += 5;
   }
 #ifdef MODEL_HAS_DCDC
@@ -170,7 +170,7 @@ bool parseCapabilitiesArray(const uint8_t numCaps, uint8_t *bestIndex, uint16_t 
           }
         }
       }
-    } else if ((lastCapabilities[i] & PD_PDO_TYPE) == PD_PDO_TYPE_AUGMENTED && getSettingValue(SettingsOptions::PDVpdo)) {
+    } else if ((lastCapabilities[i] & PD_PDO_TYPE) == PD_PDO_TYPE_AUGMENTED && getSettingValue(SettingsOptions::USBPDMode)) {
       bool sourceIsEPRCapable = lastCapabilities[0] & PD_PDO_SRC_FIXED_EPR_CAPABLE;
       bool isPPS              = false;
       bool isAVS              = false;

--- a/source/Core/Drivers/USBPD.cpp
+++ b/source/Core/Drivers/USBPD.cpp
@@ -135,7 +135,10 @@ bool parseCapabilitiesArray(const uint8_t numCaps, uint8_t *bestIndex, uint16_t 
   *bestVoltage = 5000; // Default 5V
 
   // Fudge of 0.5 ohms to round up a little to account for us always having off periods in PWM
-  uint8_t tipResistance = getTipResistanceX10() + 5;
+  uint8_t tipResistance = getTipResistanceX10();
+  if (getSettingValue(SettingsOptions::PDVpdo) == 1) {
+    tipResistance += 5;
+  }
 #ifdef MODEL_HAS_DCDC
   // If this device has step down DC/DC inductor to smooth out current spikes
   // We can instead ignore resistance and go for max voltage we can accept; and rely on the DC/DC regulation to keep under current limit

--- a/source/Core/Drivers/Utils.cpp
+++ b/source/Core/Drivers/Utils.cpp
@@ -22,7 +22,10 @@ int32_t Utils::InterpolateLookupTable(const int32_t *lookupTable, const int noIt
 int32_t Utils::LinearInterpolate(int32_t x1, int32_t y1, int32_t x2, int32_t y2, int32_t x) { return y1 + (((((x - x1) * 1000) / (x2 - x1)) * (y2 - y1))) / 1000; }
 
 uint16_t Utils::RequiredCurrentForTipAtVoltage(uint16_t voltageX10) {
-  uint8_t tipResistancex10 = getTipResistanceX10() + 5;
+  uint8_t tipResistancex10 = getTipResistanceX10();
+  if (getSettingValue(SettingsOptions::PDVpdo) == 1) {
+    tipResistancex10 += 5;
+  }
 #ifdef MODEL_HAS_DCDC
   // If this device has step down DC/DC inductor to smooth out current spikes
   // We can instead ignore resistance and go for max voltage we can accept; and rely on the DC/DC regulation to keep under current limit

--- a/source/Core/Drivers/Utils.cpp
+++ b/source/Core/Drivers/Utils.cpp
@@ -23,7 +23,7 @@ int32_t Utils::LinearInterpolate(int32_t x1, int32_t y1, int32_t x2, int32_t y2,
 
 uint16_t Utils::RequiredCurrentForTipAtVoltage(uint16_t voltageX10) {
   uint8_t tipResistancex10 = getTipResistanceX10();
-  if (getSettingValue(SettingsOptions::PDVpdo) == 1) {
+  if (getSettingValue(SettingsOptions::USBPDMode) == 1) {
     tipResistancex10 += 5;
   }
 #ifdef MODEL_HAS_DCDC

--- a/source/Core/Inc/Settings.h
+++ b/source/Core/Inc/Settings.h
@@ -52,7 +52,7 @@ enum SettingsOptions {
   LOGOTime                       = 35, // Duration the logo will be displayed for
   CalibrateCJC                   = 36, // Toggle calibrate CJC at next boot
   BluetoothLE                    = 37, // Toggle BLE if present
-  PDVpdo                         = 38, // Toggle PPS & EPR
+  USBPDMode                      = 38, // Toggle PPS & EPR
   ProfilePhases                  = 39, // Number of profile mode phases
   ProfilePreheatTemp             = 40, // Temperature to preheat to before the first phase
   ProfilePreheatSpeed            = 41, // Maximum allowed preheat speed in degrees per second

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -145,6 +145,9 @@ struct TranslationIndexTable {
   uint16_t SettingStartSleepOffChar;
   uint16_t SettingLockBoostChar;
   uint16_t SettingLockFullChar;
+  uint16_t USBPDModeDefault;
+  uint16_t USBPDModeNoDynamic;
+  uint16_t USBPDModeSafe;
 
   uint16_t SettingsDescriptions[static_cast<uint32_t>(SettingsItemIndex::NUM_ITEMS)];
   uint16_t SettingsShortNames[static_cast<uint32_t>(SettingsItemIndex::NUM_ITEMS)];

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -59,7 +59,7 @@ enum class SettingsItemIndex : uint8_t {
   MinVolCell,
   QCMaxVoltage,
   PDNegTimeout,
-  PDVpdo,
+  USBPDMode,
   BoostTemperature,
   AutoStart,
   TempChangeShortStep,

--- a/source/Core/Src/Settings.cpp
+++ b/source/Core/Src/Settings.cpp
@@ -89,7 +89,7 @@ static const SettingConstants settingsConstants[(int)SettingsOptions::SettingsOp
     {                     0,                                 6,                 1,                            1}, // LOGOTime
     {                     0,                                 1,                 1,                            0}, // CalibrateCJC
     {                     0,                                 1,                 1,                            0}, // BluetoothLE
-    {                     0,                                 1,                 1,                            1}, // PDVpdo
+    {                     0,                                 2,                 1,                            1}, // PDVpdo
     {                     1,                                 5,                 1,                            4}, // ProfilePhases
     {            MIN_TEMP_C,                        MAX_TEMP_F,                 5,                           90}, // ProfilePreheatTemp
     {                     1,                                10,                 1,                            1}, // ProfilePreheatSpeed

--- a/source/Core/Src/Settings.cpp
+++ b/source/Core/Src/Settings.cpp
@@ -89,7 +89,7 @@ static const SettingConstants settingsConstants[(int)SettingsOptions::SettingsOp
     {                     0,                                 6,                 1,                            1}, // LOGOTime
     {                     0,                                 1,                 1,                            0}, // CalibrateCJC
     {                     0,                                 1,                 1,                            0}, // BluetoothLE
-    {                     0,                                 2,                 1,                            1}, // PDVpdo
+    {                     0,                                 2,                 1,                            1}, // USBPDMode
     {                     1,                                 5,                 1,                            4}, // ProfilePhases
     {            MIN_TEMP_C,                        MAX_TEMP_F,                 5,                           90}, // ProfilePreheatTemp
     {                     1,                                10,                 1,                            1}, // ProfilePreheatSpeed

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -26,7 +26,7 @@ static void displayQCInputV(void);
 
 #ifdef POW_PD
 static void displayPDNegTimeout(void);
-static void displayPDVpdo(void);
+static void displayUSBPDMode(void);
 #endif /* POW_PD */
 
 static void displaySensitivity(void);
@@ -131,7 +131,7 @@ static void displayAdvancedMenu(void);
  *  -Minimum Voltage
  *  QC Voltage
  *  PD Timeout
- *  PDVpdo
+ *  USBPDMode
  *
  * Soldering
  *  Boost Mode Temp
@@ -232,7 +232,7 @@ const menuitem powerMenu[] = {
    * -Minimum Voltage
    * QC Voltage
    * PD Timeout
-   * PDVpdo
+   * USBPDMode
    */
 #ifdef POW_DC
   /* Voltage input */
@@ -248,7 +248,7 @@ const menuitem powerMenu[] = {
   /* PD timeout setup */
   {SETTINGS_DESC(SettingsItemIndex::PDNegTimeout), nullptr, displayPDNegTimeout, nullptr, SettingsOptions::PDNegTimeout, SettingsItemIndex::PDNegTimeout, 6},
   /* Toggle PPS & EPR */
-  {SETTINGS_DESC(SettingsItemIndex::PDVpdo), nullptr, displayPDVpdo, nullptr, SettingsOptions::PDVpdo, SettingsItemIndex::PDVpdo, 7},
+  {SETTINGS_DESC(SettingsItemIndex::USBPDMode), nullptr, displayUSBPDMode, nullptr, SettingsOptions::USBPDMode, SettingsItemIndex::USBPDMode, 7},
 #endif
   /* vvvv end of menu marker. DO NOT REMOVE vvvv */
   {0, nullptr, nullptr, nullptr, SettingsOptions::SettingsOptionsLength, SettingsItemIndex::NUM_ITEMS, 0}
@@ -433,7 +433,7 @@ const menuitem advancedMenu[] = {
 /* clang-format on */
 
 const menuitem *subSettingsMenus[] {
-#if defined(POW_DC) || defined(POW_QC) || defined(POW_PD)
+#if defined(POW_DC) || defined(POW_QC) || defined(POW_PD) || defined(POW_PD_EXT)
   powerMenu,
 #endif
       solderingMenu, PowerSavingMenu, UIMenu, advancedMenu,
@@ -529,7 +529,26 @@ static void displayPDNegTimeout(void) {
   }
 }
 
-static void displayPDVpdo(void) { OLED::drawCheckbox(getSettingValue(SettingsOptions::PDVpdo)); }
+static void displayUSBPDMode(void) {
+  /*
+   * PD Mode
+   * 0 = Safe mode, no PPS, no EPR
+   * 1 = Default mode, tolerant + PPS + EPR
+   * 2 = Strict mode + PPS + EPR
+   */
+
+  switch (getSettingValue(SettingsOptions::USBPDMode)) {
+  case 1:
+    OLED::print(translatedString(Tr->SettingPDModeDefaultChar), FontStyle::LARGE);
+    break;
+  case 2:
+    OLED::print(translatedString(Tr->SettingPDModeSafeChar), FontStyle::LARGE);
+    break;
+  default:
+    OLED::print(translatedString(Tr->SettingPDModeNoDynamicChar), FontStyle::LARGE);
+    break;
+  }
+}
 
 #endif /* POW_PD */
 

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -433,7 +433,7 @@ const menuitem advancedMenu[] = {
 /* clang-format on */
 
 const menuitem *subSettingsMenus[] {
-#if defined(POW_DC) || defined(POW_QC) || defined(POW_PD) || defined(POW_PD_EXT)
+#if defined(POW_DC) || defined(POW_QC) || defined(POW_PD)
   powerMenu,
 #endif
       solderingMenu, PowerSavingMenu, UIMenu, advancedMenu,

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -248,7 +248,7 @@ const menuitem powerMenu[] = {
   /* PD timeout setup */
   {SETTINGS_DESC(SettingsItemIndex::PDNegTimeout), nullptr, displayPDNegTimeout, nullptr, SettingsOptions::PDNegTimeout, SettingsItemIndex::PDNegTimeout, 6},
   /* Toggle PPS & EPR */
-  {SETTINGS_DESC(SettingsItemIndex::USBPDMode), nullptr, displayUSBPDMode, nullptr, SettingsOptions::USBPDMode, SettingsItemIndex::USBPDMode, 7},
+  {SETTINGS_DESC(SettingsItemIndex::USBPDMode), nullptr, displayUSBPDMode, nullptr, SettingsOptions::USBPDMode, SettingsItemIndex::USBPDMode, 4},
 #endif
   /* vvvv end of menu marker. DO NOT REMOVE vvvv */
   {0, nullptr, nullptr, nullptr, SettingsOptions::SettingsOptionsLength, SettingsItemIndex::NUM_ITEMS, 0}
@@ -539,13 +539,13 @@ static void displayUSBPDMode(void) {
 
   switch (getSettingValue(SettingsOptions::USBPDMode)) {
   case 1:
-    OLED::print(translatedString(Tr->SettingPDModeDefaultChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->USBPDModeDefault), FontStyle::SMALL, 255, OLED::getCursorX());
     break;
   case 2:
-    OLED::print(translatedString(Tr->SettingPDModeSafeChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->USBPDModeSafe), FontStyle::SMALL, 255, OLED::getCursorX());
     break;
   default:
-    OLED::print(translatedString(Tr->SettingPDModeNoDynamicChar), FontStyle::LARGE);
+    OLED::print(translatedString(Tr->USBPDModeNoDynamic), FontStyle::SMALL, 255, OLED::getCursorX());
     break;
   }
 }

--- a/source/dfuse-pack.py
+++ b/source/dfuse-pack.py
@@ -256,7 +256,7 @@ if __name__ == "__main__":
                 sys.exit(1)
             for hexf in options.hexfiles:
                 ih = IntelHex(hexf)
-                for (address, end) in ih.segments():
+                for address, end in ih.segments():
                     try:
                         address = address & 0xFFFFFFFF
                     except ValueError:

--- a/source/metadata.py
+++ b/source/metadata.py
@@ -12,8 +12,12 @@ import sys
 
 if len(sys.argv) < 2 or len(sys.argv) > 3:
     print("Usage: metadata.py OUTPUT_FILE [model]")
-    print("  OUTPUT_FILE      - the name of output file in json format with meta info about binary files")
-    print("  model [optional] - name of the model (as for `make model=NAME`) to scan files for explicitly (all files in source/Hexfile by default otherwise)")
+    print(
+        "  OUTPUT_FILE      - the name of output file in json format with meta info about binary files"
+    )
+    print(
+        "  model [optional] - name of the model (as for `make model=NAME`) to scan files for explicitly (all files in source/Hexfile by default otherwise)"
+    )
     exit(1)
 
 # If model is provided explicitly to scan related files only for json output, then process the argument
@@ -30,15 +34,18 @@ HexFileFolder = os.path.join(HERE, "Hexfile")
 OutputJSONPath = os.path.join(HexFileFolder, sys.argv[1])
 TranslationsFilesPath = os.path.join(HERE.parent, "Translations")
 
+
 def load_json(filename: str):
     with open(filename) as f:
         return json.loads(f.read())
+
 
 def read_git_tag():
     if os.environ.get("GITHUB_CI_PR_SHA", "") != "":
         return os.environ["GITHUB_CI_PR_SHA"][:7].upper()
     else:
         return f"{subprocess.check_output(['git', 'rev-parse', '--short=7', 'HEAD']).strip().decode('ascii').upper()}"
+
 
 def read_version():
     with open(HERE / "version.h") as version_file:
@@ -49,9 +56,18 @@ def read_version():
                     return matches[0]
     raise Exception("Could not parse version")
 
+
 # Fetch our file listings
-translation_files = [os.path.join(TranslationsFilesPath, f) for f in os.listdir(TranslationsFilesPath) if os.path.isfile(os.path.join(TranslationsFilesPath, f)) and f.endswith(".json")]
-output_files = [os.path.join(HexFileFolder, f) for f in sorted(os.listdir(HexFileFolder)) if os.path.isfile(os.path.join(HexFileFolder, f))]
+translation_files = [
+    os.path.join(TranslationsFilesPath, f)
+    for f in os.listdir(TranslationsFilesPath)
+    if os.path.isfile(os.path.join(TranslationsFilesPath, f)) and f.endswith(".json")
+]
+output_files = [
+    os.path.join(HexFileFolder, f)
+    for f in sorted(os.listdir(HexFileFolder))
+    if os.path.isfile(os.path.join(HexFileFolder, f))
+]
 
 parsed_languages = {}
 for path in translation_files:
@@ -74,7 +90,9 @@ for file_path in output_files:
             if not name.startswith(ModelName + "_"):
                 continue
             # If build of interest is not multi-lang one but scanning one is not MODEL_LANG-ID here, then skip it to avoid mess in json between MODEL_LANG-ID & MODEL_multi'
-            if not ModelName.endswith("_multi") and not re.match(r"^" + ModelName + "_" + "([A-Z]+).*$", name):
+            if not ModelName.endswith("_multi") and not re.match(
+                r"^" + ModelName + "_" + "([A-Z]+).*$", name
+            ):
                 continue
         matches = re.findall(r"^([a-zA-Z0-9]+)_(.+)\.(.+)$", name)
         if matches:
@@ -86,10 +104,17 @@ for file_path in output_files:
                 lang_file = parsed_languages.get(lang_code, None)
                 if lang_file is None and lang_code.startswith("multi_"):
                     # Multi files wont match, but we fake this by just taking the filename to it
-                    lang_file = {"languageLocalName": lang_code.replace("multi_", "").replace("compressed_", "")}
+                    lang_file = {
+                        "languageLocalName": lang_code.replace("multi_", "").replace(
+                            "compressed_", ""
+                        )
+                    }
                 if lang_file is None:
                     raise Exception(f"Could not match language code {lang_code}")
-                file_record = {"language_code": lang_code, "language_name": lang_file.get("languageLocalName", None)}
+                file_record = {
+                    "language_code": lang_code,
+                    "language_name": lang_file.get("languageLocalName", None),
+                }
                 output_json["contents"][name] = file_record
             else:
                 print(f"failed to parse {matches}")


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
Fixes #1904 by providing user control for how we select input.

* **What is the new behavior (if this is a feature change)?**

This expands the PD menu setting from enable/disable VDPO to instead have 3 options:
1. Padding 0.5 ohm + PPS/EPR enabled
2. No Padding 0.5 ohm + PPS/EPR enabled
3. No Padding 0.5 + PPS/EPR disabled (just fixed PDO's)


* **Other information**:

This is currently _a_ solution to the problem. I can't make SRAM over hard-reset be reliable enough in all cases to do this magically easily. I also have supplies that do not fill out the overload bits 😓 .

Would love feedback, tests or reviews.

Note: `shell_check` CI action is breaking due to diff size, will be ignored for merge.