### PR TITLE
Sequre Faster PWM

### DIFF
--- a/source/Core/BSP/Sequre_S60/BSP.cpp
+++ b/source/Core/BSP/Sequre_S60/BSP.cpp
@@ -105,7 +105,7 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim) {
     if (PWMSafetyTimer == 0) {
       htim4.Instance->CCR3 = 0;
     } else {
-      htim4.Instance->CCR3 = pendingPWM;
+      htim4.Instance->CCR3 = pendingPWM / 4;
     }
   } else if (htim->Instance == TIM1) {
     // STM uses this for internal functions as a counter for timeouts

--- a/source/Core/BSP/Sequre_S60/Setup.cpp
+++ b/source/Core/BSP/Sequre_S60/Setup.cpp
@@ -57,7 +57,7 @@ void        Setup_HAL() {
     GPIO_InitStruct.Pin   = MOVEMENT_Pin;
     GPIO_InitStruct.Mode  = GPIO_MODE_INPUT;
     GPIO_InitStruct.Pull  = GPIO_PULLDOWN;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH; // We would like sharp rising edges
+    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
     HAL_GPIO_Init(MOVEMENT_GPIO_Port, &GPIO_InitStruct);
   }
 }
@@ -254,23 +254,20 @@ static void MX_IWDG_Init(void) {
 
 static void MX_TIM4_Init(void) {
   /*
-   * We use the channel 1 to trigger the ADC at end of PWM period
-   * And we use the channel 4 as the PWM modulation source using Interrupts
+   * On Sequre devies we run the output PWM as fast as possible due to the low tip resistance + no inductor for filtering.
+   * So we run it as fast as we can and hope that the caps filter out the current spikes.
    * */
   TIM_ClockConfigTypeDef  sClockSourceConfig;
   TIM_MasterConfigTypeDef sMasterConfig;
   TIM_OC_InitTypeDef      sConfigOC;
   memset(&sConfigOC, 0, sizeof(sConfigOC));
-  // Timer 2 is fairly slow as its being used to run the PWM and trigger the ADC
-  // in the PWM off time.
+
   htim4.Instance = TIM4;
   // dummy value, will be reconfigured by BSPInit()
-  htim4.Init.Prescaler = 10; // 2 MHz timer clock/1000 = 2 kHz tick rate
+  htim4.Init.Prescaler = 10; // 2 MHz timer clock/10 = 200 kHz tick rate
 
-  // pwm out is 10k from tim3, we want to run our PWM at around 10hz or slower on the output stage
-  // These values give a rate of around 3.5 Hz for "fast" mode and 1.84 Hz for "slow"
   htim4.Init.CounterMode = TIM_COUNTERMODE_UP;
-  htim4.Init.Period      = 255;
+  htim4.Init.Period      = 64;
 
   htim4.Init.ClockDivision     = TIM_CLOCKDIVISION_DIV1; // 8 MHz (x2 APB1) before divide
   htim4.Init.AutoReloadPreload = TIM_AUTORELOAD_PRELOAD_DISABLE;

--- a/source/Core/BSP/Sequre_S60/configuration.h
+++ b/source/Core/BSP/Sequre_S60/configuration.h
@@ -148,7 +148,7 @@
 
 #define HARDWARE_MAX_WATTAGE_X10 600
 
-#define TIP_THERMAL_MASS    8   // X10 watts to raise 1 deg C in 1 second
+#define TIP_THERMAL_MASS    10  // X10 watts to raise 1 deg C in 1 second
 #define TIP_THERMAL_INERTIA 128 // We use a large inertia value to smooth out the drive to the tip since its stupidly sensitive
 
 #define TIP_RESISTANCE 20 //(actually 2.5 ish but we need to be more conservative on pwm'ing watt limit) x10 ohms
@@ -162,6 +162,7 @@
 #define TEMP_NTC
 #define I2C_SOFT_BUS_2 // For now we are doing software I2C to get around hardware chip issues
 #define OLED_I2CBB2
+#define FILTER_DISPLAYED_TIP_TEMP 4 // Filtering for GUI display
 
 #define MODEL_HAS_DCDC // We dont have DC/DC but have reallly fast PWM that gets us roughly the same place
 #endif                 /* S60 */
@@ -179,7 +180,7 @@
 
 #define HARDWARE_MAX_WATTAGE_X10 600
 
-#define TIP_THERMAL_MASS    8   // X10 watts to raise 1 deg C in 1 second
+#define TIP_THERMAL_MASS    10  // X10 watts to raise 1 deg C in 1 second
 #define TIP_THERMAL_INERTIA 128 // We use a large inertia value to smooth out the drive to the tip since its stupidly sensitive
 
 #define TIP_RESISTANCE 20 //(actually 2.5 ish but we need to be more conservative on pwm'ing watt limit) x10 ohms
@@ -193,6 +194,7 @@
 #define TEMP_NTC
 #define I2C_SOFT_BUS_2 // For now we are doing software I2C to get around hardware chip issues
 #define OLED_I2CBB2
+#define FILTER_DISPLAYED_TIP_TEMP 4 // Filtering for GUI display
 
 #define MODEL_HAS_DCDC // We dont have DC/DC but have reallly fast PWM that gets us roughly the same place
 #endif                 /* S60P */


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
Bumps the PWM rate for the Sequre S60/S60P.
For me this improves performance a fair bit.
Also added a UX filter to the display temp to make it easier to track with the eye.


* **What is the current behavior?**
<!-- (You can also just link to an open issue here) -->

* **What is the new behavior (if this is a feature change)?**

* **Other information**:
