### PR TITLE
Add enum for USB PD modes

### DIFF
--- a/source/Core/Drivers/FS2711.cpp
+++ b/source/Core/Drivers/FS2711.cpp
@@ -158,7 +158,7 @@ void FS2711::negotiate() {
   // FS2711 uses mV instead of V
   const uint16_t vmax           = USB_PD_VMAX * 1000;
   uint8_t        tip_resistance = getTipResistanceX10();
-  if (getSettingValue(SettingsOptions::USBPDMode) == 1) {
+  if (getSettingValue(SettingsOptions::USBPDMode) == usbpdMode_t::DEFAULT) {
     tip_resistance += 5;
   }
 

--- a/source/Core/Drivers/USBPD.cpp
+++ b/source/Core/Drivers/USBPD.cpp
@@ -136,7 +136,7 @@ bool parseCapabilitiesArray(const uint8_t numCaps, uint8_t *bestIndex, uint16_t 
 
   // Fudge of 0.5 ohms to round up a little to account for us always having off periods in PWM
   uint8_t tipResistance = getTipResistanceX10();
-  if (getSettingValue(SettingsOptions::USBPDMode) == 1) {
+  if (getSettingValue(SettingsOptions::USBPDMode) == usbpdMode_t::DEFAULT) {
     tipResistance += 5;
   }
 #ifdef MODEL_HAS_DCDC

--- a/source/Core/Drivers/Utils.cpp
+++ b/source/Core/Drivers/Utils.cpp
@@ -23,7 +23,7 @@ int32_t Utils::LinearInterpolate(int32_t x1, int32_t y1, int32_t x2, int32_t y2,
 
 uint16_t Utils::RequiredCurrentForTipAtVoltage(uint16_t voltageX10) {
   uint8_t tipResistancex10 = getTipResistanceX10();
-  if (getSettingValue(SettingsOptions::USBPDMode) == 1) {
+  if (getSettingValue(SettingsOptions::USBPDMode) == usbpdMode_t::DEFAULT) {
     tipResistancex10 += 5;
   }
 #ifdef MODEL_HAS_DCDC

--- a/source/Core/Inc/Settings.h
+++ b/source/Core/Inc/Settings.h
@@ -104,6 +104,12 @@ typedef enum {
   INFINITY = 6, // Show boot logo on repeat (if animated) until a button toggled
 } logoMode_t;
 
+typedef enum {
+  DEFAULT    = 1, // PPS + EPR + more power request through increasing resistance by 0.5 Ohm
+  SAFE       = 2, // PPS + EPR, without requesting more power
+  NO_DYNAMIC = 0, // Disabled, fixed PDO only
+} usbpdMode_t;
+
 // Settings wide operations
 void saveSettings();
 bool loadSettings();

--- a/source/Core/Inc/Settings.h
+++ b/source/Core/Inc/Settings.h
@@ -105,9 +105,9 @@ typedef enum {
 } logoMode_t;
 
 typedef enum {
-  DEFAULT    = 1, // PPS + EPR + more power request through increasing resistance by 0.5 Ohm
+  DEFAULT    = 1, // PPS + EPR + more power request through increasing resistance by 0.5 Ohm to compensate power loss over cable/PCB/etc.
   SAFE       = 2, // PPS + EPR, without requesting more power
-  NO_DYNAMIC = 0, // Disabled, fixed PDO only
+  NO_DYNAMIC = 0, // PPS + EPR disabled, fixed PDO only
 } usbpdMode_t;
 
 // Settings wide operations

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -532,9 +532,9 @@ static void displayPDNegTimeout(void) {
 static void displayUSBPDMode(void) {
   /*
    * Supported PD modes:
-   *  DEFAULT,    1 = PPS + EPR + more power request through increasing resistance by 0.5 Ohm
+   *  DEFAULT,    1 = PPS + EPR + more power request through increasing resistance by 0.5 Ohm to compensate power loss over cable/PCB/etc.
    *  SAFE,       2 = PPS + EPR, without requesting more power
-   *  NO_DYNAMIC, 0 = Disabled, fixed PDO only
+   *  NO_DYNAMIC, 0 = PPS + EPR disabled, fixed PDO only
    */
 
   switch (getSettingValue(SettingsOptions::USBPDMode)) {

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -531,19 +531,20 @@ static void displayPDNegTimeout(void) {
 
 static void displayUSBPDMode(void) {
   /*
-   * PD Mode
-   * 0 = Safe mode, no PPS, no EPR
-   * 1 = Default mode, tolerant + PPS + EPR
-   * 2 = Strict mode + PPS + EPR
+   * Supported PD modes:
+   *  DEFAULT,    1 = PPS + EPR + more power request through increasing resistance by 0.5 Ohm
+   *  SAFE,       2 = PPS + EPR, without requesting more power
+   *  NO_DYNAMIC, 0 = Disabled, fixed PDO only
    */
 
   switch (getSettingValue(SettingsOptions::USBPDMode)) {
-  case 1:
+  case usbpdMode_t::DEFAULT:
     OLED::print(translatedString(Tr->USBPDModeDefault), FontStyle::SMALL, 255, OLED::getCursorX());
     break;
-  case 2:
+  case usbpdMode_t::SAFE:
     OLED::print(translatedString(Tr->USBPDModeSafe), FontStyle::SMALL, 255, OLED::getCursorX());
     break;
+  case usbpdMode_t::NO_DYNAMIC:
   default:
     OLED::print(translatedString(Tr->USBPDModeNoDynamic), FontStyle::SMALL, 255, OLED::getCursorX());
     break;


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Small refactoring by adding `enum` for USB PD modes.

* **What is the current behavior?**
USB PD mode related code uses constants.

* **What is the new behavior (if this is a feature change)?**
USB PD mode related code uses self-documenting `enum` values.

* **Other information**:
I took some liberty to update comments as well based on information provided from PR #1917 and from its _"code review"_ comment to make it more clear for those who will be looking through the code next time.

As always, let me know what you think.