### PR TITLE
Implement OLED::drawUnavailableIcon() to simplify duplicated calls

### DIFF
--- a/source/Core/Drivers/OLED.hpp
+++ b/source/Core/Drivers/OLED.hpp
@@ -136,6 +136,7 @@ public:
   static void drawBattery(uint8_t state) { drawSymbol(3 + (state > 10 ? 10 : state)); }
   // Draws a checkbox
   static void drawCheckbox(bool state) { drawSymbol((state) ? 16 : 17); }
+  inline static void drawUnavailableIcon() { drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, UnavailableIcon); }
   static void debugNumber(int32_t val, FontStyle fontStyle);
   static void drawHex(uint32_t x, FontStyle fontStyle, uint8_t digits);
   static void drawSymbol(uint8_t symbolID);                                                           // Used for drawing symbols of a predictable width

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -522,11 +522,7 @@ static void displayQCInputV(void) {
 
 static void displayPDNegTimeout(void) {
   auto value = getSettingValue(SettingsOptions::PDNegTimeout);
-  if (value == 0) {
-    OLED::drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, UnavailableIcon);
-  } else {
-    OLED::printNumber(value, 2, FontStyle::LARGE);
-  }
+  value ? OLED::printNumber(value, 2, FontStyle::LARGE) : OLED::drawUnavailableIcon();
 }
 
 static void displayUSBPDMode(void) {
@@ -583,14 +579,14 @@ static void displayBoostTemp(void) {
   if (getSettingValue(SettingsOptions::BoostTemp)) {
     OLED::printNumber(getSettingValue(SettingsOptions::BoostTemp), 3, FontStyle::LARGE);
   } else {
-    OLED::drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, UnavailableIcon);
+    OLED::drawUnavailableIcon();
   }
 }
 
 static void displayAutomaticStartMode(void) {
   switch (getSettingValue(SettingsOptions::AutoStartMode)) {
   case autoStartMode_t::NO:
-    OLED::drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, UnavailableIcon);
+    OLED::drawUnavailableIcon();
     break;
   case autoStartMode_t::SOLDER:
     OLED::print(translatedString(Tr->SettingStartSolderingChar), FontStyle::LARGE);
@@ -602,7 +598,7 @@ static void displayAutomaticStartMode(void) {
     OLED::print(translatedString(Tr->SettingStartSleepOffChar), FontStyle::LARGE);
     break;
   default:
-    OLED::drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, UnavailableIcon);
+    OLED::drawUnavailableIcon();
     break;
   }
 }
@@ -614,7 +610,7 @@ static void displayTempChangeLongStep(void) { OLED::printNumber(getSettingValue(
 static void displayLockingMode(void) {
   switch (getSettingValue(SettingsOptions::LockingMode)) {
   case 0:
-    OLED::drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, UnavailableIcon);
+    OLED::drawUnavailableIcon();
     break;
   case 1:
     OLED::print(translatedString(Tr->SettingLockBoostChar), FontStyle::LARGE);
@@ -623,7 +619,7 @@ static void displayLockingMode(void) {
     OLED::print(translatedString(Tr->SettingLockFullChar), FontStyle::LARGE);
     break;
   default:
-    OLED::drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, UnavailableIcon);
+    OLED::drawUnavailableIcon();
     break;
   }
 }
@@ -683,7 +679,7 @@ static void displaySensitivity(void) {
   if (getSettingValue(SettingsOptions::Sensitivity)) {
     OLED::printNumber(getSettingValue(SettingsOptions::Sensitivity), 1, FontStyle::LARGE, false);
   } else {
-    OLED::drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, UnavailableIcon);
+    OLED::drawUnavailableIcon();
   }
 }
 static bool showSleepOptions(void) { return getSettingValue(SettingsOptions::Sensitivity) > 0; }
@@ -712,7 +708,7 @@ static void displaySleepTemp(void) { OLED::printNumber(getSettingValue(SettingsO
 
 static void displaySleepTime(void) {
   if (getSettingValue(SettingsOptions::SleepTime) == 0) {
-    OLED::drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, UnavailableIcon);
+    OLED::drawUnavailableIcon();
   } else if (getSettingValue(SettingsOptions::SleepTime) < 6) {
     OLED::printNumber(getSettingValue(SettingsOptions::SleepTime) * 10, 2, FontStyle::LARGE);
     OLED::print(LargeSymbolSeconds, FontStyle::LARGE);
@@ -726,7 +722,7 @@ static void displaySleepTime(void) {
 
 static void displayShutdownTime(void) {
   if (getSettingValue(SettingsOptions::ShutdownTime) == 0) {
-    OLED::drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, UnavailableIcon);
+    OLED::drawUnavailableIcon();
   } else {
     OLED::printNumber(getSettingValue(SettingsOptions::ShutdownTime), 2, FontStyle::LARGE);
     OLED::print(LargeSymbolMinutes, FontStyle::LARGE);
@@ -738,7 +734,7 @@ static void displayHallEffect(void) {
   if (getSettingValue(SettingsOptions::HallEffectSensitivity)) {
     OLED::printNumber(getSettingValue(SettingsOptions::HallEffectSensitivity), 1, FontStyle::LARGE, false);
   } else {
-    OLED::drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, UnavailableIcon);
+    OLED::drawUnavailableIcon();
   }
 }
 static bool showHallEffect(void) { return getHallSensorFitted(); }
@@ -836,7 +832,7 @@ static void displayAnimationSpeed(void) {
     OLED::print(translatedString(Tr->SettingFastChar), FontStyle::LARGE);
     break;
   default:
-    OLED::drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, UnavailableIcon);
+    OLED::drawUnavailableIcon();
     break;
   }
 }
@@ -859,7 +855,7 @@ static void displayInvertColor(void) {
 static void displayLogoTime(void) {
   switch (getSettingValue(SettingsOptions::LOGOTime)) {
   case logoMode_t::SKIP:
-    OLED::drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, UnavailableIcon);
+    OLED::drawUnavailableIcon();
     break;
   case logoMode_t::ONETIME:
     OLED::drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, RepeatOnce);
@@ -884,7 +880,7 @@ static void displayBluetoothLE(void) { OLED::drawCheckbox(getSettingValue(Settin
 
 static void displayPowerLimit(void) {
   if (getSettingValue(SettingsOptions::PowerLimit) == 0) {
-    OLED::drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, UnavailableIcon);
+    OLED::drawUnavailableIcon();
   } else {
     OLED::printNumber(getSettingValue(SettingsOptions::PowerLimit), 3, FontStyle::LARGE);
     OLED::print(LargeSymbolWatts, FontStyle::LARGE);
@@ -952,7 +948,7 @@ static void displayPowerPulse(void) {
     OLED::print(LargeSymbolDot, FontStyle::LARGE);
     OLED::printNumber(getSettingValue(SettingsOptions::KeepAwakePulse) % 10, 1, FontStyle::LARGE);
   } else {
-    OLED::drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, UnavailableIcon);
+    OLED::drawUnavailableIcon();
   }
 }
 


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Implement `OLED::drawUnavailableIcon()` to simplify duplicated calls.

* **What is the current behavior?**
Multiple calls of `OLED::drawArea(OLED_WIDTH - 16 - 2, 0, 16, 16, UnavailableIcon)` in `settingsGUI.cpp` with magic constants.

* **What is the new behavior (if this is a feature change)?**
Simply call `OLED::drawUnavailableIcon()` to draw `UnavailableIcon` which helps:
  - hide magic constants under the hood;
  - remove duplicated calls;
  - simplify future updates/extends for related call in the case of need by changing logic in one single place.

* **Other information**:
Check this another one small trivial refactoring out. ;)
I'm not sure about the necessity of `inline` but I just wanted to give compilers explicit directive to make calls _in place_ to make sure.