### PR TITLE
Keep the locked warning for some time

### DIFF
--- a/source/Core/Threads/UI/logic/OperatingModes.h
+++ b/source/Core/Threads/UI/logic/OperatingModes.h
@@ -62,6 +62,7 @@ struct guiContext {
     uint32_t state4; // 32 bit state scratch
     uint16_t state5; // 16 bit state scratch
     uint16_t state6; // 16 bit state scratch
+    uint32_t state7; // 32 bit state scratch
 
   } scratch_state;
 };

--- a/source/Core/Threads/UI/logic/Soldering.cpp
+++ b/source/Core/Threads/UI/logic/Soldering.cpp
@@ -17,7 +17,7 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
           cxt->scratch_state.state7 = 0;
         }
       } else {
-        warnUser(translatedString(Tr->WarningKeysLockedString), buttons);
+        warnUser(translatedString(Tr->LockingKeysString), buttons);
       }
       return OperatingMode::Soldering;
     }

--- a/source/Core/Threads/UI/logic/Soldering.cpp
+++ b/source/Core/Threads/UI/logic/Soldering.cpp
@@ -39,7 +39,7 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
       }
     /*Fall through*/
     default: // Set timer for and display a lock warning
-      cxt->scratch_state.state1 |= (xTaskGetTickCount() + TICKS_SECOND / 2) << 2;
+      cxt->scratch_state.state1 |= (xTaskGetTickCount() + TICKS_SECOND) << 2;
       warnUser(translatedString(Tr->WarningKeysLockedString), buttons);
       break;
     }

--- a/source/Core/Threads/UI/logic/Soldering.cpp
+++ b/source/Core/Threads/UI/logic/Soldering.cpp
@@ -7,7 +7,7 @@
 // State 3 = buzzer timer
 
 OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt) {
-  if (cxt->scratch_state.state1 >= 2) {
+  if (cxt->scratch_state.state1 & (2|3)) {
     // Buttons are currently locked
     switch (buttons) {
     case BUTTON_F_LONG:
@@ -16,17 +16,21 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
       }
       break;
     case BUTTON_BOTH_LONG:
-      if (cxt->scratch_state.state1 == 3) {
+      if ((cxt->scratch_state.state1 & (2|3)) == 3) {
         // Unlocking
         if (warnUser(translatedString(Tr->UnlockingKeysString), buttons)) {
-          cxt->scratch_state.state1 = 1;
+          // cxt->scratch_state.state1 &= ~3;
+          // cxt->scratch_state.state1 |= 1;
+          cxt->scratch_state.state1 &= ~2;
         }
       } else {
         warnUser(translatedString(Tr->WarningKeysLockedString), buttons);
       }
       break;
     case BUTTON_NONE:
-      cxt->scratch_state.state1 = 3;
+      //cxt->scratch_state.state1 &= ~2;
+      //cxt->scratch_state.state1 |= 3;
+      cxt->scratch_state.state1 |= 3;
       break;
     default: // Do nothing and display a lock warning
       warnUser(translatedString(Tr->WarningKeysLockedString), buttons);
@@ -38,7 +42,7 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
   switch (buttons) {
   case BUTTON_NONE:
     cxt->scratch_state.state2 = 0;
-    cxt->scratch_state.state1 = 0;
+    cxt->scratch_state.state1 &= ~1;
     break;
   case BUTTON_BOTH:
   /*Fall through*/
@@ -58,9 +62,9 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
   case BUTTON_BOTH_LONG:
     if (getSettingValue(SettingsOptions::LockingMode)) {
       // Lock buttons
-      if (cxt->scratch_state.state1 == 0) {
+      if ((cxt->scratch_state.state1 & 1) == 0) {
         if (warnUser(translatedString(Tr->LockingKeysString), buttons)) {
-          cxt->scratch_state.state1 = 2;
+          cxt->scratch_state.state1 |= 2;
         }
       } else {
         // FIXME should be WarningKeysUnlockedString

--- a/source/Core/Threads/UI/logic/Soldering.cpp
+++ b/source/Core/Threads/UI/logic/Soldering.cpp
@@ -26,7 +26,7 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
           cxt->scratch_state.state1 = 1;
         }
       } else {
-        warnUser(translatedString(Tr->WarningKeysLockedString), buttons);
+        vTaskDelay(TICKS_SECOND);
       }
       break;
     case BUTTON_NONE:
@@ -76,6 +76,7 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
       } else {
         // FIXME should be WarningKeysUnlockedString
         warnUser(translatedString(Tr->UnlockingKeysString), buttons);
+        vTaskDelay(TICKS_SECOND);
       }
     }
     break;

--- a/source/Core/Threads/UI/logic/Soldering.cpp
+++ b/source/Core/Threads/UI/logic/Soldering.cpp
@@ -11,7 +11,7 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
     // Buttons are currently locked
     if (cxt->scratch_state.state1 > 3) {
       // show locked until timer is up
-      if ((uint16_t)(xTaskGetTickCount() << 2) - (cxt->scratch_state.state1 & ~3) > TICKS_SECOND) {
+      if ((uint16_t)(xTaskGetTickCount() << 2) - (cxt->scratch_state.state1 & ~3) > TICKS_SECOND << 2) {
         cxt->scratch_state.state1 &= 3;
       } else {
         warnUser(translatedString(Tr->WarningKeysLockedString), buttons);

--- a/source/Core/Threads/UI/logic/Soldering.cpp
+++ b/source/Core/Threads/UI/logic/Soldering.cpp
@@ -7,7 +7,7 @@
 // State 3 = buzzer timer
 
 OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt) {
-  if (cxt->scratch_state.state1 & (2|3)) {
+  if (cxt->scratch_state.state1 >= 2) {
     // Buttons are currently locked
     switch (buttons) {
     case BUTTON_F_LONG:
@@ -16,21 +16,17 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
       }
       break;
     case BUTTON_BOTH_LONG:
-      if ((cxt->scratch_state.state1 & (2|3)) == 3) {
+      if (cxt->scratch_state.state1 == 3) {
         // Unlocking
         if (warnUser(translatedString(Tr->UnlockingKeysString), buttons)) {
-          // cxt->scratch_state.state1 &= ~3;
-          // cxt->scratch_state.state1 |= 1;
-          cxt->scratch_state.state1 &= ~2;
+          cxt->scratch_state.state1 = 1;
         }
       } else {
         warnUser(translatedString(Tr->WarningKeysLockedString), buttons);
       }
       break;
     case BUTTON_NONE:
-      //cxt->scratch_state.state1 &= ~2;
-      //cxt->scratch_state.state1 |= 3;
-      cxt->scratch_state.state1 |= 3;
+      cxt->scratch_state.state1 = 3;
       break;
     default: // Do nothing and display a lock warning
       warnUser(translatedString(Tr->WarningKeysLockedString), buttons);
@@ -42,7 +38,7 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
   switch (buttons) {
   case BUTTON_NONE:
     cxt->scratch_state.state2 = 0;
-    cxt->scratch_state.state1 &= ~1;
+    cxt->scratch_state.state1 = 0;
     break;
   case BUTTON_BOTH:
   /*Fall through*/
@@ -62,9 +58,9 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
   case BUTTON_BOTH_LONG:
     if (getSettingValue(SettingsOptions::LockingMode)) {
       // Lock buttons
-      if ((cxt->scratch_state.state1 & 1) == 0) {
+      if (cxt->scratch_state.state1 == 0) {
         if (warnUser(translatedString(Tr->LockingKeysString), buttons)) {
-          cxt->scratch_state.state1 |= 2;
+          cxt->scratch_state.state1 = 2;
         }
       } else {
         // FIXME should be WarningKeysUnlockedString

--- a/source/Core/Threads/UI/logic/Soldering.cpp
+++ b/source/Core/Threads/UI/logic/Soldering.cpp
@@ -9,10 +9,10 @@
 OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt) {
   if (cxt->scratch_state.state1 >= 2) {
     // Buttons are currently locked
-    if (cxt->scratch_state.state1 > 3) {
+    if (cxt->scratch_state.state7 != 0) {
       // show locked until timer is up
-      if ((uint16_t)(xTaskGetTickCount() << 2) - (cxt->scratch_state.state1 & ~3) > TICKS_SECOND << 2) {
-        cxt->scratch_state.state1 &= 3;
+      if (xTaskGetTickCount() >= cxt->scratch_state.state7) {
+        cxt->scratch_state.state7 = 0;
       } else {
         warnUser(translatedString(Tr->WarningKeysLockedString), buttons);
         return OperatingMode::Soldering;
@@ -26,7 +26,7 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
           cxt->scratch_state.state1 = 1;
         }
       } else {
-        vTaskDelay(TICKS_SECOND);
+        warnUser(translatedString(Tr->WarningKeysLockedString), buttons);
       }
       break;
     case BUTTON_NONE:
@@ -39,7 +39,7 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
       }
     /*Fall through*/
     default: // Set timer for and display a lock warning
-      cxt->scratch_state.state1 |= (xTaskGetTickCount() + TICKS_SECOND) << 2;
+      cxt->scratch_state.state7 = xTaskGetTickCount() + TICKS_SECOND;
       warnUser(translatedString(Tr->WarningKeysLockedString), buttons);
       break;
     }
@@ -76,7 +76,6 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
       } else {
         // FIXME should be WarningKeysUnlockedString
         warnUser(translatedString(Tr->UnlockingKeysString), buttons);
-        vTaskDelay(TICKS_SECOND);
       }
     }
     break;

--- a/source/Core/Threads/UI/logic/Soldering.cpp
+++ b/source/Core/Threads/UI/logic/Soldering.cpp
@@ -11,7 +11,7 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
     // Buttons are currently locked
     if (cxt->scratch_state.state1 > 3) {
       // show locked until timer is up
-      if ((cxt->scratch_state.state1 >> 2) < xTaskGetTickCount()) {
+      if ((uint16_t)(xTaskGetTickCount() << 2) - (cxt->scratch_state.state1 & ~3) > TICKS_SECOND) {
         cxt->scratch_state.state1 &= 3;
       } else {
         warnUser(translatedString(Tr->WarningKeysLockedString), buttons);

--- a/source/Core/Threads/UI/logic/Soldering.cpp
+++ b/source/Core/Threads/UI/logic/Soldering.cpp
@@ -9,6 +9,18 @@
 OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt) {
   if (cxt->scratch_state.state1 >= 2) {
     // Buttons are currently locked
+    if (buttons == BUTTON_BOTH_LONG) {
+      if (cxt->scratch_state.state1 == 3) {
+        // Unlocking
+        if (warnUser(translatedString(Tr->UnlockingKeysString), buttons)) {
+          cxt->scratch_state.state1 = 1;
+          cxt->scratch_state.state7 = 0;
+        }
+      } else {
+        warnUser(translatedString(Tr->WarningKeysLockedString), buttons);
+      }
+      return OperatingMode::Soldering;
+    }
     if (cxt->scratch_state.state7 != 0) {
       // show locked until timer is up
       if (xTaskGetTickCount() >= cxt->scratch_state.state7) {
@@ -19,16 +31,6 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
       }
     }
     switch (buttons) {
-    case BUTTON_BOTH_LONG:
-      if (cxt->scratch_state.state1 == 3) {
-        // Unlocking
-        if (warnUser(translatedString(Tr->UnlockingKeysString), buttons)) {
-          cxt->scratch_state.state1 = 1;
-        }
-      } else {
-        warnUser(translatedString(Tr->WarningKeysLockedString), buttons);
-      }
-      break;
     case BUTTON_NONE:
       cxt->scratch_state.state1 = 3;
       break;


### PR DESCRIPTION
This is an untested draft to keep the locked warning for some time, independet of how long a button is pressed.