### PR TITLE
Add stub implementations of unused syscalls explicitly

### DIFF
--- a/source/Core/Src/syscalls.c
+++ b/source/Core/Src/syscalls.c
@@ -11,4 +11,14 @@
 /* Functions */
 void initialise_monitor_handles() {}
 
+/* Syscalls (stub implementations to avoid compile warnings and possibe future problems) */
 int _getpid(void) { return 1; }
+
+#if defined(MODEL_Pinecil) || defined(MODEL_Pinecilv2)
+// do nothing here because some stubs and real implementations added for Pinecils already
+#else
+off_t   _lseek(int fd, off_t ptr, int dir) { return -1; }
+ssize_t _read(int fd, void *ptr, size_t len) { return -1; }
+ssize_t _write(int fd, const void *ptr, size_t len) { return -1; }
+int     _close(int fd) { return -1; }
+#endif


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Add stub implementations of unused _syscalls_ explicitly.

* **What is the current behavior?**
There are missed stub implementations for some _syscalls_ which leads to compile warnings for all target devices except _Pinecil_ (both versions) [like these ones](https://github.com/Ralim/IronOS/actions/runs/10376691546/job/28729207594#step:8:26):
```
/usr/lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/bin/ld: /usr/lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/lib/thumb/v7-m/nofp/libc_nano.a(libc_a-closer.o): in function `_close_r':
closer.c:(.text._close_r+0xc): warning: _close is not implemented and will always fail
/usr/lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/bin/ld: /usr/lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/lib/thumb/v7-m/nofp/libc_nano.a(libc_a-lseekr.o): in function `_lseek_r':
lseekr.c:(.text._lseek_r+0x10): warning: _lseek is not implemented and will always fail
/usr/lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/bin/ld: /usr/lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/lib/thumb/v7-m/nofp/libc_nano.a(libc_a-readr.o): in function `_read_r':
readr.c:(.text._read_r+0x10): warning: _read is not implemented and will always fail
/usr/lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/bin/ld: /usr/lib/gcc/arm-none-eabi/13.1.0/../../../../arm-none-eabi/lib/thumb/v7-m/nofp/libc_nano.a(libc_a-writer.o): in function `_write_r':
writer.c:(.text._write_r+0x10): warning: _write is not implemented and will always fail
```

* **What is the new behavior (if this is a feature change)?**
Implemented stubs of unused _syscalls_ to make compiler... linker, to be precise, happy.

* **Other information**:
  - _Pinecil_ & _Pinecil2_ are not affected since deeply inside in their `BSP` dirs they either have syscalls implemented as [stubs already](https://github.com/Ralim/IronOS/blob/dev/source/Core/BSP/Pinecil/Vendor/SoC/gd32vf103/Common/Source/Stubs/read.c) or actually used for [debugging](https://github.com/Ralim/IronOS/blob/adfc521122590ac6f54702e52b8d6cf7e3d963eb/source/Core/BSP/Pinecil/Debug.cpp#L40);
  - at first I tried to put related code to [`BSP_Common.c`](https://github.com/Ralim/IronOS/blob/dev/source/Core/BSP/BSP_Common.c) but _it seems_ this file is never compiled and out of source tree somehow for some reason;
  - can't wait to hear the feedback.