### PR TITLE
Add direct links to stable and dev builds in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,15 +106,15 @@ After powering on the device for the first time with _IronOS_ installed and havi
 - pressing the `+/A` button enters the _soldering mode_;
 - pressing the `-/B` button enters the _settings menu_;
 - in _soldering mode_:
-  - short press of _+/A_ / _-/B_ buttons changes the soldering temperature;
-  - long press of the _+/A button_ enables _boost mode_ (increasing soldering temperature to the adjustable setting as long as the button is pressed);
-  - long press of the _-/B button_ enters _standby mode_ and stops heating;
+  - short press of `+/A` / `-/B` buttons changes the soldering temperature;
+  - long press of the `+/A` button enables _boost mode_ (increasing soldering temperature to the adjustable setting as long as the button is pressed);
+  - long press of the `-/B` button enters _standby mode_ and stops heating;
 - in _standby mode_:
-  - long press of the _+/A button_ enters _soldering temperature adjust mode_ (the same as the one in the _soldering mode_, but allows to adjust the temperature before heating up);
-  - long hold of the _-/B button_ enters the [_debug menu_](https://ralim.github.io/IronOS/DebugMenu/);
+  - long press of the `+/A` button enters _soldering temperature adjust mode_ (the same as the one in the _soldering mode_, but allows to adjust the temperature before heating up);
+  - long hold of the `-/B` button enters the [_debug menu_](https://ralim.github.io/IronOS/DebugMenu/);
 - in _menu mode_ (to make it short here):
-  - _-/B_ scrolls & cycles through menus and submenus;
-  - _-/A_ enters to menu & submenu settings or changes their values if they are activated already.
+  - `-/B` scrolls & cycles through menus and submenus;
+  - `-/A` enters to menu & submenu settings or changes their values if they are activated already.
 
 Additional details are described in the [menu information](https://ralim.github.io/IronOS/Menu/).
 

--- a/README.md
+++ b/README.md
@@ -93,15 +93,18 @@ For notes on installation for your device, please refer to the flashing guide fo
 
 ## Basic control
 
-Supported device is [usually] controlled by two buttons only which can be pressed in the following ways: short (~1 second or so), long (more than 1 second), and both buttons are pressed.
+Supported device is controlled by two buttons which can be pressed in the following ways:
+ - short: ~1 second or so;
+ - long: more than 1 second;
+ - both (press & hold both of them together).
 
 Available buttons are (by default because they can be swapped in settings):
- - _+/A button_: near the front closer to the tip (for irons) or on the left side of the device (for plates);
- - _-/B button_: near the back far from the tip (for irons) or on the right side of the device (for plates).
+ - `+/A` button: near the front closer to the tip (for irons) or on the left side of the device (for plates);
+ - `-/B` button: near the back far from the tip (for irons) or on the right side of the device (for plates).
 
 After powering on the device for the first time with _IronOS_ installed and having the tip/plate plugged in, on the main menu in _standby mode_ the unit shows a pair of prompts for the two most common operations:
-- pressing the _+/A button_ enters the _soldering mode_;
-- pressing the _-/B button_ enters the _settings menu_;
+- pressing the `+/A` button enters the _soldering mode_;
+- pressing the `-/B` button enters the _settings menu_;
 - in _soldering mode_:
   - short press of _+/A_ / _-/B_ buttons changes the soldering temperature;
   - long press of the _+/A button_ enables _boost mode_ (increasing soldering temperature to the adjustable setting as long as the button is pressed);

--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ _Recommended Purchase_ is only referring to if you are buying a **new** device. 
 
 The _TS101_ & _S60(P)_ irons and _MHP30_ & _T55_ plates feature a higher resolution OLED than other devices. Work is ongoing to support this fully, for now a cropped view is usable.
 
-** \* ** _PinecilV1_ stopped being manufactured a long time ago now, all models for sale online are generally clones (or old stock). Vendors are trying to sell these for more than _Pine64_ sells the _V2_ for now. Thus the _V1_ is **_no longer recommended_**.
+\* _PinecilV1_ stopped being manufactured a long time ago now, all models for sale online are generally clones (or old stock). Vendors are trying to sell these for more than _Pine64_ sells the _V2_ for now. Thus the _V1_ is **_no longer recommended_**.
 
-** \*\* ** Please note that _Miniware_ started shipping _TS100_'s using **cloned STM32 chips**. While these do work with _IronOS_, their **DFU bootloader** works terribly, and it is hard to get it to successfully flash larger firmware images like _IronOS_ without timing out. This is the main reason why the _TS100_ is **_no longer recommended_**.
+\*\* Please note that _Miniware_ started shipping _TS100_'s using **cloned STM32 chips**. While these do work with _IronOS_, their **DFU bootloader** works terribly, and it is hard to get it to successfully flash larger firmware images like _IronOS_ without timing out. This is the main reason why the _TS100_ is **_no longer recommended_**.
 
-** \*\*\* ** _TS80_ is replaced by _TS80P_. Production ramped down a long time ago and it's just existing stock clearing the system. It's marked not recommended being optimistic that people might pause and buy the far superior _TS80P_ instead. This is the main reason why the _TS80_ is **_no longer recommended_**.
+\*\*\* _TS80_ is replaced by _TS80P_. Production ramped down a long time ago and it's just existing stock clearing the system. It's marked not recommended being optimistic that people might pause and buy the far superior _TS80P_ instead. This is the main reason why the _TS80_ is **_no longer recommended_**.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project is considered feature complete for use on a daily basis, _so please
 
 _This firmware does **NOT** support the USB port while running for changing settings (this is done through the onscreen menu only). Custom logos are edited on a computer and flashed in the same manner as firmware._
 
-## Support
+## Supported Hardware
 
 |     Device     | DC  | QC  | PD  | EPR | BLE | Tip Sense | Recommended Purchase |                  Notes                  |
 | :------------: | :-: | :-: | :-: | :-: | :-: | :-------: | :------------------: | :-------------------------------------: |

--- a/README.md
+++ b/README.md
@@ -3,23 +3,25 @@
 [![Contributors](https://img.shields.io/github/contributors-anon/ralim/ironos?color=blue&style=flat)](https://github.com/Ralim/IronOS/graphs/contributors)
 [![Latest Release](https://img.shields.io/github/v/release/ralim/IronOS)](https://github.com/Ralim/IronOS/releases/latest)
 
-# IronOS - Flexible Soldering iron control Firmware
+# IronOS - Open Source Flexible Firmware for Soldering Hardware
 
 _This repository was formerly known as TS100, it's the same great code. Just with more supported devices._
 
-Originally conceived as an alternative firmware for the TS100, this firmware has evolved into a complex soldering iron control firmware.
+Originally conceived as an alternative firmware for the _TS100_, this firmware has evolved into a complex soldering equipment control firmware.
 
 The firmware implements all of the standard features of a 'smart' soldering iron, with lots of little extras and tweaks.
 I highly recommend reading the installation guide fully when installing on your iron. And after install just explore the settings menu.
 
-For soldering irons that are designed to be powered by 'smart' power sources (PD and QC), the firmware supports settings around the negotiated power and voltage.
-For soldering irons that are designed to be powered by batteries (TS100 & Pinecil), settings for a cutoff voltage for battery protection are supported.
+For soldering hardware that are designed to be powered by 'smart' power sources (PD and QC), the firmware supports settings around the negotiated power and voltage.
+For soldering hardware that are designed to be powered by batteries (_TS100_ & _Pinecil_), settings for a cutoff voltage for battery protection are supported.
 
-Currently **31** languages are supported. When downloading the firmware for your soldering iron, take note of the language code in the file name.
+Currently **31** languages are supported. When downloading the firmware for your soldering hardware, take note of the language code in the file name.
 
-This project is considered feature complete for use as a soldering iron, _so please suggest any feature improvements you would like!_
+This project is considered feature complete for use on a daily basis, _so please suggest any feature improvements you would like!_
 
 _This firmware does **NOT** support the USB port while running for changing settings. This is done through the onscreen menu only. Logos are edited on a computer and flashed like firmware._
+
+## Support
 
 |     Device     | DC  | QC  | PD  | EPR | BLE | Tip Sense | Recommended Purchase |                  Notes                  |
 | :------------: | :-: | :-: | :-: | :-: | :-: | :-------: | :------------------: | :-------------------------------------: |
@@ -34,23 +36,21 @@ _This firmware does **NOT** support the USB port while running for changing sett
 | Miniware TS100 | ✔️  | ❌  | ❌  | ❌  | ❌  |    ❌     |        ❌\*\*        |                                         |
 | Miniware TS80  | ❌  | ✔️  | ❌  | ❌  | ❌  |    N/A    |       ❌\*\*\*       |                                         |
 
-_Tip Sense_ refers to the device being able to choose between the 'usual' TS100 or Hakko T12 style tips and Pine64's custom shorter tips which have lower resistance and allow for more power. This is N/A for TS80/TS80P as there is only one model of tip for them.
+_Tip Sense_ refers to the device being able to choose between the 'usual' _TS100_ or _Hakko T12 style_ tips and _Pine64_'s custom shorter tips which have lower resistance and allow for more power. This is N/A for _TS80(P)_ as there is only one model of tip for them.
 
 _Recommended Purchase_ is only referring to if you are buying a **new** device. Of course all the devices listed are supported and will work excellently for years to come.
 
-The TS101 and S60 feature a higher resolution OLED than other devices. Work is ongoing to support this fully, for now a cropped view is usable.
+The _TS101_ & _S60(P)_ irons and _MHP30_ & _T55_ plates feature a higher resolution OLED than other devices. Work is ongoing to support this fully, for now a cropped view is usable.
 
-\*PinecilV1 stopped being manufactured a long time ago now, all models for sale online are generally clones (or old stock). Vendors are trying to sell these for more than Pine64 sells the V2 for now. Thus the V1 is **_no longer recommended_**.
+\* _PinecilV1_ stopped being manufactured a long time ago now, all models for sale online are generally clones (or old stock). Vendors are trying to sell these for more than _Pine64_ sells the _V2_ for now. Thus the _V1_ is **_no longer recommended_**.
 
-\*\*Please note that Miniware started shipping TS100's using cloned STM32 Chips. While these do work with IronOS, their DFU bootloader works terribly, and it is hard to get it to successfully flash larger firmware images like IronOS without timing out. This is the main reason why the TS100 is **_no longer recommended_**.
+\*\* Please note that _Miniware_ started shipping _TS100_'s using **cloned STM32 chips**. While these do work with _IronOS_, their **DFU bootloader** works terribly, and it is hard to get it to successfully flash larger firmware images like _IronOS_ without timing out. This is the main reason why the _TS100_ is **_no longer recommended_**.
 
-\*\*\*TS80 is replaced by TS80P. Production ramped down a long time ago and it's just existing stock clearing the system. It's marked not recommended being optimistic that people might pause and buy the far superior TS80P instead. This is the main reason why the TS80 is **_no longer recommended_**.
+\*\*\* _TS80_ is replaced by _TS80P_. Production ramped down a long time ago and it's just existing stock clearing the system. It's marked not recommended being optimistic that people might pause and buy the far superior _TS80P_ instead. This is the main reason why the _TS80_ is **_no longer recommended_**.
 
 ## Getting Started
 
-To get started with IronOS firmware, please jump to [Getting Started Guide](https://ralim.github.io/IronOS/GettingStarted/).
-But the [TL;DR](https://www.merriam-webster.com/dictionary/TL%3BDR) is to press the button near the front of the iron to heat up. Use the button near the back of the iron to enter the settings menu.
-Long hold the rear button in soldering mode to exit back to the start screen.
+To get started with _IronOS firmware_, please jump to [Getting Started Guide](https://ralim.github.io/IronOS/GettingStarted/).
 
 ## Installation
 
@@ -64,23 +64,23 @@ For notes on installation for your device, please refer to the flashing guide fo
 
 ## Key Features
 
-- PID style iron temperature control
-- Automatic sleep with selectable sensitivity
-- Motion wake support
-- All settings exposed in the intuitive menu
-- (TS100) Set a voltage lower limit for Lithium batteries so you don't kill your battery pack
-- (TS80) Set 18 W or 24 W settings for your power bank
-- (TS80P) Automatically negotiates appropriate PD and falls back to QC mode like TS80
-- (Pinecil) Supports all 3 power modes (PD, QC, DC In).
-- (Pinecilv2) Supports USB-PD EPR for 28V operation.
-- Improved readability Fonts, supporting multiple languages
-- Use hardware features to improve reliability
-- Can disable movement detection if desired
-- Boost mode lets you temporarily change the temperature when soldering (i.e. raise the temperature for short periods)
-- (TS100/Pinecil) Battery charge level indicator if power source set to a lipo cell count
-- (TS80/TS80P/Pinecil) Power bank operating voltage is displayed
-- [Custom boot up logo support](https://ralim.github.io/IronOS/Logo/)[^bootlogo]
-- Automatic LCD rotation based on the orientation
+- PID style iron temperature control;
+- automatic sleep with selectable sensitivity;
+- adjustable & tweakable motion wake support;
+- all settings exposed in the intuitive menu;
+- (_TS100_) set a voltage lower limit for Lithium batteries so you don't kill your battery pack;
+- (_TS80_) set 18W or 24W settings for your power bank;
+- (_TS80P_) automatically negotiates appropriate PD and falls back to QC mode like _TS80_;
+- (_Pinecil_) supports all 3 power modes (PD, QC, DC In);
+- (_Pinecilv2_) supports _USB-PD EPR_ for **28V** operation;
+- improved readability Fonts, supporting multiple languages;
+- use hardware features to improve reliability;
+- boost mode lets you temporarily change the temperature when soldering (i.e. raise the temperature for short periods);
+- (_TS100_/_Pinecil_) battery charge level indicator if power source set to a LiPo cell count;
+- (_TS80_/_TS80P_/_Pinecil_) power bank operating voltage is displayed;
+- [custom boot up logo support](https://ralim.github.io/IronOS/Logo/)[^bootlogo];
+- automatic LCD rotation based on the orientation;
+- ... and many many other cool & hackable features![^changelog]
 
 [^bootlogo]:
     **BOOTUP LOGO NOTICE**:
@@ -88,23 +88,38 @@ For notes on installation for your device, please refer to the flashing guide fo
     However, _**they are no longer included in this repo**_.
     **Please, [read the docs](https://ralim.github.io/IronOS/Logo/) for more information**.
 
-## Menu System
+[^changelog]:
+    [See the full changelog here](https://ralim.github.io/IronOS/History).
 
-This new firmware uses a new menu system to allow access to the settings on the device.
-When on the main screen and having the tip plugged in, the unit shows a pair of prompts for the two most common operations.
+## Basic control
 
-- Pressing the button near the tip enters the _soldering mode_
-- Pressing the button near the USB end enters the _settings menu_
-- When not in _soldering mode_, holding down the button near the tip will enter _soldering temperature adjust mode_ (This is the same as the one in the _soldering mode_, but allows to adjust the temperature before heating up), in _soldering mode_ however this will activate _boost mode_ as long as you hold down the button.
-- Holding down the button near the USB end will show the _[debug menu](https://ralim.github.io/IronOS/DebugMenu/)._ In _soldering mode_ this ends the heating.
+Supported device is [usually] controlled by two buttons only which can be pressed in the following ways: short (~1 second or so), long (more than 1 second), and both buttons are pressed.
 
-Operation details are over in the [Menu information.](https://ralim.github.io/IronOS/Menu/)
+Available buttons are (by default because they can be swapped in settings):
+ - _+/A button_: near the front closer to the tip (for irons) or on the left side of the device (for plates);
+ - _-/B button_: near the back far from the tip (for irons) or on the right side of the device (for plates).
+
+After powering on the device for the first time with _IronOS_ installed and having the tip/plate plugged in, on the main menu in _standby mode_ the unit shows a pair of prompts for the two most common operations:
+- pressing the _+/A button_ enters the _soldering mode_;
+- pressing the _-/B button_ enters the _settings menu_;
+- in _soldering mode_:
+  - short press of _+/A_ / _-/B_ buttons changes the soldering temperature;
+  - long press of the _+/A button_ enables _boost mode_ (increasing soldering temperature to the adjustable setting as long as the button is pressed);
+  - long press of the _-/B button_ enters _standby mode_ and stops heating;
+- in _standby mode_:
+  - long press of the _+/A button_ enters _soldering temperature adjust mode_ (the same as the one in the _soldering mode_, but allows to adjust the temperature before heating up);
+  - long hold of the _-/B button_ enters the [_debug menu_](https://ralim.github.io/IronOS/DebugMenu/);
+- in _menu mode_ (to make it short here):
+  - _-/B_ scrolls & cycles through menus and submenus;
+  - _-/A_ enters to menu & submenu settings or changes their values if they are activated already.
+
+Additional details are described in the [menu information](https://ralim.github.io/IronOS/Menu/).
 
 ## Translations
 
 Is your preferred language missing localisation of some of the text?
-Translations are stored as `json` files in the Translations folder.
-PR's are loved and accepted to enhance the firmware.
+Translations are stored as `json` files in the `Translations` folder.
+_Pull requests_ are loved and accepted to enhance the firmware.
 
 ## Thanks
 
@@ -129,13 +144,13 @@ Especially to the following users, who have helped in various ways that are mass
 
 Plus the huge number of people who have contributed translations, your effort is massively appreciated.
 
-## Licence
+## License
 
-The code created by the community is GNU GPLv3. Unless noted elsewhere.
-Other components such as FreeRTOS/USB-PD have their own licence.
+The code created by the community is covered by the [GNU GPLv3](https://www.gnu.org/licenses/gpl-3.0.html#license-text) license **unless noted elsewhere**.
+Other components such as _FreeRTOS_ and _USB-PD_ have their own licenses.
 
 ## Commercial Use
 
 This software is provided as-is, so I cannot provide any commercial support for the firmware.
-However, you are more than welcome to distribute links to the firmware or provide irons with this software on them.
-Please do not re-host the files, but rather link to this page, so that there are no old versions of the firmware scattered around.
+However, you are more than welcome to distribute links to the firmware or provide hardware with this firmware.
+**Please do not re-host the files, but rather link to this page, so that there are no old versions of the firmware scattered around**.

--- a/README.md
+++ b/README.md
@@ -36,17 +36,17 @@ _This firmware does **NOT** support the USB port while running for changing sett
 | Miniware TS100 | ✔️  | ❌  | ❌  | ❌  | ❌  |    ❌     |        ❌\*\*        |                                         |
 | Miniware TS80  | ❌  | ✔️  | ❌  | ❌  | ❌  |    N/A    |       ❌\*\*\*       |                                         |
 
-_Tip Sense_ refers to the device being able to choose between the 'usual' _TS100_ or _Hakko T12 style_ tips and _Pine64_'s custom shorter tips which have lower resistance and allow for more power. This is N/A for _TS80(P)_ as there is only one model of tip for them.
+_Tip Sense_ refers to the device being able to choose between the _"regular"_ _TS100_ or _Hakko T12 style_ tips and _Pine64_'s custom shorter tips which have lower resistance and allow for more power. This is N/A for _TS80(P)_ as there is only one model of tip for them.
 
 _Recommended Purchase_ is only referring to if you are buying a **new** device. Of course all the devices listed are supported and will work excellently for years to come.
 
 The _TS101_ & _S60(P)_ irons and _MHP30_ & _T55_ plates feature a higher resolution OLED than other devices. Work is ongoing to support this fully, for now a cropped view is usable.
 
-\* _PinecilV1_ stopped being manufactured a long time ago now, all models for sale online are generally clones (or old stock). Vendors are trying to sell these for more than _Pine64_ sells the _V2_ for now. Thus the _V1_ is **_no longer recommended_**.
+** \* ** _PinecilV1_ stopped being manufactured a long time ago now, all models for sale online are generally clones (or old stock). Vendors are trying to sell these for more than _Pine64_ sells the _V2_ for now. Thus the _V1_ is **_no longer recommended_**.
 
-\*\* Please note that _Miniware_ started shipping _TS100_'s using **cloned STM32 chips**. While these do work with _IronOS_, their **DFU bootloader** works terribly, and it is hard to get it to successfully flash larger firmware images like _IronOS_ without timing out. This is the main reason why the _TS100_ is **_no longer recommended_**.
+** \*\* ** Please note that _Miniware_ started shipping _TS100_'s using **cloned STM32 chips**. While these do work with _IronOS_, their **DFU bootloader** works terribly, and it is hard to get it to successfully flash larger firmware images like _IronOS_ without timing out. This is the main reason why the _TS100_ is **_no longer recommended_**.
 
-\*\*\* _TS80_ is replaced by _TS80P_. Production ramped down a long time ago and it's just existing stock clearing the system. It's marked not recommended being optimistic that people might pause and buy the far superior _TS80P_ instead. This is the main reason why the _TS80_ is **_no longer recommended_**.
+** \*\*\* ** _TS80_ is replaced by _TS80P_. Production ramped down a long time ago and it's just existing stock clearing the system. It's marked not recommended being optimistic that people might pause and buy the far superior _TS80P_ instead. This is the main reason why the _TS80_ is **_no longer recommended_**.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@
 
 _This repository was formerly known as TS100, it's the same great code. Just with more supported devices._
 
-Originally conceived as an alternative firmware for the _TS100_, this firmware has evolved into a complex soldering equipment control firmware.
+Originally conceived as an alternative firmware for the _TS100_, this firmware has evolved into a complex soldering hardware control firmware.
 
-The firmware implements all of the standard features of a 'smart' soldering iron, with lots of little extras and tweaks.
-I highly recommend reading the installation guide fully when installing on your iron. And after install just explore the settings menu.
+The firmware implements all of the standard features of a _smart_ soldering hardware, with lots of little extras and tweaks.
+I highly recommend reading the installation guide fully when installing on your device. And after install just explore the settings menu.
 
-For soldering hardware that are designed to be powered by 'smart' power sources (PD and QC), the firmware supports settings around the negotiated power and voltage.
+For soldering hardware that are designed to be powered by _smart_ power sources (PD and QC), the firmware supports settings around the negotiated power and voltage.
 For soldering hardware that are designed to be powered by batteries (_TS100_ & _Pinecil_), settings for a cutoff voltage for battery protection are supported.
 
-Currently **31** languages are supported. When downloading the firmware for your soldering hardware, take note of the language code in the file name.
+Currently **31** languages are supported. When downloading the firmware for your soldering hardware, take note of the _language code_ in the file name.
 
 This project is considered feature complete for use on a daily basis, _so please suggest any feature improvements you would like!_
 

--- a/README.md
+++ b/README.md
@@ -154,6 +154,6 @@ Other components such as _FreeRTOS_ and _USB-PD_ have their own licenses.
 
 ## Commercial Use
 
-This software is provided as-is, so I cannot provide any commercial support for the firmware.
+This software is provided "AS IS", so I cannot provide any commercial support for the firmware.
 However, you are more than welcome to distribute links to the firmware or provide hardware with this firmware.
 **Please do not re-host the files, but rather link to this page, so that there are no old versions of the firmware scattered around**.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Originally conceived as an alternative firmware for the _TS100_, this firmware h
 The firmware implements all of the standard features of a _smart_ soldering hardware, with lots of little extras and tweaks.
 I highly recommend reading the installation guide fully when installing on your device. And after install just explore the settings menu.
 
-For soldering hardware that are designed to be powered by _smart_ power sources such as _PD_ or _QC_, the firmware supports settings around the negotiated power and voltage.
-For soldering hardware that are designed to be powered by batteries (_TS100_ & _Pinecil_), settings for a cutoff voltage for battery protection are supported.
+For soldering hardware that is designed to be powered by _smart_ power sources such as _PD_ or _QC_, the firmware supports settings around the negotiated power and voltage.
+For soldering hardware that is designed to be powered by batteries (_TS100_ & _Pinecil_), settings for a cutoff voltage for battery protection are supported.
 
 Currently **31** languages are supported. When downloading the firmware for your soldering hardware, take note of the _language code_ in the file name.
 
@@ -114,7 +114,7 @@ After powering on the device for the first time with _IronOS_ installed and havi
   - long hold of the `-/B` button enters the [_debug menu_](https://ralim.github.io/IronOS/DebugMenu/);
 - in _menu mode_ (to make it short here):
   - `-/B` scrolls & cycles through menus and submenus;
-  - `-/A` enters to menu & submenu settings or changes their values if they are activated already.
+  - `+/A` enters to menu & submenu settings or changes their values if they are activated already.
 
 Additional details are described in the [menu information](https://ralim.github.io/IronOS/Menu/).
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,28 @@ For notes on installation for your device, please refer to the flashing guide fo
 - [TS80 / TS80P](https://ralim.github.io/IronOS/Flashing/TS80%28P%29/)
 - [TS100](https://ralim.github.io/IronOS/Flashing/TS100)
 
+## Builds
+
+The links in the table below allow to download available builds directly.
+
+Current stable release is `v2.22`.  
+_Devel builds_ **dynamically** provide _**the latest successful build**_ from **`dev`** branch.
+
+|        Device         | Stable Release | Devel Build |
+|:---------------------:|:--------------:|:-----------:|
+| Pinecil  V1           | [Pinecil.zip](https://github.com/Ralim/IronOS/releases/download/v2.22/Pinecil.zip)                           | [Pinecil.zip](https://nightly.link/Ralim/IronOS/workflows/push/dev/Pinecil.zip)                           |
+| Pinecil  V1/multilang | [Pinecil_multi-lang.zip](https://github.com/Ralim/IronOS/releases/download/v2.22/Pinecil_multi-lang.zip)     | [Pinecil_multi-lang.zip](https://nightly.link/Ralim/IronOS/workflows/push/dev/Pinecil_multi-lang.zip)     |
+| Pinecil  V2           | [PinecilV2.zip](https://github.com/Ralim/IronOS/releases/download/v2.22/PinecilV2.zip)                       | [PinecilV2.zip](https://nightly.link/Ralim/IronOS/workflows/push/dev/Pinecilv2.zip)                       |
+| Pinecil  V2/multilang | [PinecilV2_multi-lang.zip](https://github.com/Ralim/IronOS/releases/download/v2.22/PinecilV2_multi-lang.zip) | [PinecilV2_multi-lang.zip](https://nightly.link/Ralim/IronOS/workflows/push/dev/Pinecilv2_multi-lang.zip) |
+| Miniware TS100        | [TS100.zip](https://github.com/Ralim/IronOS/releases/download/v2.22/TS100.zip)                               | [TS100.zip](https://nightly.link/Ralim/IronOS/workflows/push/dev/TS100.zip)                               |
+| Miniware TS101        | [TS101.zip](https://github.com/Ralim/IronOS/releases/download/v2.22/TS101.zip)                               | [TS101.zip](https://nightly.link/Ralim/IronOS/workflows/push/dev/TS101.zip)                               |
+| Miniware TS80         | [TS80.zip](https://github.com/Ralim/IronOS/releases/download/v2.22/TS80.zip)                                 | [TS80.zip](https://nightly.link/Ralim/IronOS/workflows/push/dev/TS80.zip)                                 |
+| Miniware TS80P        | [TS80P.zip](https://github.com/Ralim/IronOS/releases/download/v2.22/TS80P.zip)                               | [TS80P.zip](https://nightly.link/Ralim/IronOS/workflows/push/dev/TS80P.zip)                               |
+| Miniware MHP30        | [MHP30.zip](https://github.com/Ralim/IronOS/releases/download/v2.22/MHP30.zip)                               | [MHP30.zip](https://nightly.link/Ralim/IronOS/workflows/push/dev/MHP30.zip)                               |
+| Sequre   S60          | [S60.zip](https://github.com/Ralim/IronOS/releases/download/v2.22/S60.zip)                                   | [S60.zip](https://nightly.link/Ralim/IronOS/workflows/push/dev/S60.zip)                                   |
+| Sequre   S60P         | Not Released                                                                                                 | [S60P.zip](https://nightly.link/Ralim/IronOS/workflows/push/dev/S60P.zip)                                 |
+| Sequre   T55          | Not Released                                                                                                 | [T55.zip](https://nightly.link/Ralim/IronOS/workflows/push/dev/T55.zip)                                   |
+
 ## Key Features
 
 - PID style iron temperature control;

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Supported device is controlled by two buttons which can be pressed in the follow
  - long: more than 1 second;
  - both (press & hold both of them together).
 
-Available buttons are (by default because they can be swapped in settings):
+Available buttons are:
  - `+/A` button: near the front closer to the tip (for irons) or on the left side of the device (for plates);
  - `-/B` button: near the back far from the tip (for irons) or on the right side of the device (for plates).
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Originally conceived as an alternative firmware for the _TS100_, this firmware h
 The firmware implements all of the standard features of a _smart_ soldering hardware, with lots of little extras and tweaks.
 I highly recommend reading the installation guide fully when installing on your device. And after install just explore the settings menu.
 
-For soldering hardware that are designed to be powered by _smart_ power sources (PD and QC), the firmware supports settings around the negotiated power and voltage.
+For soldering hardware that are designed to be powered by _smart_ power sources such as _PD_ or _QC_, the firmware supports settings around the negotiated power and voltage.
 For soldering hardware that are designed to be powered by batteries (_TS100_ & _Pinecil_), settings for a cutoff voltage for battery protection are supported.
 
 Currently **31** languages are supported. When downloading the firmware for your soldering hardware, take note of the _language code_ in the file name.
@@ -91,7 +91,7 @@ For notes on installation for your device, please refer to the flashing guide fo
 [^changelog]:
     [See the full changelog here](https://ralim.github.io/IronOS/History).
 
-## Basic control
+## Basic Control
 
 Supported device is controlled by two buttons which can be pressed in the following ways:
  - short: ~1 second or so;

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Currently **31** languages are supported. When downloading the firmware for your
 
 This project is considered feature complete for use on a daily basis, _so please suggest any feature improvements you would like!_
 
-_This firmware does **NOT** support the USB port while running for changing settings. This is done through the onscreen menu only. Logos are edited on a computer and flashed like firmware._
+_This firmware does **NOT** support the USB port while running for changing settings (this is done through the onscreen menu only). Custom logos are edited on a computer and flashed in the same manner as firmware._
 
 ## Support
 


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Add direct links to stable and the latest successful dev builds in README.

* **What is the current behavior?**
To download the latest `dev` build for the device, a user have to: go to _Actions_ tab, find successful `dev` build item, open it, scroll down to _Artifacts_, download related `zip`.

* **What is the new behavior (if this is a feature change)?**
Just providing [https://github.com/Ralim/IronOS#builds](https://github.com/Ralim/IronOS#builds) link will be enough to get any type of build in one click.

* **Other information**:

This is possible through awesome [nightly.link](https://nightly.link) service using _GitHub_ _API_ to extract latest successful builds. I just did feed our `push.yml` to it and the service generated dynamic links to our artifacts.

At first I was thinking to combine this table with _Supported Hardware_ but then I thought that it will be more clear if this info will be in a separate table for ease access.