### PR TITLE
Introducing IronOS Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Total Downloads](https://img.shields.io/github/downloads/ralim/IronOS/total)](https://github.com/Ralim/IronOS)
 [![Contributors](https://img.shields.io/github/contributors-anon/ralim/ironos?color=blue&style=flat)](https://github.com/Ralim/IronOS/graphs/contributors)
 [![Latest Release](https://img.shields.io/github/v/release/ralim/IronOS)](https://github.com/Ralim/IronOS/releases/latest)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20IronOS%20Guru-006BFF)](https://gurubase.io/g/ironos)
 
 # IronOS - Open Source Flexible Firmware for Soldering Hardware
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [IronOS Guru](https://gurubase.io/g/ironos) to Gurubase. IronOS Guru uses the data from this repo and data from the [docs](https://ralim.github.io/IronOS/) to answer questions by leveraging the LLM.

In this PR, I showcased the "IronOS Guru", which highlights that IronOS now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable IronOS Guru in Gurubase, just let me know that's totally fine.
