### PR TITLE
Lower max USB voltage for Pinecil V2 to protect the PD chip

### DIFF
--- a/source/Core/BSP/Pinecilv2/configuration.h
+++ b/source/Core/BSP/Pinecilv2/configuration.h
@@ -136,7 +136,7 @@
 #define POWER_LIMIT_STEPS          5                         //
 #define OP_AMP_GAIN_STAGE          OP_AMP_GAIN_STAGE_PINECIL // Uses TS100 resistors
 #define TEMP_uV_LOOKUP_HAKKO                                 // Use Hakko lookup table
-#define USB_PD_VMAX                28                        // Maximum voltage for PD to negotiate
+#define USB_PD_VMAX                21                        // Maximum voltage for PD to negotiate
 #define PID_TIM_HZ                 (10)                      // Tick rate of the PID loop
 #define MAX_TEMP_C                 450                       // Max soldering temp selectable °C
 #define MAX_TEMP_F                 850                       // Max soldering temp selectable °F


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [X] The changes have been tested locally
- [X] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->

_TLDR: The Pinecil V2 can die when using PD voltages >21V._

After using the Pinecil V2 without issues for a long time with regular 20V PD, I got the chance to use newer 140W power supplies. These offer up to 28V to deliver the maximum power.
However, with such supplies the iron worked only once (reading 29V iirc) and now doesn't power up.

The same issue is mentioned in the wiki, which identifies the cause is the PD chip sometimes just stops working: https://wiki.pine64.org/wiki/Pinecil:_Test,_Repair,_Issues#Not_Powering_Up_Anymore
In the linked Reddit thread, some have been broken with as low as 23V: https://www.reddit.com/r/PINE64official/comments/q8d08a/pinecil_does_not_power_on/
Edit: Also this video cut mentions two irons which PD chip failed with a new PSU: https://www.youtube.com/watch?v=VULQXBKzniQ&t=195s

Going to the datasheet shows that we were getting way too close to the chip's maximum rating:
![image](https://github.com/user-attachments/assets/f5455140-64c1-4c50-a412-38b355dd9d76)

While it is pretty impressive to be able to power the iron with 28V when it works, and we would probably be safe by setting 22-23V, I don't think it's worth the risk to break the PD chip by going above the manufacturer's recommendation of 21V.
I've checked the other IronOS devices under the BSP folder and they are all capped at ~20V, and functionality is excellent anyways.

* **What is the new behavior (if this is a feature change)?**

The iron requests PD up to 21V instead of 28V.

* **Other information**:

Datasheet for the PD chip FUSB302: https://rocelec.widen.net/view/pdf/0av2cqef3a/FAIR-S-A0001311862-1.pdf#page=12