### PR TITLE
Add macro to enable tip types for supported hardware only

### DIFF
--- a/source/Core/BSP/Miniware/BSP.cpp
+++ b/source/Core/BSP/Miniware/BSP.cpp
@@ -388,8 +388,8 @@ uint8_t getTipResistanceX10() {
     return lastTipResistance; // Auto mode
   }
   return user_selected_tip;
-#else
 
+#else
   uint8_t user_selected_tip = getUserSelectedTipResistance();
   if (user_selected_tip == 0) {
     return TIP_RESISTANCE; // Auto mode

--- a/source/Core/BSP/Miniware/BSP.cpp
+++ b/source/Core/BSP/Miniware/BSP.cpp
@@ -379,6 +379,8 @@ uint8_t preStartChecksDone() {
 #endif
 }
 
+#ifdef TIP_TYPE_SUPPORT
+// new version for models supporting tips of different length/resistance
 uint8_t getTipResistanceX10() {
 #ifdef TIP_RESISTANCE_SENSE_Pin
   // Return tip resistance in x10 ohms
@@ -388,7 +390,6 @@ uint8_t getTipResistanceX10() {
     return lastTipResistance; // Auto mode
   }
   return user_selected_tip;
-
 #else
   uint8_t user_selected_tip = getUserSelectedTipResistance();
   if (user_selected_tip == 0) {
@@ -397,6 +398,18 @@ uint8_t getTipResistanceX10() {
   return user_selected_tip;
 #endif
 }
+#else /* no tip type support: legacy version */
+uint8_t getTipResistanceX10() {
+#ifdef TIP_RESISTANCE_SENSE_Pin
+  // Return tip resistance in x10 ohms
+  // We can measure this using the op-amp
+  return lastTipResistance;
+#else
+  return TIP_RESISTANCE;
+#endif
+}
+#endif /* TIP_TYPE_SUPPORT */
+
 #ifdef TIP_RESISTANCE_SENSE_Pin
 bool isTipShorted() { return tipShorted; }
 #else

--- a/source/Core/BSP/Miniware/BSP.cpp
+++ b/source/Core/BSP/Miniware/BSP.cpp
@@ -379,8 +379,6 @@ uint8_t preStartChecksDone() {
 #endif
 }
 
-#ifdef TIP_TYPE_SUPPORT
-// new version for models supporting tips of different length/resistance
 uint8_t getTipResistanceX10() {
 #ifdef TIP_RESISTANCE_SENSE_Pin
   // Return tip resistance in x10 ohms
@@ -398,17 +396,6 @@ uint8_t getTipResistanceX10() {
   return user_selected_tip;
 #endif
 }
-#else /* no tip type support: legacy version */
-uint8_t getTipResistanceX10() {
-#ifdef TIP_RESISTANCE_SENSE_Pin
-  // Return tip resistance in x10 ohms
-  // We can measure this using the op-amp
-  return lastTipResistance;
-#else
-  return TIP_RESISTANCE;
-#endif
-}
-#endif /* TIP_TYPE_SUPPORT */
 
 #ifdef TIP_RESISTANCE_SENSE_Pin
 bool isTipShorted() { return tipShorted; }

--- a/source/Core/BSP/Miniware/BSP.cpp
+++ b/source/Core/BSP/Miniware/BSP.cpp
@@ -389,6 +389,7 @@ uint8_t getTipResistanceX10() {
   }
   return user_selected_tip;
 #else
+
   uint8_t user_selected_tip = getUserSelectedTipResistance();
   if (user_selected_tip == 0) {
     return TIP_RESISTANCE; // Auto mode
@@ -396,7 +397,6 @@ uint8_t getTipResistanceX10() {
   return user_selected_tip;
 #endif
 }
-
 #ifdef TIP_RESISTANCE_SENSE_Pin
 bool isTipShorted() { return tipShorted; }
 #else

--- a/source/Core/BSP/Miniware/configuration.h
+++ b/source/Core/BSP/Miniware/configuration.h
@@ -218,6 +218,7 @@
 #define TEMP_NTC             1
 #define ACCEL_I2CBB1         1
 #define POW_EPR              1
+#define TIP_TYPE_SUPPORT     1 // Support for tips of different types, i.e. resistance
 #define AUTO_TIP_SELECTION   1 // Can auto-select the tip
 #define TIPTYPE_T12          1 // Can manually pick a T12 tip
 #define HAS_POWER_DEBUG_MENU

--- a/source/Core/BSP/Pinecilv2/configuration.h
+++ b/source/Core/BSP/Pinecilv2/configuration.h
@@ -154,6 +154,7 @@
 #define POW_EPR                    1
 #define ENABLE_QC2                 1
 #define MAG_SLEEP_SUPPORT          1
+#define TIP_TYPE_SUPPORT           1 // Support for tips of different types, i.e. resistance
 #define AUTO_TIP_SELECTION         1 // Can auto-select the tip
 #define TIPTYPE_T12                1 // Can manually pick a T12 tip
 #define DEVICE_HAS_VALIDATION_SUPPORT

--- a/source/Core/Inc/Settings.h
+++ b/source/Core/Inc/Settings.h
@@ -143,10 +143,15 @@ typedef enum {
   // #endif
   TIP_TYPE_MAX, // Max value marker
 } tipType_t;
-uint8_t getUserSelectedTipResistance(); // returns the resistance matching the selected tip type or 0 for auto
 #else
-typedef enum { TIP_TYPE_MAX = 0 } tipType_t;
+typedef enum {
+  TIP_TYPE_AUTO = 0, // value for the default case
+  TIP_TYPE_MAX  = 0, // marker for settings when not supported
+} tipType_t;
 #endif /* TIP_TYPE_SUPPORT */
+
+// returns the resistance matching the selected tip type or 0 for auto and when not supported
+uint8_t getUserSelectedTipResistance();
 
 // Settings wide operations
 void saveSettings();

--- a/source/Core/Inc/Settings.h
+++ b/source/Core/Inc/Settings.h
@@ -123,6 +123,7 @@ typedef enum {
  * Some devices allow multiple types of tips to be fitted, this allows selecting them or overriding the logic
  * The first type will be the default (gets value of 0)
  */
+#ifdef TIP_TYPE_SUPPORT
 typedef enum {
 #ifdef AUTO_TIP_SELECTION
   TIP_TYPE_AUTO, // If the hardware supports automatic detection
@@ -143,6 +144,9 @@ typedef enum {
   TIP_TYPE_MAX, // Max value marker
 } tipType_t;
 uint8_t getUserSelectedTipResistance(); // returns the resistance matching the selected tip type or 0 for auto
+#else
+typedef enum { TIP_TYPE_MAX = 0 } tipType_t;
+#endif /* TIP_TYPE_SUPPORT */
 
 // Settings wide operations
 void saveSettings();
@@ -162,5 +166,7 @@ void setSettingValue(const enum SettingsOptions option, const uint16_t newValue)
 // Special access helpers, to reduce logic duplication
 uint8_t     lookupVoltageLevel();
 uint16_t    lookupHallEffectThreshold();
+#ifdef TIP_TYPE_SUPPORT
 const char *lookupTipName(); // Get the name string for the current soldering tip
+#endif /* TIP_TYPE_SUPPORT */
 #endif                       /* SETTINGS_H_ */

--- a/source/Core/Src/Settings.cpp
+++ b/source/Core/Src/Settings.cpp
@@ -298,6 +298,7 @@ uint8_t lookupVoltageLevel() {
   }
 }
 
+#ifdef TIP_TYPE_SUPPORT
 const char *lookupTipName() {
   // Get the name string for the current soldering tip
   tipType_t value = (tipType_t)getSettingValue(SettingsOptions::SolderingTipType);
@@ -334,7 +335,10 @@ const char *lookupTipName() {
     break;
   }
 }
+#endif /* TIP_TYPE_SUPPORT */
+
 // Returns the resistance for the current tip selected by the user or 0 for auto
+#ifdef TIP_TYPE_SUPPORT
 uint8_t getUserSelectedTipResistance() {
   tipType_t value = (tipType_t)getSettingValue(SettingsOptions::SolderingTipType);
 
@@ -370,3 +374,4 @@ uint8_t getUserSelectedTipResistance() {
     break;
   }
 }
+#endif /* TIP_TYPE_SUPPORT */

--- a/source/Core/Src/Settings.cpp
+++ b/source/Core/Src/Settings.cpp
@@ -374,4 +374,6 @@ uint8_t getUserSelectedTipResistance() {
     break;
   }
 }
+#else
+uint8_t getUserSelectedTipResistance() { return tipType_t::TIP_TYPE_AUTO; }
 #endif /* TIP_TYPE_SUPPORT */

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -116,8 +116,10 @@ static bool showHallEffect(void);
 #endif /* HALL_SENSOR */
 
 // Tip type selection
+#ifdef TIP_TYPE_SUPPORT
 static void displaySolderingTipType(void);
 static bool showSolderingTipType(void);
+#endif /* TIP_TYPE_SUPPORT */
 
 // Menu functions
 
@@ -267,12 +269,12 @@ const menuitem powerMenu[] = {
 
 const menuitem solderingMenu[] = {
   /*
-   *  Tip Type
    *  Boost Mode Temp
    *  Auto Start
    *  Temp Change Short Step
    *  Temp Change Long Step
    *  Locking Mode
+   *  Tip Type
    *  Profile Phases
    *  Profile Preheat Temperature
    *  Profile Preheat Max Temperature Change Per Second
@@ -288,8 +290,6 @@ const menuitem solderingMenu[] = {
    *  Profile Phase 5 Duration (s)
    *  Profile Cooldown Max Temperature Change Per Second
    */
-  /* Tip Type */
-  {SETTINGS_DESC(SettingsItemIndex::SolderingTipType), nullptr, displaySolderingTipType, showSolderingTipType, SettingsOptions::SolderingTipType, SettingsItemIndex::SolderingTipType, 5},
   /* Boost Temp */
   {SETTINGS_DESC(SettingsItemIndex::BoostTemperature), setBoostTemp, displayBoostTemp, nullptr, SettingsOptions::BoostTemp, SettingsItemIndex::BoostTemperature, 5},
   /* Auto start */
@@ -300,6 +300,10 @@ const menuitem solderingMenu[] = {
   {SETTINGS_DESC(SettingsItemIndex::TempChangeLongStep), nullptr, displayTempChangeLongStep, nullptr, SettingsOptions::TempChangeLongStep, SettingsItemIndex::TempChangeLongStep, 6},
   /* Locking Mode */
   {SETTINGS_DESC(SettingsItemIndex::LockingMode), nullptr, displayLockingMode, nullptr, SettingsOptions::LockingMode, SettingsItemIndex::LockingMode, 7},
+#ifdef TIP_TYPE_SUPPORT
+  /* Tip Type */
+  {SETTINGS_DESC(SettingsItemIndex::SolderingTipType), nullptr, displaySolderingTipType, showSolderingTipType, SettingsOptions::SolderingTipType, SettingsItemIndex::SolderingTipType, 5},
+#endif /* TIP_TYPE_SUPPORT */
 #ifdef PROFILE_SUPPORT
   /* Profile Phases */
   {SETTINGS_DESC(SettingsItemIndex::ProfilePhases), nullptr, displayProfilePhases, nullptr, SettingsOptions::ProfilePhases, SettingsItemIndex::ProfilePhases, 7},
@@ -763,12 +767,16 @@ static void displayHallEffectSleepTime(void) {
   }
 }
 #endif /* HALL_SENSOR */
+
+#ifdef TIP_TYPE_SUPPORT
 static void displaySolderingTipType(void) {
   // TODO wrapping X value
   OLED::print(lookupTipName(), FontStyle::SMALL, 255, OLED::getCursorX());
 }
 // If there is no detection, and no options, max is 0
 static bool showSolderingTipType(void) { return tipType_t::TIP_TYPE_MAX != 0; }
+#endif /* TIP_TYPE_SUPPORT */
+
 static void setTempF(const enum SettingsOptions option) {
   uint16_t Temp = getSettingValue(option);
   if (getSettingValue(SettingsOptions::TemperatureInF)) {


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Enable `Soldering Tip Type` routines for supported hardware only.

* **What is the current behavior?**
There are parts of code which are not relevant for all supported models, but yet the code is compiled & takes space on flash.

* **What is the new behavior (if this is a feature change)?**
- add `TIP_TYPE_SUPPORT` macro;
- enable related functions using the macro;
- enable `TIP_TYPE_SUPPORT` only for _TS101_ and _Pinecil v2_ as main targets for this feature;
- put `Soldering Tip Type` down the list in the settings, since it's optional.

* **Other information**:

Hello. I understand that this is raw & experimental feature. And I'm sorry I wasn't around when it was implemented, because probably even back then I would suggest the same what I propose now. When I was testing some translations on _TS80P_, I did end up with this:

![soldering tip type](https://raw.githubusercontent.com/ia/IronOSf/refs/heads/data/pics/tip_type.jpg)


Apparently, `Soldering Tip Type` is enabled for _TS80P_ but none of available options (even _Auto_) are picked from the related [`switch/case`](https://github.com/Ralim/IronOS/blob/71a1e2a367fcb0f6fd486fd4db2eeaeaa75fdf51/source/Core/Src/Settings.cpp#L305-L335) block. But instead of fixing the symptom (i.e., just enable _Auto_ for _TS80P_ & others), I took some liberty to look around the related parts of code scattered in the project and came out with this suggestion. Further I will add a couple of comments as code review to clarify the decisions.

And just as an illustration - the results which I did get for _TS80P/EN_:
- build from the current `dev`:
```
Memory region         Used Size  Region Size  %age Used
             ROM:       41488 B        46 KB     88.08%
```
- build with this patch:
```
Memory region         Used Size  Region Size  %age Used
             ROM:       41420 B        46 KB     87.93%
```

I know that ~0.15% is just laughable, but to keep beefing up code base with unused code for some of the targets is just not quite reasonable approach, while the same space can be used for really useful features & code in the future.

Please, let me know what you think.