### PR TITLE
Set tip type as auto by default in runtime

### DIFF
--- a/source/Core/Src/Settings.cpp
+++ b/source/Core/Src/Settings.cpp
@@ -304,11 +304,6 @@ const char *lookupTipName() {
   tipType_t value = (tipType_t)getSettingValue(SettingsOptions::SolderingTipType);
 
   switch (value) {
-#ifdef AUTO_TIP_SELECTION
-  case tipType_t::TIP_TYPE_AUTO:
-    return translatedString(Tr->TipTypeAuto);
-    break;
-#endif
 #ifdef TIPTYPE_T12
   case tipType_t::T12_8_OHM:
     return translatedString(Tr->TipTypeT12Long);
@@ -320,7 +315,7 @@ const char *lookupTipName() {
     return translatedString(Tr->TipTypeT12PTS);
     break;
 #endif
-#ifdef TIPTYE_TS80
+#ifdef TIPTYPE_TS80
   case tipType_t::TS80_4_5_OHM:
     return translatedString(Tr->TipTypeTS80);
     break;
@@ -330,8 +325,11 @@ const char *lookupTipName() {
     return translatedString(Tr->TipTypeJBCC210);
     break;
 #endif
+#ifdef AUTO_TIP_SELECTION
+  case tipType_t::TIP_TYPE_AUTO:
+#endif
   default:
-    return nullptr;
+    return translatedString(Tr->TipTypeAuto);
     break;
   }
 }


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Set `TipTypeAuto` for _tip type_ by default in runtime.

* **What is the current behavior?**
If there is no matched tip, then `lookupTipName()` returns `nullptr`, which leads to [the problem displaying _Soldering Tip Type_](https://github.com/Ralim/IronOS/pull/2031#issue-2756657524).

* **What is the new behavior (if this is a feature change)?**
Return `TipTypeAuto` as the only one reasonable default option here.

* **Other information**:
Just a #2031 follow up "safety net" suggestion: the fact that this code is under development, doesn't mean we can't start to put some air bags for the future. ;) `TIPTYPE_TS80` defined for _TS80/P_ and `TIPTYPE_JBC` is not defined at all (yet), so even if `TIP_TYPE_SUPPORT` is enabled, there _shouldn't be_ any complications, _I hope_.