### PR TITLE
Disable change temp with B/+ in soldering mode (Personal Feature pulled for GH Actions)

### DIFF
--- a/source/Core/Threads/UI/logic/Soldering.cpp
+++ b/source/Core/Threads/UI/logic/Soldering.cpp
@@ -65,6 +65,7 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
     }
     break;
   case BUTTON_F_SHORT:
+    break;
   case BUTTON_B_SHORT:
     cxt->transitionMode = TransitionAnimation::Left;
     return OperatingMode::TemperatureAdjust;


### PR DESCRIPTION
Disabled the change temp menu appearing when + is pressed in soldering mode to prevent accidental changes of temperature while using boost mode.

<!-- (Bug fix, feature, docs update, ...) -->
Disable change temp with B/+ in soldering mode per #1663

This is untested as of creation, as i am only creating this PR for GH Actions.