### PR TITLE
Disable short press of + button to change temperature to prevent accidentally changing temp only when using boost mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ After powering on the device for the first time with _IronOS_ installed and havi
 - pressing the `+/A` button enters the _soldering mode_;
 - pressing the `-/B` button enters the _settings menu_;
 - in _soldering mode_:
-  - short press of `+/A` / `-/B` buttons changes the soldering temperature;
+  - short press of the `-/B` button changes the soldering temperature;
   - long press of the `+/A` button enables _boost mode_ (increasing soldering temperature to the adjustable setting as long as the button is pressed);
   - long press of the `-/B` button enters _standby mode_ and stops heating;
 - in _standby mode_:

--- a/source/Core/Src/Settings.cpp
+++ b/source/Core/Src/Settings.cpp
@@ -110,6 +110,7 @@ static const SettingConstants settingsConstants[(int)SettingsOptions::SettingsOp
     {                     1,                                                                    10,                 1,                            2}, // ProfileCooldownSpeed
     {                     0,                                                                    12,                 1,                            0}, // HallEffectSleepTime
     {                     0, (tipType_t::TIP_TYPE_MAX - 1) > 0 ? (tipType_t::TIP_TYPE_MAX - 1) : 0,                 1,                            0}, // SolderingTipType
+    {                     0,                                                                     1,                 1,     BOOST_BUTTON_TEMP_CHANGE}, //BoostButtonTempChange
 };
 static_assert((sizeof(settingsConstants) / sizeof(SettingConstants)) == ((int)SettingsOptions::SettingsOptionsLength));
 

--- a/source/Core/Src/Settings.cpp
+++ b/source/Core/Src/Settings.cpp
@@ -110,7 +110,6 @@ static const SettingConstants settingsConstants[(int)SettingsOptions::SettingsOp
     {                     1,                                                                    10,                 1,                            2}, // ProfileCooldownSpeed
     {                     0,                                                                    12,                 1,                            0}, // HallEffectSleepTime
     {                     0, (tipType_t::TIP_TYPE_MAX - 1) > 0 ? (tipType_t::TIP_TYPE_MAX - 1) : 0,                 1,                            0}, // SolderingTipType
-    {                     0,                                                                     1,                 1,     BOOST_BUTTON_TEMP_CHANGE}, //BoostButtonTempChange
 };
 static_assert((sizeof(settingsConstants) / sizeof(SettingConstants)) == ((int)SettingsOptions::SettingsOptionsLength));
 

--- a/source/Core/Threads/UI/logic/Soldering.cpp
+++ b/source/Core/Threads/UI/logic/Soldering.cpp
@@ -39,7 +39,7 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
         cxt->scratch_state.state2 = 1;
         break;
       }
-    /*Fall through*/
+    /*Fall throuhg*/
     default: // Set timer for and display a lock warning
       cxt->scratch_state.state7 = xTaskGetTickCount() + TICKS_SECOND;
       warnUser(translatedString(Tr->WarningKeysLockedString), buttons);
@@ -65,8 +65,9 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
     }
     break;
   case BUTTON_F_SHORT:
-    break;
-  case BUTTON_B_SHORT:
+    if (getSettingValue(SettingsOptions::BoostButtonTempChange)) {
+    break;}
+  case BUTTON_B_SHORT:    
     cxt->transitionMode = TransitionAnimation::Left;
     return OperatingMode::TemperatureAdjust;
   case BUTTON_BOTH_LONG:

--- a/source/Core/Threads/UI/logic/Soldering.cpp
+++ b/source/Core/Threads/UI/logic/Soldering.cpp
@@ -65,6 +65,7 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
     }
     break;
   case BUTTON_F_SHORT:
+    break;
   case BUTTON_B_SHORT:
     cxt->transitionMode = TransitionAnimation::Left;
     return OperatingMode::TemperatureAdjust;

--- a/source/Core/Threads/UI/logic/Soldering.cpp
+++ b/source/Core/Threads/UI/logic/Soldering.cpp
@@ -65,7 +65,7 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
     }
     break;
   case BUTTON_F_SHORT:
-    if (getSettingValue(SettingsOptions::BoostButtonTempChange)) {
+    if (getSettingValue(SettingsOptions::BoostTemp)) {
     break;}
   case BUTTON_B_SHORT:    
     cxt->transitionMode = TransitionAnimation::Left;


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally *tested on pinecilV2*
- [x] There are no breaking changes 

* **What kind of change does this PR introduce?**
Feature addition

* **What is the current behavior?**
#1663 

* **What is the new behavior (if this is a feature change)?**
When boost temperature is not set to 0 (not disabled) the + button will not activate the temperature change menu while in soldering mode.
* **Other information**:
While i feel that this change should be the default, I know some may prefer the original, and as such, I plan on trying to separate this feature into it's own setting so it can be disabled for those who prefer short + to change temperature even with boost mode enabled. This is the first project I have contributed on in my life, so any guidance on what I need to change for docs or how to best test would be greatly appreciated.