### PR TITLE
Set python-version for actions/setup-python to remove the github actions warning

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12.3'
 
       - run: |
           pip install --upgrade pip &&


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Fix GitHub Actions warning for docs workflow.

* **What is the current behavior?**
There is [the warning in docs workflow](https://github.com/Ralim/IronOS/actions/runs/12875477058):
[**deploy-docs**](https://github.com/Ralim/IronOS/actions/runs/12875477058/job/35896840617#step:3:10):
```
The `python-version` input is not set. The version of Python currently in `PATH` will be used.
```

* **What is the new behavior (if this is a feature change)?**
Set `python-version` explicitly for `actions/setup-python` in `docs.yml` workflow configuration file to remove the warning.

* **Other information**:
It seems that [since some time](https://github.com/actions/setup-python/issues/458) `actions/setup-python` recommends to set version of python explicitly, whether through local `.python-version` file in a repository or through [the variable with the related name](https://github.com/actions/setup-python#basic-usage) right in the _yml_ configuration file. So since there are already few configuration files right in the root directory, the preferable way would be just to set the value for the variable inside the related _yml_ configuration file. Selected version `'3.12.3'` based on the default version of python included to the enabled `ubuntu-latest` distro in the same _yml_ configuration file.