### PR TITLE
scripts/deploy.sh: add handmade linter for translation-related json files to check for tabs and odd spaces

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -215,7 +215,7 @@ jobs:
 
     steps:
       - name: Install dependencies (apk)
-        run: apk add --no-cache git
+        run: apk add --no-cache git bash grep
 
       - uses: actions/checkout@v4
         with:
@@ -227,4 +227,4 @@ jobs:
         run: git config --global --add safe.directory /__w/IronOS/IronOS && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Check and verify documentation
-        run: /bin/sh ./scripts/deploy.sh docs
+        run: ./scripts/deploy.sh docs

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ test-md:
 	@echo ""
 	@echo "---- Checking documentation... ----"
 	@echo ""
-	@/bin/sh  ./scripts/deploy.sh  docs
+	@./scripts/deploy.sh  docs
 
 # shell style & linter check (github CI version of shellcheck is more recent than alpine one so the latter may not catch some policies)
 test-sh:

--- a/Translations/translation_UZ.json
+++ b/Translations/translation_UZ.json
@@ -137,7 +137,7 @@
   "menuOptions": {
     "DCInCutoff": {
       "displayText": "Quvvat\nmanbai",
-      "description": "Batareya haddan tashqari zaryadsizlanishini oldini olish uchun kuchlanish chegarasini o'rnatish (DC 10V) (S=3.3V har bir yacheyka uchun, quvvat PWR chegarasini o'chirish)"			
+      "description": "Batareya haddan tashqari zaryadsizlanishini oldini olish uchun kuchlanish chegarasini o'rnatish (DC 10V) (S=3.3V har bir yacheyka uchun, quvvat PWR chegarasini o'chirish)"
     },
     "MinVolCell": {
       "displayText": "Minimal\nkuchlanish",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -97,7 +97,7 @@ docs_links()
 	md="README.md"
 	ver_md="$(grep -c "${ver_git}" "${md}")"
 	ret=0
-	if [ "${ver_md}" -ne 0 ]; then
+	if [ "${ver_md}" -eq 0 ]; then
 		ret=1
 		echo "Please, update mention & links in ${md} inside Builds section for release builds with version ${ver_git}."
 	fi;

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -110,14 +110,28 @@ build_langs()
 	mk="../source/Makefile"
 	cd Translations/ || exit 1
 	langs="$(echo "$(find ./*.json | sed -ne 's,^\./translation_,,; s,\.json$,,; /[A-Z]/p' ; sed -ne 's/^ALL_LANGUAGES=//p;' "${mk}")" | sed 's, ,\n,g; s,\r,,g' | sort | uniq -u)"
-	ret=0
 	if [ -n "${langs}" ]; then
-		ret=1
 		echo "It seems there is mismatch between supported languages and enabled builds."
 		echo "Please, check files in Translations/ and ALL_LANGUAGES variable in source/Makefile for:"
 		echo "${langs}"
+		return 1
 	fi;
-	return "${ret}"
+	
+	grep -nH $'\11' Translations/translation*.json
+	if [ "${?}" -eq 0 ]; then
+		echo "Please, remove any tabs as indention from json file(s) in Translations/ directory (see the exact files & lines in the list above)."
+		echo "Use spaces only to indent in the future, please."
+		return 1
+	fi;
+	
+	grep -nH -e "^ [^ ]" -e "^   [^ ]" -e "^     [^ ]" -e "^       [^ ]" -e "^         [^ ]" -e "^           [^ ]" Translations/translation*.json
+	if [ "${?}" -eq 0 ]; then
+		echo "Please, remove any odd amount of extra spaces as indention from json file(s) in Translations/ directory (see the exact files & lines in the list above)."
+		echo "Use even amount of spaces to indent in the future, please (two actual spaces per one indent, not tab)."
+		return 1
+	fi;
+	
+	return 0
 }
 
 # Helper function to check code style using clang-format & grep/sed custom parsers:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -122,7 +122,7 @@ build_langs()
 	grep -nH $'\11' Translations/translation*.json
 	ret="${?}"
 	if [ "${ret}" -eq 0 ]; then
-		echo -ne "\t^^^^\t^^^^"
+		echo -ne "\t^^^^\t^^^^\n"
 		echo "Please, remove any tabs as indention from json file(s) in Translations/ directory (see the exact files & lines in the list above)."
 		echo "Use spaces only to indent in the future, please."
 		echo -ne "\n"
@@ -132,7 +132,7 @@ build_langs()
 	grep -nH -e "^ [^ ]" -e "^   [^ ]" -e "^     [^ ]" -e "^       [^ ]" -e "^         [^ ]" -e "^           [^ ]" Translations/translation*.json
 	ret="${?}"
 	if [ "${ret}" -eq 0 ]; then
-		echo -ne "\t^^^^\t^^^^"
+		echo -ne "\t^^^^\t^^^^\n"
 		echo "Please, remove any odd amount of extra spaces as indention from json file(s) in Translations/ directory (see the exact files & lines in the list above)."
 		echo "Use even amount of spaces to indent in the future, please (two actual spaces per one indent, not tab)."
 		echo -ne "\n"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -116,6 +116,7 @@ build_langs()
 		echo "${langs}"
 		return 1
 	fi;
+	cd ..
 	
 	grep -nH $'\11' Translations/translation*.json
 	if [ "${?}" -eq 0 ]; then

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -130,7 +130,7 @@ build_langs()
 		return 1
 	fi;
 	
-	grep -nH -e "^ [^ ]" -e "^   [^ ]" -e "^     [^ ]" -e "^       [^ ]" -e "^         [^ ]" -e "^           [^ ]" Translations/translation*.json
+	grep -nEH -e "^( {1}| {3}| {5}| {7}| {9}| {11})[^ ]" Translations/translation*.json
 	ret="${?}"
 	if [ "${ret}" -eq 0 ]; then
 		echo -ne "\t^^^^\t^^^^\n"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -118,19 +118,24 @@ build_langs()
 	fi;
 	cd ..
 	
+	echo -ne "\n"
 	grep -nH $'\11' Translations/translation*.json
 	ret="${?}"
 	if [ "${ret}" -eq 0 ]; then
+		echo -ne "\t^^^^\t^^^^"
 		echo "Please, remove any tabs as indention from json file(s) in Translations/ directory (see the exact files & lines in the list above)."
 		echo "Use spaces only to indent in the future, please."
+		echo -ne "\n"
 		return 1
 	fi;
 	
 	grep -nH -e "^ [^ ]" -e "^   [^ ]" -e "^     [^ ]" -e "^       [^ ]" -e "^         [^ ]" -e "^           [^ ]" Translations/translation*.json
 	ret="${?}"
 	if [ "${ret}" -eq 0 ]; then
+		echo -ne "\t^^^^\t^^^^"
 		echo "Please, remove any odd amount of extra spaces as indention from json file(s) in Translations/ directory (see the exact files & lines in the list above)."
 		echo "Use even amount of spaces to indent in the future, please (two actual spaces per one indent, not tab)."
+		echo -ne "\n"
 		return 1
 	fi;
 	

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -119,14 +119,16 @@ build_langs()
 	cd ..
 	
 	grep -nH $'\11' Translations/translation*.json
-	if [ "${?}" -eq 0 ]; then
+	ret="${?}"
+	if [ "${ret}" -eq 0 ]; then
 		echo "Please, remove any tabs as indention from json file(s) in Translations/ directory (see the exact files & lines in the list above)."
 		echo "Use spaces only to indent in the future, please."
 		return 1
 	fi;
 	
 	grep -nH -e "^ [^ ]" -e "^   [^ ]" -e "^     [^ ]" -e "^       [^ ]" -e "^         [^ ]" -e "^           [^ ]" Translations/translation*.json
-	if [ "${?}" -eq 0 ]; then
+	ret="${?}"
+	if [ "${ret}" -eq 0 ]; then
 		echo "Please, remove any odd amount of extra spaces as indention from json file(s) in Translations/ directory (see the exact files & lines in the list above)."
 		echo "Use even amount of spaces to indent in the future, please (two actual spaces per one indent, not tab)."
 		return 1

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -95,6 +95,7 @@ docs_links()
 {
 	ver_git="$(git tag -l | sort | grep -e "^v" | grep -v "rc" | tail -1)"
 	md="README.md"
+	test -f "${md}" || (echo "deploy.sh: docs_links: ERROR with the project directory structure!" && exit 1)
 	ver_md="$(grep -c "${ver_git}" "${md}")"
 	ret=0
 	if [ "${ver_md}" -eq 0 ]; then
@@ -108,7 +109,7 @@ docs_links()
 build_langs()
 {
 	mk="../source/Makefile"
-	cd Translations/ || exit 1
+	cd Translations/ || (echo "deploy.sh: build_langs: ERROR with the project directory structure!" && exit 1)
 	langs="$(echo "$(find ./*.json | sed -ne 's,^\./translation_,,; s,\.json$,,; /[A-Z]/p' ; sed -ne 's/^ALL_LANGUAGES=//p;' "${mk}")" | sed 's, ,\n,g; s,\r,,g' | sort | uniq -u)"
 	if [ -n "${langs}" ]; then
 		echo "It seems there is mismatch between supported languages and enabled builds."


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Implement very basic check for tabs and odd spaces in `json` files.

* **What is the current behavior?**
There are no any automatic code style checks for `json` files.

* **What is the new behavior (if this is a feature change)?**
With every modification `json` files will be checked for tabs and odd spaces as part of CI/autotesting process.

* **Other information**:
There are some full-featured `json` linters, but the ones I saw required _nodejs_/_npm_ and other "_heavy_" toolsets, so for basic checks two calls of `grep` inside `bash` should be enough: it checks for tab as octet number `11` of tab control character (`9` in dec/hex from ASCII table), and for odd amount of spaces as indent. Both `grep` calls tested successfully on _MacOS 10.10.5_ with _GNU bash_ and _BSD grep_. It even already helped to discover existed mistype - [error message example here](https://github.com/ia/IronOSf/actions/runs/13082999957/job/36510086930).