### PR TITLE
fix: accessing inactive union members

### DIFF
--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -11,6 +11,7 @@
 #include "cmsis_os.h"
 #include "configuration.h"
 #include <OLED.hpp>
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -209,21 +210,18 @@ void OLED::drawChar(const uint16_t charCode, const FontStyle fontStyle, const ui
  * of the indicator in pixels (0..<16).
  */
 void OLED::drawScrollIndicator(uint8_t y, uint8_t height) {
-  union u_type {
-    uint32_t whole;
-    uint8_t  strips[4];
-  } column;
 
-  column.whole = (1 << height) - 1; // preload a set of set bits of height
-  column.whole <<= y;               // Shift down by the y value
-
+  const uint32_t whole = ((1 << height) - 1) << y; // preload a set of set bits of height
+                                                   // Shift down by the y value
+  const uint8_t strips[4] = {static_cast<uint8_t>(whole & 0xff), static_cast<uint8_t>((whole & 0xff00) >> 8 * 1), static_cast<uint8_t>((whole & 0xff0000) >> 8 * 2),
+                             static_cast<uint8_t>((whole & 0xff000000) >> 8 * 3)};
   // Draw a one pixel wide bar to the left with a single pixel as
   // the scroll indicator.
-  fillArea(OLED_WIDTH - 1, 0, 1, 8, column.strips[0]);
-  fillArea(OLED_WIDTH - 1, 8, 1, 8, column.strips[1]);
+  fillArea(OLED_WIDTH - 1, 0, 1, 8, strips[0]);
+  fillArea(OLED_WIDTH - 1, 8, 1, 8, strips[1]);
 #if OLED_HEIGHT == 32
-  fillArea(OLED_WIDTH - 1, 16, 1, 8, column.strips[2]);
-  fillArea(OLED_WIDTH - 1, 24, 1, 8, column.strips[3]);
+  fillArea(OLED_WIDTH - 1, 16, 1, 8, strips[2]);
+  fillArea(OLED_WIDTH - 1, 24, 1, 8, strips[3]);
 
 #endif
 }


### PR DESCRIPTION
Access to the inactive union members is an **undefined behavior**. 
`whole` is active member here,
https://github.com/Ralim/IronOS/blob/ab1fa2486355f7dd4bfd047ac30832439067adfd/source/Core/Drivers/OLED.cpp#L217
 but the `strips` (inactive) member accessed here.
https://github.com/Ralim/IronOS/blob/ab1fa2486355f7dd4bfd047ac30832439067adfd/source/Core/Drivers/OLED.cpp#L222


Standard C++ (Working Draft):

[\[defns.undefined\]](https://eel.is/c++draft/defns.undefined)
> 3.65[defns.undefined]undefined behavior
> behavior for which this document imposes no requirements
> [Note 1: Undefined behavior may be expected when this document omits any explicit definition of behavior or when a program uses an incorrect construct or invalid data. Permissible undefined behavior ranges from ignoring the situation completely with unpredictable results, to behaving during translation or program execution in a documented manner characteristic of the environment (with or without the issuance of a diagnostic message ([defns.diagnostic])), to terminating a translation or execution (with the issuance of a diagnostic message). Many incorrect program constructs do not engender undefined behavior; they are required to be diagnosed. Evaluation of a constant expression ([expr.const]) never exhibits behavior explicitly specified as undefined in [intro] through [cpp]. — end note]

[\[defns.undefined.runtime\]](https://eel.is/c++draft/defns.undefined.runtime)
> 3.50[defns.undefined.runtime]runtime-undefined behavior
> behavior that is undefined except when it occurs during constant evaluation
> [Note 1: During constant evaluation,
> it is implementation-defined whether runtime-undefined behavior results in the expression being deemed non-constant (as specified in [expr.const]) and
> runtime-undefined behavior has no other effect.
> — end note]

[\[basic.life\]](https://eel.is/c++draft/basic.life#2.sentence-3)
> except that if the object is a union member or subobject thereof, its lifetime only begins if that union member is the initialized member in the union ([dcl.init.aggr], [class.base.init]), or as described in [class.union], [class.copy.ctor], and [class.copy.assign], and except as described in [allocator.members]. The lifetime of an object o of type T ends when:
> -- if T is a non-class type, the object is destroyed, or
> -- if T is a class type, the destructor call starts, or
> -- the storage which the object occupies is released, or is reused by an object that is not nested within o ([intro.object]).

[\[class.union#general-2\]](https://eel.is/c++draft/class.union#general-2)
> In a union, a non-static data member is active if its name refers to an object whose lifetime has begun and has not ended ([basic.life]). At most one of the non-static data members of an object of union type can be active at any time, that is, the value of at most one of the non-static data members can be stored in a union at any time.

[\[basic.life#8\]](https://eel.is/c++draft/basic.life#8)

> Similarly, before the lifetime of an object has started but after the storage which the object will occupy has been allocated or, after the lifetime of an object has ended and before the storage which the object occupied is reused or released, any glvalue that refers to the original object may be used but only in limited ways. For an object under construction or destruction, see [class.cdtor]. Otherwise, such a glvalue refers to allocated storage ([basic.stc.dynamic.allocation]), and using the properties of the glvalue that do not depend on its value is well-defined. The program has undefined behavior if
> -- the glvalue is used to access the object, or
> -- the glvalue is used to call a non-static member function of the object, or
> -- the glvalue is bound to a reference to a virtual base class ([dcl.init.ref]), or
> -- the glvalue is used as the operand of a dynamic_cast ([expr.dynamic.cast]) or as the operand of typeid.


https://en.cppreference.com/w/cpp/language/union :

>  It is undefined behavior to read from the member of the union that wasn't most recently written.

```cpp
#include <cstdint>
#include <iostream>
 
union S
{
    std::int32_t n;     // occupies 4 bytes
    std::uint16_t s[2]; // occupies 4 bytes
    std::uint8_t c;     // occupies 1 byte
};                      // the whole union occupies 4 bytes
 
int main()
{
    S s = {0x12345678}; // initializes the first member, s.n is now the active member
    // At this point, reading from s.s or s.c is undefined behavior,
    // but most compilers define it.
    std::cout << std::hex << "s.n = " << s.n << '\n';
 
    s.s[0] = 0x0011; // s.s is now the active member
    // At this point, reading from s.n or s.c is undefined behavior,
    // but most compilers define it.
    std::cout << "s.c is now " << +s.c << '\n' // 11 or 00, depending on platform
              << "s.n is now " << s.n << '\n'; // 12340011 or 00115678
}
```

Same issue: https://gitlab.com/libeigen/eigen/-/issues/2898


Additional Note: Accessing parts of a _multi-byte integer_ via a _byte array_ may result in different output data, since the _byte order_ may differ across systems. However, without pointer casting, access via _bit shifts_ is guaranteed to result in the same behavior across platforms.
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [] The changes have been tested locally
- [] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->



* **What is the current behavior?**
<!-- (You can also just link to an open issue here) -->

* **What is the new behavior (if this is a feature change)?**

* **Other information**:
