### PR TITLE
README.md: add notice about BLE turned off by default now

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,19 @@ After powering on the device for the first time with _IronOS_ installed and havi
 
 Additional details are described in the [menu information](https://ralim.github.io/IronOS/Menu/).
 
+# Remote Control
+
+## Pinecil V2 only
+
+Pinecil V2 has [_Bluetooth Low Energy_ module](https://ralim.github.io/IronOS/Bluetooth), which is supported by _IronOS_ since `2.21` release to control some of the settings using additional tools like [PineSAM](https://github.com/builder555/PineSAM) or [PineTool](https://github.com/lachlanbell/PineTool). In `2.21` and `2.22` releases the module was _on_ by default. However, **_Bluetooth_ is turned off in the settings by default on current `dev` builds and for the next releases** [due to security concerns](#1856). But this is related only to situations when a user restores default settings using menu, or when the _IronOS_ update is taking place on a new device or on a device with a previous firmware version.
+
+To enable _Bluetooth_ back:
+- go to _Settings_ menu;
+- press `-/B` button four times to scroll the menu for `Advanced settings`;
+- press `+/A` button to open submenu;
+- press `+/A` button to toggle/enable _Bluetooth_ feature;
+- press `-/B` **and hold it** for just more than five seconds to exit from the _Settings_ menu.
+
 ## Translations
 
 Is your preferred language missing localisation of some of the text?

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Additional details are described in the [menu information](https://ralim.github.
 
 ## Pinecil V2 only
 
-Pinecil V2 has [_Bluetooth Low Energy_ module](https://ralim.github.io/IronOS/Bluetooth), which is supported by _IronOS_ since `2.21` release to control some of the settings using additional tools like [PineSAM](https://github.com/builder555/PineSAM) or [PineTool](https://github.com/lachlanbell/PineTool). In `2.21` and `2.22` releases the module was _on_ by default. However, **_Bluetooth_ is turned off in the settings by default on current `dev` builds and for the next releases** [due to security concerns](#1856). But this is related only to situations when a user restores default settings using menu, or when the _IronOS_ update is taking place on a new device or on a device with a previous firmware version.
+Pinecil V2 has [_Bluetooth Low Energy_ module](https://ralim.github.io/IronOS/Bluetooth), which is supported by _IronOS_ since `2.21` release to control some of the settings using additional tools like [PineSAM](https://github.com/builder555/PineSAM) or [PineTool](https://github.com/lachlanbell/PineTool). In `2.21` and `2.22` releases the module was _on_ by default. However, **_Bluetooth_ is turned off in the settings by default in current `dev` builds and for the next releases** [due to security concerns](#1856).[^ble]
 
 To enable _Bluetooth_ back:
 - go to _Settings_ menu;
@@ -151,6 +151,9 @@ To enable _Bluetooth_ back:
 - press `+/A` button to open submenu;
 - press `+/A` button to toggle/enable _Bluetooth_ feature;
 - press `-/B` **and hold it** for just more than five seconds to exit from the _Settings_ menu.
+
+[^ble]:
+    This is related only to situations when a user restores default settings using menu, or when _IronOS_ update is taking place on a new device or on a device with a previous firmware version.
 
 ## Translations
 


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Add notice that _BLE_ is turned off in _IronOS_ for _Pinecil V2_ by default.

* **What is the current behavior?**
There is no any information about _BLE_ in _Pinecil V2_, nor that it's off by default now.

* **What is the new behavior (if this is a feature change)?**
Main `REAMDE.md` provides basic information about _BLE_ in _Pinecil V2_ & its new default setting, and how to turn it on back.

* **Other information**:
This is follow-up for [very good suggestion](https://github.com/Ralim/IronOS/issues/1856#issuecomment-2608817183).