### PR TITLE
Default to no EPR/PPS so its opt in

### DIFF
--- a/source/Core/Src/Settings.cpp
+++ b/source/Core/Src/Settings.cpp
@@ -93,7 +93,7 @@ static const SettingConstants settingsConstants[(int)SettingsOptions::SettingsOp
     {                     0,                                                                     6,                 1,                            1}, // LOGOTime
     {                     0,                                                                     1,                 1,                            0}, // CalibrateCJC
     {                     0,                                                                     1,                 1,                            0}, // BluetoothLE
-    {                     0,                                                                     2,                 1,                            1}, // USBPDMode
+    {                     0,                                                                     2,                 1,                            0}, // USBPDMode
     {                     1,                                                                     5,                 1,                            4}, // ProfilePhases
     {            MIN_TEMP_C,                                                            MAX_TEMP_F,                 5,                           90}, // ProfilePreheatTemp
     {                     1,                                                                    10,                 1,                            1}, // ProfilePreheatSpeed


### PR DESCRIPTION
Some chargers have funky PPS.
Plus some do not want EPR be default (even though 28V is safe by designer on PinecilV2).

So take the safest option by default and make it opt-in


<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
Request from Pinecil Chat - d​simic


* **What is the current behavior?**
<!-- (You can also just link to an open issue here) -->

* **What is the new behavior (if this is a feature change)?**

* **Other information**:
