### PR TITLE
Add the notice about EPR/PPS disabled by default in the main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ _This firmware does **NOT** support the USB port while running for changing sett
 
 ## Supported Hardware
 
-|     Device     | DC  | QC  | PD  | EPR | BLE | Tip Sense | Recommended Purchase |                  Notes                  |
+|     Device     | DC  | QC  | PD  | EPR\*\*\*\* | BLE | Tip Sense | Recommended Purchase |                  Notes                  |
 | :------------: | :-: | :-: | :-: | :-: | :-: | :-------: | :------------------: | :-------------------------------------: |
 | Miniware MHP30 | ❌  | ❌  | ✔️  | ❌  | ❌  |    ✔️     |          ✔️          |                                         |
 |   Pinecil V1   | ✔️  | ✔️  | ✔️  | ❌  | ❌  |    ❌     |        ❌ \*         |                                         |
@@ -47,6 +47,8 @@ The _TS101_ & _S60(P)_ irons and _MHP30_ & _T55_ plates feature a higher resolut
 \*\* Please note that _Miniware_ started shipping _TS100_'s using **cloned STM32 chips**. While these do work with _IronOS_, their **DFU bootloader** works terribly, and it is hard to get it to successfully flash larger firmware images like _IronOS_ without timing out. This is the main reason why the _TS100_ is **_no longer recommended_**.
 
 \*\*\* _TS80_ is replaced by _TS80P_. Production ramped down a long time ago and it's just existing stock clearing the system. It's marked not recommended being optimistic that people might pause and buy the far superior _TS80P_ instead. This is the main reason why the _TS80_ is **_no longer recommended_**.
+
+\*\*\*\* EPR/PPS with 28V support is _**disabled by default**_ due to [safety concerns](https://github.com/Ralim/IronOS/pull/2073), but to turn it back on set _Power settings_ - _PD Mode_ to _Safe_ or _Default_.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The _TS101_ & _S60(P)_ irons and _MHP30_ & _T55_ plates feature a higher resolut
 
 \*\*\* _TS80_ is replaced by _TS80P_. Production ramped down a long time ago and it's just existing stock clearing the system. It's marked not recommended being optimistic that people might pause and buy the far superior _TS80P_ instead. This is the main reason why the _TS80_ is **_no longer recommended_**.
 
-\*\*\*\* **EPR/PPS with 28V support** is _**disabled by default**_ due to [safety concerns](https://github.com/Ralim/IronOS/pull/2073), but to enable it back
+\*\*\*\* **EPR/PPS with 28V support** is _**disabled by default**_ due to [safety concerns](https://github.com/Ralim/IronOS/pull/2073), but to enable it back  
 set _PD Mode_ option in _Power settings_ submenu to _Safe_ or _Default_.
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The _TS101_ & _S60(P)_ irons and _MHP30_ & _T55_ plates feature a higher resolut
 
 \*\*\* _TS80_ is replaced by _TS80P_. Production ramped down a long time ago and it's just existing stock clearing the system. It's marked not recommended being optimistic that people might pause and buy the far superior _TS80P_ instead. This is the main reason why the _TS80_ is **_no longer recommended_**.
 
-\*\*\*\* **EPR/PPS with 28V support** is _**disabled by default**_ due to [safety concerns](https://github.com/Ralim/IronOS/pull/2073), but to enable it back set  
+\*\*\*\* **EPR/PPS with 28V support** is _**disabled by default**_ due to [safety concerns](https://github.com/Ralim/IronOS/pull/2073), but to turn it back on set  
 _PD Mode_ option in _Power settings_ submenu to _Safe_ or _Default_.
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ The _TS101_ & _S60(P)_ irons and _MHP30_ & _T55_ plates feature a higher resolut
 
 \*\*\* _TS80_ is replaced by _TS80P_. Production ramped down a long time ago and it's just existing stock clearing the system. It's marked not recommended being optimistic that people might pause and buy the far superior _TS80P_ instead. This is the main reason why the _TS80_ is **_no longer recommended_**.
 
-\*\*\*\* **EPR/PPS with 28V support** is _**disabled by default**_ due to [safety concerns](https://github.com/Ralim/IronOS/pull/2073), but to enable it back  
-set _PD Mode_ option in _Power settings_ submenu to _Safe_ or _Default_.
+\*\*\*\* **EPR/PPS with 28V support** is _**disabled by default**_ due to [safety concerns](https://github.com/Ralim/IronOS/pull/2073), but to enable it back set  
+_PD Mode_ option in _Power settings_ submenu to _Safe_ or _Default_.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The _TS101_ & _S60(P)_ irons and _MHP30_ & _T55_ plates feature a higher resolut
 
 \*\*\* _TS80_ is replaced by _TS80P_. Production ramped down a long time ago and it's just existing stock clearing the system. It's marked not recommended being optimistic that people might pause and buy the far superior _TS80P_ instead. This is the main reason why the _TS80_ is **_no longer recommended_**.
 
-\*\*\*\* EPR/PPS with 28V support is _**disabled by default**_ due to [safety concerns](https://github.com/Ralim/IronOS/pull/2073), but to turn it back on set _Power settings_ - _PD Mode_ to _Safe_ or _Default_.
+\*\*\*\* **EPR/PPS with 28V support** is _**disabled by default**_ due to [safety concerns](https://github.com/Ralim/IronOS/pull/2073), but to enable it back set _PD Mode_ option in _Power settings_ submenu to _Safe_ or _Default_.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ The _TS101_ & _S60(P)_ irons and _MHP30_ & _T55_ plates feature a higher resolut
 
 \*\*\* _TS80_ is replaced by _TS80P_. Production ramped down a long time ago and it's just existing stock clearing the system. It's marked not recommended being optimistic that people might pause and buy the far superior _TS80P_ instead. This is the main reason why the _TS80_ is **_no longer recommended_**.
 
-\*\*\*\* **EPR/PPS with 28V support** is _**disabled by default**_ due to [safety concerns](https://github.com/Ralim/IronOS/pull/2073), but to enable it set _PD Mode_ option in _Power settings_ submenu to _Safe_ or _Default_.
+\*\*\*\* **EPR/PPS with 28V support** is _**disabled by default**_ due to [safety concerns](https://github.com/Ralim/IronOS/pull/2073), but to enable it back
+set _PD Mode_ option in _Power settings_ submenu to _Safe_ or _Default_.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The _TS101_ & _S60(P)_ irons and _MHP30_ & _T55_ plates feature a higher resolut
 
 \*\*\* _TS80_ is replaced by _TS80P_. Production ramped down a long time ago and it's just existing stock clearing the system. It's marked not recommended being optimistic that people might pause and buy the far superior _TS80P_ instead. This is the main reason why the _TS80_ is **_no longer recommended_**.
 
-\*\*\*\* **EPR/PPS with 28V support** is _**disabled by default**_ due to [safety concerns](https://github.com/Ralim/IronOS/pull/2073), but to enable it back set _PD Mode_ option in _Power settings_ submenu to _Safe_ or _Default_.
+\*\*\*\* **EPR/PPS with 28V support** is _**disabled by default**_ due to [safety concerns](https://github.com/Ralim/IronOS/pull/2073), but to enable it set _PD Mode_ option in _Power settings_ submenu to _Safe_ or _Default_.
 
 ## Getting Started
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Main `README.md` update.

* **What is the current behavior?**
There is no mention about _EPR/PPS_ [disabled by default now](#2073).

* **What is the new behavior (if this is a feature change)?**
Add _"foot note"-like_ mention about _EPR/PPS_ disabled by default right in the table with _Supported Hardware_, and how to enable it back.

* **Other information**:
I think it's worth adding, so new users getting _Pinecil V2_ for its main feature wouldn't be much confused why it doesn't work _out-of-the-box_.