### PR TITLE
Debug Menu: add time of compilation to timestamp build

### DIFF
--- a/Documentation/DebugMenu.md
+++ b/Documentation/DebugMenu.md
@@ -40,9 +40,9 @@ I.e.:
 
 **Additional scroll-able items appear in this order**:
 
-### Date
+### Timestamp
 
-- This is a date of firmware compilation and it has the following format: `DD-MM-YY` (i.e., `01-07-23` means it has been built in July, 1st, 2023)
+- This is a timestamp of firmware compilation and it has the following format: `YYYYMMDD HHMMSS` (i.e., `20230701 213456` means it has been built in July, 1st, 2023 at 9:34:56 pm)
 
 ### ID
 

--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -152,7 +152,7 @@ def get_constants() -> List[Tuple[str, str]]:
 
 def get_debug_menu() -> List[str]:
     return [
-        datetime.today().strftime("%Y-%m-%d"),
+        datetime.today().strftime("%Y%m%d %H%M%S"),
         "ID ",
         "ACC   ",
         "PWR   ",


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Add time of compilation to timestamp build in _Debug Menu_.

* **What is the current behavior?**
Timestamp in _Debug Menu_ shows date of build only.

* **What is the new behavior (if this is a feature change)?**
Timestamp in _Debug Menu_ shows time of build (`HHMMSS`) right next to a date of build.

* **Other information**:
While testing different builds with local changes only (i.e., can't rely on `sha id` info), I would like to have more _"differential"_ way to distinguish prepared test builds. Considering that there are a perfect spot for time even on _96x16_ screens, I hope it won't hurt. In addition, as you may know, a lot of timestamp build info for all kind of software usually contains not only date but time as well, so it's a well known common practice:
```
$ uname -a
Linux cs-default 6.1.58+ #1 SMP PREEMPT_DYNAMIC ** Mon Jan 29 15:19:25 UTC 2024 ** x86_64 GNU/Linux
```