### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/source/Middlewares/Third_Party/FreeRTOS/Source/queue.c
+++ b/source/Middlewares/Third_Party/FreeRTOS/Source/queue.c
@@ -397,6 +397,9 @@ BaseType_t xQueueGenericReset( QueueHandle_t xQueue,
         /* Check for multiplication overflow. */
         configASSERT( ( uxItemSize == 0 ) || ( uxQueueLength == ( xQueueSizeInBytes / uxItemSize ) ) );
 
+        /* Check for addition overflow. */
+        configASSERT( ( sizeof( Queue_t ) + xQueueSizeInBytes ) >  xQueueSizeInBytes );
+        
         /* Allocate the queue and storage area.  Justification for MISRA
          * deviation as follows:  pvPortMalloc() always ensures returned memory
          * blocks are aligned per the requirements of the MCU stack.  In this case


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
This PR fixes a security vulnerability in xQueueGenericCreate() that was cloned from FreeRTOS-Kernel but did not receive the security patch. The original issue was reported and fixed under https://github.com/FreeRTOS/FreeRTOS-Kernel/commit/47338393f1f79558f6144213409f09f81d7c4837.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2021-31571
https://github.com/FreeRTOS/FreeRTOS-Kernel/commit/47338393f1f79558f6144213409f09f81d7c4837