### PR TITLE
Fix: Potential Vulnerability in Cloned Function

### DIFF
--- a/source/Core/BSP/Pinecilv2/bl_mcu_sdk/components/ble/ble_stack/common/tinycrypt/source/ecc_dsa.c
+++ b/source/Core/BSP/Pinecilv2/bl_mcu_sdk/components/ble/ble_stack/common/tinycrypt/source/ecc_dsa.c
@@ -118,7 +118,7 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash, un
      protection against side-channel attacks. */
   if (g_rng_function) {
     if (!uECC_generate_random_int(k2[carry], curve->p, num_words)) {
-        return 0;
+      return 0;
     }
     initial_Z = k2[carry];
   }

--- a/source/Core/BSP/Pinecilv2/bl_mcu_sdk/components/ble/ble_stack/common/tinycrypt/source/ecc_dsa.c
+++ b/source/Core/BSP/Pinecilv2/bl_mcu_sdk/components/ble/ble_stack/common/tinycrypt/source/ecc_dsa.c
@@ -101,6 +101,7 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash, un
   uECC_word_t  tmp[NUM_ECC_WORDS];
   uECC_word_t  s[NUM_ECC_WORDS];
   uECC_word_t *k2[2] = {tmp, s};
+  uECC_word_t *initial_Z = 0;
   uECC_word_t  p[NUM_ECC_WORDS * 2];
   uECC_word_t  carry;
   wordcount_t  num_words   = curve->num_words;
@@ -113,7 +114,15 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash, un
   }
 
   carry = regularize_k(k, tmp, s, curve);
-  EccPoint_mult(p, curve->G, k2[!carry], 0, num_n_bits + 1, curve);
+  /* If an RNG function was specified, try to get a random initial Z value to improve
+     protection against side-channel attacks. */
+  if (g_rng_function) {
+      if (!uECC_generate_random_int(k2[carry], curve->p, num_words)) {
+          return 0;
+      }
+      initial_Z = k2[carry];
+  }
+  EccPoint_mult(p, curve->G, k2[!carry], initial_Z, num_n_bits + 1, curve);
   if (uECC_vli_isZero(p, num_words)) {
     return 0;
   }

--- a/source/Core/BSP/Pinecilv2/bl_mcu_sdk/components/ble/ble_stack/common/tinycrypt/source/ecc_dsa.c
+++ b/source/Core/BSP/Pinecilv2/bl_mcu_sdk/components/ble/ble_stack/common/tinycrypt/source/ecc_dsa.c
@@ -100,7 +100,7 @@ static void bits2int(uECC_word_t *native, const uint8_t *bits, unsigned bits_siz
 int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash, unsigned hash_size, uECC_word_t *k, uint8_t *signature, uECC_Curve curve) {
   uECC_word_t  tmp[NUM_ECC_WORDS];
   uECC_word_t  s[NUM_ECC_WORDS];
-  uECC_word_t *k2[2] = {tmp, s};
+  uECC_word_t *k2[2]     = {tmp, s};
   uECC_word_t *initial_Z = 0;
   uECC_word_t  p[NUM_ECC_WORDS * 2];
   uECC_word_t  carry;
@@ -117,10 +117,10 @@ int uECC_sign_with_k(const uint8_t *private_key, const uint8_t *message_hash, un
   /* If an RNG function was specified, try to get a random initial Z value to improve
      protection against side-channel attacks. */
   if (g_rng_function) {
-      if (!uECC_generate_random_int(k2[carry], curve->p, num_words)) {
-          return 0;
-      }
-      initial_Z = k2[carry];
+    if (!uECC_generate_random_int(k2[carry], curve->p, num_words)) {
+        return 0;
+    }
+    initial_Z = k2[carry];
   }
   EccPoint_mult(p, curve->G, k2[!carry], initial_Z, num_n_bits + 1, curve);
   if (uECC_vli_isZero(p, num_words)) {


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
This PR fixes a security vulnerability in uECC_sign_with_k() that was cloned from micro-ecc but did not receive the security patch. The original issue was reported and fixed under https://github.com/kmackay/micro-ecc/commit/1b5f5cea5145c96dd8791b9b2c41424fc74c2172.
This PR applies the same patch to eliminate the vulnerability.

**References**
https://nvd.nist.gov/vuln/detail/CVE-2020-27209
https://github.com/kmackay/micro-ecc/commit/1b5f5cea5145c96dd8791b9b2c41424fc74c2172