### PR TITLE
push.yml: update runs-on to ubuntu-24.04 to fix upload_metadata build step

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -118,7 +118,7 @@ jobs:
 
   upload_metadata:
     needs: [build, build_multi-lang]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Download all prebuilts
@@ -197,7 +197,7 @@ jobs:
 
   check_shell:
     name: check_shell
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: shellcheck


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Update runs-on to ubuntu-24.04 to fix `upload_metadata` build step in GitHub Actions.

* **What is the current behavior?**
[Build error](https://github.com/ia/IronOSf/actions/runs/13656421811/job/38176930648): `This is a scheduled Ubuntu 20.04 brownout. Ubuntu 20.04 LTS runner will be removed on 2025-04-01. For more details, see https://github.com/actions/runner-images/issues/11101`.

* **What is the new behavior (if this is a feature change)?**
Build pipeline should be fixed & restored.

* **Other information**:
[Bug report](#2096).