### PR TITLE
AnimationSlide: add a new setting to control slide-scroll animation

### DIFF
--- a/Translations/translation_BE.json
+++ b/Translations/translation_BE.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "Ч",
     "SettingStartSleepOffChar": "К",
     "SettingLockBoostChar": "Т",
-    "SettingLockFullChar": "П"
+    "SettingLockFullChar": "П",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Хуткасць\nанімацыі",

--- a/Translations/translation_BE.json
+++ b/Translations/translation_BE.json
@@ -275,6 +275,10 @@
       "displayText": "Інвертаваць\nкнопкі",
       "description": "Інвертаваць кнопкі вымярэння тэмпературы"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Хуткасць\nанімацыі",
       "description": "Хуткасць анімацыі гузікаў у галоўным меню (Мілісекунды) (Н=Нізкая | С=Сярэдняя | В=Высокая)"

--- a/Translations/translation_BG.json
+++ b/Translations/translation_BG.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "С",
     "SettingStartSleepOffChar": "П",
     "SettingLockBoostChar": "Т",
-    "SettingLockFullChar": "П"
+    "SettingLockFullChar": "П",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Скорост на\nанимацията",

--- a/Translations/translation_BG.json
+++ b/Translations/translation_BG.json
@@ -275,6 +275,10 @@
       "displayText": "Размяна\nбутони +/-",
       "description": "Обръщане на бутоните + и - за промяна на температурата на човка на поялника"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Скорост на\nанимацията",
       "description": "Скорост на анимация на иконата в главното меню (Н=Ниска | C=Средна | B=Висока)"

--- a/Translations/translation_CS.json
+++ b/Translations/translation_CS.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "S",
     "SettingStartSleepOffChar": "M",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "U"
+    "SettingLockFullChar": "U",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Anim.\nrychlost",

--- a/Translations/translation_CS.json
+++ b/Translations/translation_CS.json
@@ -275,6 +275,10 @@
       "displayText": "Prohodit\ntl. +-?",
       "description": "Prohodit tlačítka pro změnu teploty"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nrychlost",
       "description": "Tempo animace ikon v menu (P=pomalu | S=středně | R=rychle)"

--- a/Translations/translation_DA.json
+++ b/Translations/translation_DA.json
@@ -275,6 +275,10 @@
       "displayText": "Skift\n+ - tasterne",
       "description": "Skift tildeling af knapper til temperaturjustering"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nHastighed",
       "description": "Hastigheden for ikonanimationer i menuen (S=langsomt | M=medium | F=hurtigt)"

--- a/Translations/translation_DA.json
+++ b/Translations/translation_DA.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "D",
     "SettingStartSleepOffChar": "R",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Anim.\nHastighed",

--- a/Translations/translation_DE.json
+++ b/Translations/translation_DE.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "R",
     "SettingStartSleepOffChar": "K",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "V"
+    "SettingLockFullChar": "V",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Anim.\nGeschw.",

--- a/Translations/translation_DE.json
+++ b/Translations/translation_DE.json
@@ -275,6 +275,10 @@
       "displayText": "+- Tasten\numkehren",
       "description": "Tastenbelegung zur Temperaturänderung umkehren"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nGeschw.",
       "description": "Geschwindigkeit der Icon-Animationen im Menü (L=langsam | M=mittel | S=schnell)"

--- a/Translations/translation_EL.json
+++ b/Translations/translation_EL.json
@@ -275,6 +275,10 @@
       "displayText": "Αντιστροφή\nπλήκτρων + -",
       "description": "Αντιστροφή διάταξης πλήκτρων στη ρύθμιση θερμοκρασίας"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Ταχύτητα\nκιν. εικονιδ.",
       "description": "Ρυθμός κίνησης εικονιδίων στο μενού (Α=αργός | Μ=μέτριος | Γ=γρήγορος)"

--- a/Translations/translation_EL.json
+++ b/Translations/translation_EL.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "Ζ",
     "SettingStartSleepOffChar": "Υ",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "Π"
+    "SettingLockFullChar": "Π",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Ταχύτητα\nκιν. εικονιδ.",

--- a/Translations/translation_EN.json
+++ b/Translations/translation_EN.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "Z",
     "SettingStartSleepOffChar": "R",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Anim.\nspeed",

--- a/Translations/translation_EN.json
+++ b/Translations/translation_EN.json
@@ -275,6 +275,10 @@
       "displayText": "Swap\n+ - keys",
       "description": "Reverse assignment of buttons for temperature adjustment"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nspeed",
       "description": "Pace of icon animations in menu (S=slow | M=medium | F=fast)"

--- a/Translations/translation_ES.json
+++ b/Translations/translation_ES.json
@@ -275,6 +275,10 @@
       "displayText": "Invertir\nbotones +/-",
       "description": "Invertir botones de ajuste de temperatura"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nvelocidad",
       "description": "Velocidad de animaciones de iconos en el menú (L=baja | M=media | R=alta)"

--- a/Translations/translation_ES.json
+++ b/Translations/translation_ES.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "R",
     "SettingStartSleepOffChar": "F",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Anim.\nvelocidad",

--- a/Translations/translation_ET.json
+++ b/Translations/translation_ET.json
@@ -275,6 +275,10 @@
       "displayText": "Vaheta\n+ - nupud",
       "description": "Temperatuurinuppude asukohtade vahetus"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nkiirus",
       "description": "Menüüikoonide animatsiooni kiirus (A=aeglane | K=keskmine | T=tempokas)"

--- a/Translations/translation_ET.json
+++ b/Translations/translation_ET.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "Z",
     "SettingStartSleepOffChar": "P",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "T"
+    "SettingLockFullChar": "T",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Anim.\nkiirus",

--- a/Translations/translation_FI.json
+++ b/Translations/translation_FI.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "L",
     "SettingStartSleepOffChar": "H",
     "SettingLockBoostChar": "V",
-    "SettingLockFullChar": "K"
+    "SettingLockFullChar": "K",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Animaation\nnopeus",

--- a/Translations/translation_FI.json
+++ b/Translations/translation_FI.json
@@ -275,6 +275,10 @@
       "displayText": "Suunnanvaihto\n+ - näppäimille",
       "description": "Lämpötilapainikkeiden suunnan vaihtaminen"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Animaation\nnopeus",
       "description": "Animaatioiden nopeus valikossa (A=alhainen | K=keskiverto | S=suuri)"

--- a/Translations/translation_FR.json
+++ b/Translations/translation_FR.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "V",
     "SettingStartSleepOffChar": "O",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "V"
+    "SettingLockFullChar": "V",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Vitesse\nanim. icônes",

--- a/Translations/translation_FR.json
+++ b/Translations/translation_FR.json
@@ -275,6 +275,10 @@
       "displayText": "Inverser les\ntouches + -",
       "description": "Inverser les boutons d'ajustement de température"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Vitesse\nanim. icônes",
       "description": "Vitesse des animations des icônes dans le menu (L=lente | M=moyenne | R=rapide)"

--- a/Translations/translation_HR.json
+++ b/Translations/translation_HR.json
@@ -275,6 +275,10 @@
       "displayText": "Zamjena\n+ - tipki",
       "description": "Zamjenjuje funkciju gornje i donje tipke za podešavanje temperature"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Brzina\nanimacije",
       "description": "Brzina animacije ikona u menijima (S=sporo | M=srednje | B=brzo)"

--- a/Translations/translation_HR.json
+++ b/Translations/translation_HR.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "T",
     "SettingStartSleepOffChar": "H",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "Z"
+    "SettingLockFullChar": "Z",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Brzina\nanimacije",

--- a/Translations/translation_HU.json
+++ b/Translations/translation_HU.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "A",
     "SettingStartSleepOffChar": "Sz",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "T"
+    "SettingLockFullChar": "T",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Animáció\nsebessége",

--- a/Translations/translation_HU.json
+++ b/Translations/translation_HU.json
@@ -275,6 +275,10 @@
       "displayText": "+/- gomb\nmegfordítása",
       "description": "Forrasztó hegy hőmérsékletállító gombok felcserélése"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Animáció\nsebessége",
       "description": "Menüikonok animációjának sebessége (L=lassú | K=közepes | Gy=gyors)"

--- a/Translations/translation_IT.json
+++ b/Translations/translation_IT.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "R",
     "SettingStartSleepOffChar": "A",
     "SettingLockBoostChar": "T",
-    "SettingLockFullChar": "C"
+    "SettingLockFullChar": "C",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Velocità\nanimazioni",

--- a/Translations/translation_IT.json
+++ b/Translations/translation_IT.json
@@ -275,6 +275,10 @@
       "displayText": "Inversione\ntasti",
       "description": "Inverti i tasti per aumentare o diminuire la temperatura della punta"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Velocità\nanimazioni",
       "description": "Imposta la velocità di riproduzione delle animazioni del menù principale [L: lenta; M: media; V: veloce]"

--- a/Translations/translation_JA_JP.json
+++ b/Translations/translation_JA_JP.json
@@ -275,6 +275,10 @@
       "displayText": "キー入れ替え",
       "description": "温度設定時に+ボタンと-ボタンを入れ替える"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "動画の速度",
       "description": "メニューアイコンのアニメーションの速さ <遅=低速 | 中=中速 | 速=高速>"

--- a/Translations/translation_JA_JP.json
+++ b/Translations/translation_JA_JP.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "待",
     "SettingStartSleepOffChar": "室",
     "SettingLockBoostChar": "ブ",
-    "SettingLockFullChar": "全"
+    "SettingLockFullChar": "全",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "動画の速度",

--- a/Translations/translation_LT.json
+++ b/Translations/translation_LT.json
@@ -275,6 +275,10 @@
       "displayText": "Sukeisti + -\nmygtukus?",
       "description": "Sukeisti + - temperatūros keitimo mygtukus vietomis"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Animacijų\ngreitis",
       "description": "Paveiksliukų animacijų greitis meniu punktuose (L=Lėtas | V=Vidutinis | G=Greitas)"

--- a/Translations/translation_LT.json
+++ b/Translations/translation_LT.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "M",
     "SettingStartSleepOffChar": "K",
     "SettingLockBoostChar": "T",
-    "SettingLockFullChar": "V"
+    "SettingLockFullChar": "V",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Animacijų\ngreitis",

--- a/Translations/translation_NB.json
+++ b/Translations/translation_NB.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "D",
     "SettingStartSleepOffChar": "R",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Anim.\nhastighet",

--- a/Translations/translation_NB.json
+++ b/Translations/translation_NB.json
@@ -275,6 +275,10 @@
       "displayText": "Bytt\n+ - kn.",
       "description": "Bytt om på knappene for å stille temperatur"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nhastighet",
       "description": "Hastigheten til animasjonene i menyen (S=slow | M=medium | F=fast)"

--- a/Translations/translation_NL.json
+++ b/Translations/translation_NL.json
@@ -275,6 +275,10 @@
       "displayText": "Wissel\n+ - knoppen",
       "description": "Wissel de knoppen voor temperatuur controle om"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nsnelheid",
       "description": "Snelheid van de icoon animaties in het menu (Langzaam | Middel | Snel)"

--- a/Translations/translation_NL.json
+++ b/Translations/translation_NL.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "S",
     "SettingStartSleepOffChar": "Z",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "V"
+    "SettingLockFullChar": "V",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Anim.\nsnelheid",

--- a/Translations/translation_NL_BE.json
+++ b/Translations/translation_NL_BE.json
@@ -275,6 +275,10 @@
       "displayText": "Wissel\n+ - knoppen",
       "description": "Wissel de knoppen voor temperatuur controle"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nsnelheid",
       "description": "Snelheid van de icoon animaties in het menu (T=sloom | M=middel | S=snel)"

--- a/Translations/translation_NL_BE.json
+++ b/Translations/translation_NL_BE.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "S",
     "SettingStartSleepOffChar": "K",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Anim.\nsnelheid",

--- a/Translations/translation_PL.json
+++ b/Translations/translation_PL.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "Z",
     "SettingStartSleepOffChar": "O",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "P"
+    "SettingLockFullChar": "P",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Prędkosć\nanimacji",

--- a/Translations/translation_PL.json
+++ b/Translations/translation_PL.json
@@ -275,6 +275,10 @@
       "displayText": "Zamień przyc.\n+ -",
       "description": "Zamienia działanie przycisków zmiany temperatury grotu"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Prędkosć\nanimacji",
       "description": "Prędkość animacji ikon w menu (W: mała | M: średnia | S: duża)"

--- a/Translations/translation_PT.json
+++ b/Translations/translation_PT.json
@@ -275,6 +275,10 @@
       "displayText": "Trocar\nbotões + -",
       "description": "Inverte o funcionamento dos botões de ajuste da temperatura"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Velocidade\nde animação",
       "description": "Velocidade das animações no menu (S=lenta | M=média | F=rápida)"

--- a/Translations/translation_PT.json
+++ b/Translations/translation_PT.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "H",
     "SettingStartSleepOffChar": "A",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Velocidade\nde animação",

--- a/Translations/translation_RO.json
+++ b/Translations/translation_RO.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "Z",
     "SettingStartSleepOffChar": "R",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Animaţii\nviteză",

--- a/Translations/translation_RO.json
+++ b/Translations/translation_RO.json
@@ -275,6 +275,10 @@
       "displayText": "Inversare\n+ - butoane",
       "description": "Inversarea butoanelor de reglare a temperaturii"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Animaţii\nviteză",
       "description": "Ritmul animaţiilor pictogramei din meniu (Î=încet | M=mediu | R=rapid)"

--- a/Translations/translation_RU.json
+++ b/Translations/translation_RU.json
@@ -275,6 +275,10 @@
       "displayText": "Поменять\nкнопки +/-",
       "description": "Поменять кнопки изменения температуры"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Скорость\nанимации",
       "description": "Скорость анимации иконок в главном меню (М=Медленная| С=Средняя | Б=Быстрая)"

--- a/Translations/translation_RU.json
+++ b/Translations/translation_RU.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "С",
     "SettingStartSleepOffChar": "К",
     "SettingLockBoostChar": "Т",
-    "SettingLockFullChar": "П"
+    "SettingLockFullChar": "П",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Скорость\nанимации",

--- a/Translations/translation_SK.json
+++ b/Translations/translation_SK.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "S",
     "SettingStartSleepOffChar": "I",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "P"
+    "SettingLockFullChar": "P",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Rýchlosť\nanimácií",

--- a/Translations/translation_SK.json
+++ b/Translations/translation_SK.json
@@ -275,6 +275,10 @@
       "displayText": "Otočenie\ntlačidiel +/-",
       "description": "Prehodenie tlačidiel na nastavovanie teploty"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Rýchlosť\nanimácií",
       "description": "Rýchlosť animácií ikoniek v menu (P=pomaly | S=stredne | R=rýchlo)"

--- a/Translations/translation_SL.json
+++ b/Translations/translation_SL.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "Z",
     "SettingStartSleepOffChar": "V",
     "SettingLockBoostChar": "L",
-    "SettingLockFullChar": "P"
+    "SettingLockFullChar": "P",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Anim.\nspeed",

--- a/Translations/translation_SL.json
+++ b/Translations/translation_SL.json
@@ -275,6 +275,10 @@
       "displayText": "Obrni\ntipki + -?",
       "description": "Zamenjaj funkciji gumbov."
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nspeed",
       "description": "Pace of icon animations in menu (P=slow | M=medium | H=fast)"

--- a/Translations/translation_SR_CYRL.json
+++ b/Translations/translation_SR_CYRL.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "С",
     "SettingStartSleepOffChar": "X",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Anim.\nspeed",

--- a/Translations/translation_SR_CYRL.json
+++ b/Translations/translation_SR_CYRL.json
@@ -275,6 +275,10 @@
       "displayText": "Swap\n+ - keys",
       "description": "Reverse assignment of buttons for temperature adjustment"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nspeed",
       "description": "Pace of icon animations in menu (С=slow | M=medium | Б=fast)"

--- a/Translations/translation_SR_LATN.json
+++ b/Translations/translation_SR_LATN.json
@@ -275,6 +275,10 @@
       "displayText": "Swap\n+ - keys",
       "description": "Reverse assignment of buttons for temperature adjustment"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nspeed",
       "description": "Pace of icon animations in menu (S=slow | M=medium | B=fast)"

--- a/Translations/translation_SR_LATN.json
+++ b/Translations/translation_SR_LATN.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "S",
     "SettingStartSleepOffChar": "X",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Anim.\nspeed",

--- a/Translations/translation_SV.json
+++ b/Translations/translation_SV.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "V",
     "SettingStartSleepOffChar": "R",
     "SettingLockBoostChar": "T",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Anim.-\nhastighet",

--- a/Translations/translation_SV.json
+++ b/Translations/translation_SV.json
@@ -275,6 +275,10 @@
       "displayText": "Omvända\n+- knappar",
       "description": "Omvänd ordning för temperaturjustering via plus/minus knapparna"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Anim.-\nhastighet",
       "description": "Animationshastighet för ikoner i menyer (L=långsam | M=medel | S=snabb)"

--- a/Translations/translation_TR.json
+++ b/Translations/translation_TR.json
@@ -275,6 +275,10 @@
       "displayText": "Düğme Yerleri\nRotasyonu",
       "description": "\"Düğme Yerleri Rotasyonu\" Sıcaklık ayar düğmelerinin yerini değiştirin"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Animasyon\nHızı",
       "description": "Menüdeki simge animasyonlarının hızı (Y=Yavaş | O=Orta | H=Hızlı)"

--- a/Translations/translation_TR.json
+++ b/Translations/translation_TR.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "U",
     "SettingStartSleepOffChar": "S",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Animasyon\nHızı",

--- a/Translations/translation_UK.json
+++ b/Translations/translation_UK.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "С",
     "SettingStartSleepOffChar": "К",
     "SettingLockBoostChar": "Т",
-    "SettingLockFullChar": "П"
+    "SettingLockFullChar": "П",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Швидкість\nанімації",

--- a/Translations/translation_UK.json
+++ b/Translations/translation_UK.json
@@ -275,6 +275,10 @@
       "displayText": "Інвертувати\nкнопки +-?",
       "description": "Інвертувати кнопки зміни температури."
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Швидкість\nанімації",
       "description": "Швидкість анімації іконок у меню (Н=Низькa | С=Середня | М=Максимальна)"

--- a/Translations/translation_UZ.json
+++ b/Translations/translation_UZ.json
@@ -275,6 +275,10 @@
       "displayText": "(+) va (-) tugmalarni\nalmashtirish",
       "description": "Harorat o'zgarishi uchun tugmachalarni vazifasini almashish"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\ntezligi",
       "description": "Menyudagi ikonka animatsiyalari tezligini sozlash (S=sekin | O=o'rtacha | T=tez)"

--- a/Translations/translation_UZ.json
+++ b/Translations/translation_UZ.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "U",
     "SettingStartSleepOffChar": "X",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "T"
+    "SettingLockFullChar": "T",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Anim.\ntezligi",

--- a/Translations/translation_VI.json
+++ b/Translations/translation_VI.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "Z",
     "SettingStartSleepOffChar": "R",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "Toc đo\nhoat anh",

--- a/Translations/translation_VI.json
+++ b/Translations/translation_VI.json
@@ -275,6 +275,10 @@
       "displayText": "Đao nguoc\nnút + -",
       "description": "Đao nguoc chuc năng các nút đieu chinh nhiet đo"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "Toc đo\nhoat anh",
       "description": "Toc đo cua hoat anh menu (S=cham | M=trung bình | F=nhanh)"

--- a/Translations/translation_YUE_HK.json
+++ b/Translations/translation_YUE_HK.json
@@ -275,6 +275,10 @@
       "displayText": "反轉加減掣",
       "description": "反轉調校温度時加減掣嘅方向"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "動畫速度",
       "description": "功能表圖示動畫嘅速度 <慢=慢速 | 中=中速 | 快=快速>"

--- a/Translations/translation_YUE_HK.json
+++ b/Translations/translation_YUE_HK.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "待",
     "SettingStartSleepOffChar": "室",
     "SettingLockBoostChar": "增",
-    "SettingLockFullChar": "全"
+    "SettingLockFullChar": "全",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "動畫速度",

--- a/Translations/translation_ZH_CN.json
+++ b/Translations/translation_ZH_CN.json
@@ -275,6 +275,10 @@
       "displayText": "调换加减键",
       "description": "调校温度时更换加减键的方向"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "动画速度",
       "description": "主菜单中功能图标动画的播放速度 <慢=慢速 | 中=中速 | 快=快速>"

--- a/Translations/translation_ZH_CN.json
+++ b/Translations/translation_ZH_CN.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "待",
     "SettingStartSleepOffChar": "室",
     "SettingLockBoostChar": "增",
-    "SettingLockFullChar": "全"
+    "SettingLockFullChar": "全",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "动画速度",

--- a/Translations/translation_ZH_TW.json
+++ b/Translations/translation_ZH_TW.json
@@ -275,6 +275,10 @@
       "displayText": "調換加減鍵",
       "description": "調校溫度時調換加減鍵的方向"
     },
+    "AnimSlide": {
+      "displayText": "Anim.\nsliding",
+      "description": "Use slide-scroll animation"
+    },
     "AnimSpeed": {
       "displayText": "動畫速度",
       "description": "功能表圖示動畫的速度 <慢=慢速 | 中=中速 | 快=快速>"

--- a/Translations/translation_ZH_TW.json
+++ b/Translations/translation_ZH_TW.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "待",
     "SettingStartSleepOffChar": "室",
     "SettingLockBoostChar": "增",
-    "SettingLockFullChar": "全"
+    "SettingLockFullChar": "全",
+    "SettingAnimSlideFull": "E",
+    "SettingAnimSlideSettings": "S"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -277,7 +279,7 @@
     },
     "AnimSlide": {
       "displayText": "Anim.\nsliding",
-      "description": "Use slide-scroll animation"
+      "description": "Use slide-scroll animation (E=everywhere | S=in settings only)"
     },
     "AnimSpeed": {
       "displayText": "動畫速度",

--- a/Translations/translations_definitions.json
+++ b/Translations/translations_definitions.json
@@ -165,6 +165,18 @@
       "len": 1,
       "default": "F",
       "description": "Shown when the locking mode is set to lock all buttons."
+    },
+    {
+      "id": "SettingAnimSlideFull",
+      "len": 1,
+      "default": "F",
+      "description": "Shown when the animation sliding is set to full scroll-side animation."
+    },
+    {
+      "id": "SettingAnimSlideSettings",
+      "len": 1,
+      "default": "S",
+      "description": "Shown when the animation sliding is set to scroll-side animation in settings menu only."
     }
   ],
   "menuGroups": [

--- a/Translations/translations_definitions.json
+++ b/Translations/translations_definitions.json
@@ -474,6 +474,12 @@
       "description": "Swaps which button increments and decrements on temperature change screens."
     },
     {
+      "id": "AnimSlide",
+      "maxLen": 6,
+      "maxLen2": 13,
+      "description": "Use slide-scroll animation."
+    },
+    {
       "id": "AnimSpeed",
       "maxLen": 6,
       "maxLen2": 13,

--- a/source/Core/Inc/Settings.h
+++ b/source/Core/Inc/Settings.h
@@ -120,6 +120,12 @@ typedef enum {
   FULL     = 2, // Locking buttons for Boost mode AND for Soldering mode
 } lockingMode_t;
 
+typedef enum {
+  STATIC   = 0, // Sliding animation is disabled
+  SETTINGS = 1, // Sliding animation is enabled in Settings menu only
+  DYNAMIC  = 2, // Sliding animation is enabled
+} slidingMode_t;
+
 /* Selection of the soldering tip
  * Some devices allow multiple types of tips to be fitted, this allows selecting them or overriding the logic
  * The first type will be the default (gets value of 0)

--- a/source/Core/Inc/Settings.h
+++ b/source/Core/Inc/Settings.h
@@ -76,8 +76,9 @@ enum SettingsOptions {
   ProfileCooldownSpeed           = 52, // Maximum allowed cooldown speed in degrees per second
   HallEffectSleepTime            = 53, // Seconds (/5) timeout to sleep when hall effect over threshold
   SolderingTipType               = 54, // Selecting the type of soldering tip fitted
+  AnimationSlide                 = 55, // Enable slide-scroll animation
   //
-  SettingsOptionsLength = 55, // End marker
+  SettingsOptionsLength = 56, // End marker
 };
 
 typedef enum {

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -90,6 +90,7 @@ enum class SettingsItemIndex : uint8_t {
   CooldownBlink,
   ScrollingSpeed,
   ReverseButtonTempChange,
+  AnimSlide,
   AnimSpeed,
   AnimLoop,
   Brightness,

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -148,6 +148,8 @@ struct TranslationIndexTable {
   uint16_t SettingStartSleepOffChar;
   uint16_t SettingLockBoostChar;
   uint16_t SettingLockFullChar;
+  uint16_t SettingAnimSlideFull;
+  uint16_t SettingAnimSlideSettings;
   uint16_t USBPDModeDefault;
   uint16_t USBPDModeNoDynamic;
   uint16_t USBPDModeSafe;

--- a/source/Core/Src/Settings.cpp
+++ b/source/Core/Src/Settings.cpp
@@ -110,7 +110,7 @@ static const SettingConstants settingsConstants[(int)SettingsOptions::SettingsOp
     {                     1,                                                                    10,                 1,                            2}, // ProfileCooldownSpeed
     {                     0,                                                                    12,                 1,                            0}, // HallEffectSleepTime
     {                     0, (tipType_t::TIP_TYPE_MAX - 1) > 0 ? (tipType_t::TIP_TYPE_MAX - 1) : 0,                 1,                            0}, // SolderingTipType
-    {                     0,                                                                     1,                 1,                            1}, // AnimationSlide
+    {                     0,                                                                     2,                 1,                            2}, // AnimationSlide
 };
 static_assert((sizeof(settingsConstants) / sizeof(SettingConstants)) == ((int)SettingsOptions::SettingsOptionsLength));
 

--- a/source/Core/Src/Settings.cpp
+++ b/source/Core/Src/Settings.cpp
@@ -110,6 +110,7 @@ static const SettingConstants settingsConstants[(int)SettingsOptions::SettingsOp
     {                     1,                                                                    10,                 1,                            2}, // ProfileCooldownSpeed
     {                     0,                                                                    12,                 1,                            0}, // HallEffectSleepTime
     {                     0, (tipType_t::TIP_TYPE_MAX - 1) > 0 ? (tipType_t::TIP_TYPE_MAX - 1) : 0,                 1,                            0}, // SolderingTipType
+    {                     0,                                                                     1,                 1,                            1}, // AnimationSlide
 };
 static_assert((sizeof(settingsConstants) / sizeof(SettingConstants)) == ((int)SettingsOptions::SettingsOptionsLength));
 

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -102,6 +102,7 @@ static void displayPowerPulse(void);
 static bool displayAnimationOptions(void);
 static void displayAnimationSpeed(void);
 static void displayAnimationLoop(void);
+static void displayAnimationSlide(void);
 static void displayPowerPulseWait(void);
 static bool showPowerPulseOptions(void);
 static void displayPowerPulseDuration(void);
@@ -395,6 +396,8 @@ const menuitem UIMenu[] = {
   {SETTINGS_DESC(SettingsItemIndex::ScrollingSpeed), nullptr, displayScrollSpeed, nullptr, SettingsOptions::DescriptionScrollSpeed, SettingsItemIndex::ScrollingSpeed, 7},
   /* Reverse Temp change buttons +/- */
   {SETTINGS_DESC(SettingsItemIndex::ReverseButtonTempChange), nullptr, displayReverseButtonTempChangeEnabled, nullptr, SettingsOptions::ReverseButtonTempChangeEnabled, SettingsItemIndex::ReverseButtonTempChange, 7},
+  /* Animation Slide switch */
+  {SETTINGS_DESC(SettingsItemIndex::AnimSlide), nullptr, displayAnimationSlide, nullptr, SettingsOptions::AnimationSlide, SettingsItemIndex::AnimSlide, 7},
   /* Animation Speed adjustment */
   {SETTINGS_DESC(SettingsItemIndex::AnimSpeed), nullptr, displayAnimationSpeed, nullptr, SettingsOptions::AnimationSpeed, SettingsItemIndex::AnimSpeed, 7},
   /* Animation Loop switch */
@@ -852,6 +855,8 @@ static void displayCoolingBlinkEnabled(void) { OLED::drawCheckbox(getSettingValu
 static void displayScrollSpeed(void) { OLED::print(translatedString((getSettingValue(SettingsOptions::DescriptionScrollSpeed)) ? Tr->SettingFastChar : Tr->SettingSlowChar), FontStyle::LARGE); }
 
 static void displayReverseButtonTempChangeEnabled(void) { OLED::drawCheckbox(getSettingValue(SettingsOptions::ReverseButtonTempChangeEnabled)); }
+
+static void displayAnimationSlide(void) { OLED::drawCheckbox(getSettingValue(SettingsOptions::AnimationSlide)); }
 
 static void displayAnimationSpeed(void) {
   switch (getSettingValue(SettingsOptions::AnimationSpeed)) {

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -856,7 +856,20 @@ static void displayScrollSpeed(void) { OLED::print(translatedString((getSettingV
 
 static void displayReverseButtonTempChangeEnabled(void) { OLED::drawCheckbox(getSettingValue(SettingsOptions::ReverseButtonTempChangeEnabled)); }
 
-static void displayAnimationSlide(void) { OLED::drawCheckbox(getSettingValue(SettingsOptions::AnimationSlide)); }
+static void displayAnimationSlide(void) {
+  switch (getSettingValue(SettingsOptions::AnimationSlide)) {
+  case slidingMode_t::DYNAMIC:
+    OLED::print(translatedString(Tr->SettingAnimSlideFull), FontStyle::LARGE);
+    break;
+  case slidingMode_t::SETTINGS:
+    OLED::print(translatedString(Tr->SettingAnimSlideSettings), FontStyle::LARGE);
+    break;
+  case slidingMode_t::STATIC:
+  default:
+    OLED::drawUnavailableIcon();
+    break;
+  }
+}
 
 static void displayAnimationSpeed(void) {
   switch (getSettingValue(SettingsOptions::AnimationSpeed)) {

--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -158,7 +158,7 @@ void guiRenderLoop(void) {
     currentOperatingMode = newMode;
   }
   // If the transition marker is set, we need to make the next draw occur to the secondary buffer so we have something to transition to
-  if (context.transitionMode != TransitionAnimation::None) {
+  if (getSettingValue(SettingsOptions::AnimationSlide) && context.transitionMode != TransitionAnimation::None) {
     OLED::useSecondaryFramebuffer(true);
     // Now we need to fill the secondary buffer with the _next_ frame to transistion to
     guiHandleDraw();

--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -157,8 +157,14 @@ void guiRenderLoop(void) {
     memset(&context.scratch_state, 0, sizeof(context.scratch_state));
     currentOperatingMode = newMode;
   }
+
+  uint16_t animationSlide = getSettingValue(SettingsOptions::AnimationSlide);
+  if (context.transitionMode == TransitionAnimation::None || !animationSlide) {
+    return OLED::refresh();
+  }
+
   // If the transition marker is set, we need to make the next draw occur to the secondary buffer so we have something to transition to
-  if (getSettingValue(SettingsOptions::AnimationSlide) && context.transitionMode != TransitionAnimation::None) {
+  if ((animationSlide == slidingMode_t::SETTINGS && (newMode == OperatingMode::SettingsMenu || context.previousMode == OperatingMode::SettingsMenu)) || animationSlide == slidingMode_t::DYNAMIC) {
     OLED::useSecondaryFramebuffer(true);
     // Now we need to fill the secondary buffer with the _next_ frame to transistion to
     guiHandleDraw();


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Add a new setting to control side-slide-scroll animation (_Settings - User interface - Anim.sliding_).

* **What is the current behavior?**
Fancy smooth side-slide-scrolling animation between operating mode screens without any control of this option.

* **What is the new behavior (if this is a feature change)?**
Add `AnimationSlide` setting with three values:
  - `off`: static instant transition between screens;
  - `S` (as in Settings only): side-slide-scroll animation happens only if a user goes to the settings menu, navigates in the settings menu, or exits the settings menu;
  - `E` (as in Everywhere/Full): side-slide-scroll animation enabled everywhere (current default behavior).
  - **NOTE**: **this option does not intersect in any way with any other animation-related setting, and I would like to keep it in this way**.

* **Other information**:

[Related bug report](https://github.com/ralim/ironos/issues/2076). I must admit that at first I was kinda skeptical about this setting (just like against any new setting which overbloats the code base and flash storage :) but while I was testing this myself, I have to say that when it's off, I'm fascinated with the rocket-like reactive instant response from the interface. Don't get me wrong, side-slide-scrolling animation looks really cool, smooth and fancy for a such low hardware devices, but I think that some users who prefer the speed of the time to response in the interfaces over visual effects in a daily life, will find this setting to be _off_/_settings only_ most of the time useful as well.

I did make testing myself with every implemented option value and _it seems it works for me as it should_.

@discip, I can't wait to get any feedback from you, since it seems that the original user who did request this feature went silent, but you seemed interested in this as well. I know that you're busy these weeks, so don't rush, but let me know once you test it yourself. Thanks a lot in advance.

@Ralim, what do you think about the code? If it's fully ok, you can approve it (**without a merge**) when you have time, and I will merge it myself later, but **only after getting positive confirmation from @discip**.

P.S. It's really interesting, how you (re)implemented `guiRenderLoop()`, `guiHandleDraw()`, and `guiContext` struct: this is sooo convenient that we can get not only the type of current mode, but _"where we came from"_ through `previousMode` field. Nice!