### PR TITLE
Disable animation between home and soldering screens if detailed view is set for both modes (probably a finally proper fix for #2076)

### DIFF
--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -160,6 +160,13 @@ void guiRenderLoop(void) {
     memset(&context.scratch_state, 0, sizeof(context.scratch_state));
     currentOperatingMode = newMode;
   }
+
+  bool detailedView = getSettingValue(SettingsOptions::DetailedIDLE) && getSettingValue(SettingsOptions::DetailedSoldering);
+  if (detailedView && ((newMode == OperatingMode::HomeScreen && context.previousMode == OperatingMode::Soldering) || (newMode == OperatingMode::Soldering && context.previousMode == OperatingMode::HomeScreen))) {
+    // Exclude side-slide-scroll animation if we do transition between soldering/home back and forth while detailed view setting for both modes is set
+    return OLED::refresh();
+  }
+
   // If the transition marker is set, we need to make the next draw occur to the secondary buffer so we have something to transition to
   if (context.transitionMode != TransitionAnimation::None) {
     OLED::useSecondaryFramebuffer(true);

--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -162,7 +162,8 @@ void guiRenderLoop(void) {
   }
 
   bool detailedView = getSettingValue(SettingsOptions::DetailedIDLE) && getSettingValue(SettingsOptions::DetailedSoldering);
-  if (detailedView && ((newMode == OperatingMode::HomeScreen && context.previousMode == OperatingMode::Soldering) || (newMode == OperatingMode::Soldering && context.previousMode == OperatingMode::HomeScreen))) {
+  if (detailedView &&
+      ((newMode == OperatingMode::HomeScreen && context.previousMode == OperatingMode::Soldering) || (newMode == OperatingMode::Soldering && context.previousMode == OperatingMode::HomeScreen))) {
     // Exclude side-slide-scroll animation if we do transition between soldering/home back and forth while detailed view setting for both modes is set
     return OLED::refresh();
   }

--- a/source/Core/Threads/GUIThread.cpp
+++ b/source/Core/Threads/GUIThread.cpp
@@ -161,13 +161,6 @@ void guiRenderLoop(void) {
     currentOperatingMode = newMode;
   }
 
-  bool detailedView = getSettingValue(SettingsOptions::DetailedIDLE) && getSettingValue(SettingsOptions::DetailedSoldering);
-  if (detailedView &&
-      ((newMode == OperatingMode::HomeScreen && context.previousMode == OperatingMode::Soldering) || (newMode == OperatingMode::Soldering && context.previousMode == OperatingMode::HomeScreen))) {
-    // Exclude side-slide-scroll animation if we do transition between soldering/home back and forth while detailed view setting for both modes is set
-    return OLED::refresh();
-  }
-
   // If the transition marker is set, we need to make the next draw occur to the secondary buffer so we have something to transition to
   if (context.transitionMode != TransitionAnimation::None) {
     OLED::useSecondaryFramebuffer(true);

--- a/source/Core/Threads/UI/logic/HomeScreen.cpp
+++ b/source/Core/Threads/UI/logic/HomeScreen.cpp
@@ -37,7 +37,7 @@ OperatingMode handleHomeButtons(const ButtonState buttons, guiContext *cxt) {
     break;
   case BUTTON_F_SHORT:
     if (!isTipDisconnected()) {
-      bool detailedView = getSettingValue(SettingsOptions::DetailedIDLE) && getSettingValue(SettingsOptions::DetailedSoldering);
+      bool detailedView   = getSettingValue(SettingsOptions::DetailedIDLE) && getSettingValue(SettingsOptions::DetailedSoldering);
       cxt->transitionMode = detailedView ? TransitionAnimation::None : TransitionAnimation::Left;
       return OperatingMode::Soldering;
     }

--- a/source/Core/Threads/UI/logic/HomeScreen.cpp
+++ b/source/Core/Threads/UI/logic/HomeScreen.cpp
@@ -37,7 +37,8 @@ OperatingMode handleHomeButtons(const ButtonState buttons, guiContext *cxt) {
     break;
   case BUTTON_F_SHORT:
     if (!isTipDisconnected()) {
-      cxt->transitionMode = TransitionAnimation::Left;
+      bool detailedView = getSettingValue(SettingsOptions::DetailedIDLE) && getSettingValue(SettingsOptions::DetailedSoldering);
+      cxt->transitionMode = detailedView ? TransitionAnimation::None : TransitionAnimation::Left;
       return OperatingMode::Soldering;
     }
     break;

--- a/source/Core/Threads/UI/logic/Soldering.cpp
+++ b/source/Core/Threads/UI/logic/Soldering.cpp
@@ -157,7 +157,7 @@ OperatingMode gui_solderingMode(const ButtonState buttons, guiContext *cxt) {
   if (shouldShutdown()) {
     // shutdown
     currentTempTargetDegC = 0;
-    cxt->transitionMode = detailedView ? TransitionAnimation::None : TransitionAnimation::Right;
+    cxt->transitionMode   = detailedView ? TransitionAnimation::None : TransitionAnimation::Right;
     return OperatingMode::HomeScreen;
   }
 #endif

--- a/source/Core/Threads/UI/logic/Soldering.cpp
+++ b/source/Core/Threads/UI/logic/Soldering.cpp
@@ -47,6 +47,8 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
     }
     return OperatingMode::Soldering;
   }
+
+  bool detailedView = getSettingValue(SettingsOptions::DetailedIDLE) && getSettingValue(SettingsOptions::DetailedSoldering);
   // otherwise we are unlocked
   switch (buttons) {
   case BUTTON_NONE:
@@ -56,7 +58,7 @@ OperatingMode handleSolderingButtons(const ButtonState buttons, guiContext *cxt)
   case BUTTON_BOTH:
   /*Fall through*/
   case BUTTON_B_LONG:
-    cxt->transitionMode = TransitionAnimation::Right;
+    cxt->transitionMode = detailedView ? TransitionAnimation::None : TransitionAnimation::Right;
     return OperatingMode::HomeScreen;
   case BUTTON_F_LONG:
     // if boost mode is enabled turn it on
@@ -142,10 +144,12 @@ OperatingMode gui_solderingMode(const ButtonState buttons, guiContext *cxt) {
   } else {
     ui_draw_soldering_basic_status(cxt->scratch_state.state2);
   }
+
+  bool detailedView = getSettingValue(SettingsOptions::DetailedIDLE) && getSettingValue(SettingsOptions::DetailedSoldering);
   // Check if we should bail due to undervoltage for example
   if (checkExitSoldering()) {
     setBuzzer(false);
-    cxt->transitionMode = TransitionAnimation::Right;
+    cxt->transitionMode = detailedView ? TransitionAnimation::None : TransitionAnimation::Right;
     return OperatingMode::HomeScreen;
   }
 #ifdef NO_SLEEP_MODE
@@ -153,7 +157,7 @@ OperatingMode gui_solderingMode(const ButtonState buttons, guiContext *cxt) {
   if (shouldShutdown()) {
     // shutdown
     currentTempTargetDegC = 0;
-    cxt->transitionMode   = TransitionAnimation::Right;
+    cxt->transitionMode = detailedView ? TransitionAnimation::None : TransitionAnimation::Right;
     return OperatingMode::HomeScreen;
   }
 #endif


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Disable animation between home and soldering screens if detailed view is set for both modes.

* **What is the current behavior?**
  - go to settings and set detailed for idle and for soldering;
  - exit from settings;
  - try to switch from home screen to soldering mode back and forth;
  - result: double-slide effect which is considered as a minor bug.

* **What is the new behavior (if this is a feature change)?**
  - smooth non-animated transition between home & soldering.

* **Other information**:
   - [Original bug report](https://github.com/ralim/ironos/issues/2076);
   - @discip [comment clarifying original bug report](https://github.com/Ralim/IronOS/pull/2100#issuecomment-2705007036).