### PR TITLE
Add option to swap A/B buttons in Settings menu with minimal changes (fix for #2034)

### DIFF
--- a/Translations/translation_BE.json
+++ b/Translations/translation_BE.json
@@ -275,6 +275,10 @@
       "displayText": "Інвертаваць\nкнопкі",
       "description": "Інвертаваць кнопкі вымярэння тэмпературы"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Хуткасць\nанімацыі",
       "description": "Хуткасць анімацыі гузікаў у галоўным меню (Мілісекунды) (Н=Нізкая | С=Сярэдняя | В=Высокая)"

--- a/Translations/translation_BG.json
+++ b/Translations/translation_BG.json
@@ -275,6 +275,10 @@
       "displayText": "Размяна\nбутони +/-",
       "description": "Обръщане на бутоните + и - за промяна на температурата на човка на поялника"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Скорост на\nанимацията",
       "description": "Скорост на анимация на иконата в главното меню (Н=Ниска | C=Средна | B=Висока)"

--- a/Translations/translation_CS.json
+++ b/Translations/translation_CS.json
@@ -275,6 +275,10 @@
       "displayText": "Prohodit\ntl. +-?",
       "description": "Prohodit tlačítka pro změnu teploty"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nrychlost",
       "description": "Tempo animace ikon v menu (P=pomalu | S=středně | R=rychle)"

--- a/Translations/translation_DA.json
+++ b/Translations/translation_DA.json
@@ -275,6 +275,10 @@
       "displayText": "Skift\n+ - tasterne",
       "description": "Skift tildeling af knapper til temperaturjustering"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nHastighed",
       "description": "Hastigheden for ikonanimationer i menuen (S=langsomt | M=medium | F=hurtigt)"

--- a/Translations/translation_DE.json
+++ b/Translations/translation_DE.json
@@ -275,6 +275,10 @@
       "displayText": "+- Tasten\numkehren",
       "description": "Tastenbelegung zur Temperaturänderung umkehren"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nGeschw.",
       "description": "Geschwindigkeit der Icon-Animationen im Menü (L=langsam | M=mittel | S=schnell)"

--- a/Translations/translation_EL.json
+++ b/Translations/translation_EL.json
@@ -275,6 +275,10 @@
       "displayText": "Αντιστροφή\nπλήκτρων + -",
       "description": "Αντιστροφή διάταξης πλήκτρων στη ρύθμιση θερμοκρασίας"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Ταχύτητα\nκιν. εικονιδ.",
       "description": "Ρυθμός κίνησης εικονιδίων στο μενού (Α=αργός | Μ=μέτριος | Γ=γρήγορος)"

--- a/Translations/translation_EN.json
+++ b/Translations/translation_EN.json
@@ -275,6 +275,10 @@
       "displayText": "Swap\n+ - keys",
       "description": "Reverse assignment of buttons for temperature adjustment"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nspeed",
       "description": "Pace of icon animations in menu (S=slow | M=medium | F=fast)"

--- a/Translations/translation_ES.json
+++ b/Translations/translation_ES.json
@@ -275,6 +275,10 @@
       "displayText": "Invertir\nbotones +/-",
       "description": "Invertir botones de ajuste de temperatura"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nvelocidad",
       "description": "Velocidad de animaciones de iconos en el menú (L=baja | M=media | R=alta)"

--- a/Translations/translation_ET.json
+++ b/Translations/translation_ET.json
@@ -275,6 +275,10 @@
       "displayText": "Vaheta\n+ - nupud",
       "description": "Temperatuurinuppude asukohtade vahetus"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nkiirus",
       "description": "Menüüikoonide animatsiooni kiirus (A=aeglane | K=keskmine | T=tempokas)"

--- a/Translations/translation_FI.json
+++ b/Translations/translation_FI.json
@@ -275,6 +275,10 @@
       "displayText": "Suunnanvaihto\n+ - näppäimille",
       "description": "Lämpötilapainikkeiden suunnan vaihtaminen"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Animaation\nnopeus",
       "description": "Animaatioiden nopeus valikossa (A=alhainen | K=keskiverto | S=suuri)"

--- a/Translations/translation_FR.json
+++ b/Translations/translation_FR.json
@@ -275,6 +275,10 @@
       "displayText": "Inverser les\ntouches + -",
       "description": "Inverser les boutons d'ajustement de température"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Vitesse\nanim. icônes",
       "description": "Vitesse des animations des icônes dans le menu (L=lente | M=moyenne | R=rapide)"

--- a/Translations/translation_HR.json
+++ b/Translations/translation_HR.json
@@ -275,6 +275,10 @@
       "displayText": "Zamjena\n+ - tipki",
       "description": "Zamjenjuje funkciju gornje i donje tipke za podešavanje temperature"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Brzina\nanimacije",
       "description": "Brzina animacije ikona u menijima (S=sporo | M=srednje | B=brzo)"

--- a/Translations/translation_HU.json
+++ b/Translations/translation_HU.json
@@ -275,6 +275,10 @@
       "displayText": "+/- gomb\nmegfordítása",
       "description": "Forrasztó hegy hőmérsékletállító gombok felcserélése"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Animáció\nsebessége",
       "description": "Menüikonok animációjának sebessége (L=lassú | K=közepes | Gy=gyors)"

--- a/Translations/translation_IT.json
+++ b/Translations/translation_IT.json
@@ -275,6 +275,10 @@
       "displayText": "Inversione\ntasti",
       "description": "Inverti i tasti per aumentare o diminuire la temperatura della punta"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Velocità\nanimazioni",
       "description": "Imposta la velocità di riproduzione delle animazioni del menù principale [L: lenta; M: media; V: veloce]"

--- a/Translations/translation_JA_JP.json
+++ b/Translations/translation_JA_JP.json
@@ -275,6 +275,10 @@
       "displayText": "キー入れ替え",
       "description": "温度設定時に+ボタンと-ボタンを入れ替える"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "動画の速度",
       "description": "メニューアイコンのアニメーションの速さ <遅=低速 | 中=中速 | 速=高速>"

--- a/Translations/translation_LT.json
+++ b/Translations/translation_LT.json
@@ -275,6 +275,10 @@
       "displayText": "Sukeisti + -\nmygtukus?",
       "description": "Sukeisti + - temperatūros keitimo mygtukus vietomis"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Animacijų\ngreitis",
       "description": "Paveiksliukų animacijų greitis meniu punktuose (L=Lėtas | V=Vidutinis | G=Greitas)"

--- a/Translations/translation_NB.json
+++ b/Translations/translation_NB.json
@@ -275,6 +275,10 @@
       "displayText": "Bytt\n+ - kn.",
       "description": "Bytt om på knappene for å stille temperatur"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nhastighet",
       "description": "Hastigheten til animasjonene i menyen (S=slow | M=medium | F=fast)"

--- a/Translations/translation_NL.json
+++ b/Translations/translation_NL.json
@@ -275,6 +275,10 @@
       "displayText": "Wissel\n+ - knoppen",
       "description": "Wissel de knoppen voor temperatuur controle om"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nsnelheid",
       "description": "Snelheid van de icoon animaties in het menu (Langzaam | Middel | Snel)"

--- a/Translations/translation_NL_BE.json
+++ b/Translations/translation_NL_BE.json
@@ -275,6 +275,10 @@
       "displayText": "Wissel\n+ - knoppen",
       "description": "Wissel de knoppen voor temperatuur controle"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nsnelheid",
       "description": "Snelheid van de icoon animaties in het menu (T=sloom | M=middel | S=snel)"

--- a/Translations/translation_PL.json
+++ b/Translations/translation_PL.json
@@ -275,6 +275,10 @@
       "displayText": "Zamień przyc.\n+ -",
       "description": "Zamienia działanie przycisków zmiany temperatury grotu"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Prędkosć\nanimacji",
       "description": "Prędkość animacji ikon w menu (W: mała | M: średnia | S: duża)"

--- a/Translations/translation_PT.json
+++ b/Translations/translation_PT.json
@@ -275,6 +275,10 @@
       "displayText": "Trocar\nbotões + -",
       "description": "Inverte o funcionamento dos botões de ajuste da temperatura"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Velocidade\nde animação",
       "description": "Velocidade das animações no menu (S=lenta | M=média | F=rápida)"

--- a/Translations/translation_RO.json
+++ b/Translations/translation_RO.json
@@ -275,6 +275,10 @@
       "displayText": "Inversare\n+ - butoane",
       "description": "Inversarea butoanelor de reglare a temperaturii"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Animaţii\nviteză",
       "description": "Ritmul animaţiilor pictogramei din meniu (Î=încet | M=mediu | R=rapid)"

--- a/Translations/translation_RU.json
+++ b/Translations/translation_RU.json
@@ -275,6 +275,10 @@
       "displayText": "Поменять\nкнопки +/-",
       "description": "Поменять кнопки изменения температуры"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Скорость\nанимации",
       "description": "Скорость анимации иконок в главном меню (М=Медленная| С=Средняя | Б=Быстрая)"

--- a/Translations/translation_SK.json
+++ b/Translations/translation_SK.json
@@ -275,6 +275,10 @@
       "displayText": "Otočenie\ntlačidiel +/-",
       "description": "Prehodenie tlačidiel na nastavovanie teploty"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Rýchlosť\nanimácií",
       "description": "Rýchlosť animácií ikoniek v menu (P=pomaly | S=stredne | R=rýchlo)"

--- a/Translations/translation_SL.json
+++ b/Translations/translation_SL.json
@@ -275,6 +275,10 @@
       "displayText": "Obrni\ntipki + -?",
       "description": "Zamenjaj funkciji gumbov."
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nspeed",
       "description": "Pace of icon animations in menu (P=slow | M=medium | H=fast)"

--- a/Translations/translation_SR_CYRL.json
+++ b/Translations/translation_SR_CYRL.json
@@ -275,6 +275,10 @@
       "displayText": "Swap\n+ - keys",
       "description": "Reverse assignment of buttons for temperature adjustment"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nspeed",
       "description": "Pace of icon animations in menu (С=slow | M=medium | Б=fast)"

--- a/Translations/translation_SR_LATN.json
+++ b/Translations/translation_SR_LATN.json
@@ -275,6 +275,10 @@
       "displayText": "Swap\n+ - keys",
       "description": "Reverse assignment of buttons for temperature adjustment"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\nspeed",
       "description": "Pace of icon animations in menu (S=slow | M=medium | B=fast)"

--- a/Translations/translation_SV.json
+++ b/Translations/translation_SV.json
@@ -275,6 +275,10 @@
       "displayText": "Omvända\n+- knappar",
       "description": "Omvänd ordning för temperaturjustering via plus/minus knapparna"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Anim.-\nhastighet",
       "description": "Animationshastighet för ikoner i menyer (L=långsam | M=medel | S=snabb)"

--- a/Translations/translation_TR.json
+++ b/Translations/translation_TR.json
@@ -275,6 +275,10 @@
       "displayText": "Düğme Yerleri\nRotasyonu",
       "description": "\"Düğme Yerleri Rotasyonu\" Sıcaklık ayar düğmelerinin yerini değiştirin"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Animasyon\nHızı",
       "description": "Menüdeki simge animasyonlarının hızı (Y=Yavaş | O=Orta | H=Hızlı)"

--- a/Translations/translation_UK.json
+++ b/Translations/translation_UK.json
@@ -275,6 +275,10 @@
       "displayText": "Інвертувати\nкнопки +-?",
       "description": "Інвертувати кнопки зміни температури."
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Швидкість\nанімації",
       "description": "Швидкість анімації іконок у меню (Н=Низькa | С=Середня | М=Максимальна)"

--- a/Translations/translation_UZ.json
+++ b/Translations/translation_UZ.json
@@ -275,6 +275,10 @@
       "displayText": "(+) va (-) tugmalarni\nalmashtirish",
       "description": "Harorat o'zgarishi uchun tugmachalarni vazifasini almashish"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Anim.\ntezligi",
       "description": "Menyudagi ikonka animatsiyalari tezligini sozlash (S=sekin | O=o'rtacha | T=tez)"

--- a/Translations/translation_VI.json
+++ b/Translations/translation_VI.json
@@ -275,6 +275,10 @@
       "displayText": "Đao nguoc\nnút + -",
       "description": "Đao nguoc chuc năng các nút đieu chinh nhiet đo"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "Toc đo\nhoat anh",
       "description": "Toc đo cua hoat anh menu (S=cham | M=trung bình | F=nhanh)"

--- a/Translations/translation_YUE_HK.json
+++ b/Translations/translation_YUE_HK.json
@@ -275,6 +275,10 @@
       "displayText": "反轉加減掣",
       "description": "反轉調校温度時加減掣嘅方向"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "動畫速度",
       "description": "功能表圖示動畫嘅速度 <慢=慢速 | 中=中速 | 快=快速>"

--- a/Translations/translation_ZH_CN.json
+++ b/Translations/translation_ZH_CN.json
@@ -275,6 +275,10 @@
       "displayText": "调换加减键",
       "description": "调校温度时更换加减键的方向"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "动画速度",
       "description": "主菜单中功能图标动画的播放速度 <慢=慢速 | 中=中速 | 快=快速>"

--- a/Translations/translation_ZH_TW.json
+++ b/Translations/translation_ZH_TW.json
@@ -275,6 +275,10 @@
       "displayText": "調換加減鍵",
       "description": "調校溫度時調換加減鍵的方向"
     },
+    "ReverseButtonSettings": {
+      "displayText": "Swap\nA B keys",
+      "description": "Reverse assignment of buttons for Settings menu"
+    },
     "AnimSpeed": {
       "displayText": "動畫速度",
       "description": "功能表圖示動畫的速度 <慢=慢速 | 中=中速 | 快=快速>"

--- a/Translations/translations_definitions.json
+++ b/Translations/translations_definitions.json
@@ -474,6 +474,12 @@
       "description": "Swaps which button increments and decrements on temperature change screens."
     },
     {
+      "id": "ReverseButtonSettings",
+      "maxLen": 6,
+      "maxLen2": 15,
+      "description": "Swaps which button is used as Enter/Change and as Scroll/Back in Settings menu."
+    },
+    {
       "id": "AnimSpeed",
       "maxLen": 6,
       "maxLen2": 13,

--- a/source/Core/Inc/Settings.h
+++ b/source/Core/Inc/Settings.h
@@ -76,8 +76,9 @@ enum SettingsOptions {
   ProfileCooldownSpeed           = 52, // Maximum allowed cooldown speed in degrees per second
   HallEffectSleepTime            = 53, // Seconds (/5) timeout to sleep when hall effect over threshold
   SolderingTipType               = 54, // Selecting the type of soldering tip fitted
+  ReverseButtonSettings          = 55, // Change the A and B button assigment in Settings menu
   //
-  SettingsOptionsLength = 55, // End marker
+  SettingsOptionsLength = 56, // End marker
 };
 
 typedef enum {

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -90,6 +90,7 @@ enum class SettingsItemIndex : uint8_t {
   CooldownBlink,
   ScrollingSpeed,
   ReverseButtonTempChange,
+  ReverseButtonSettings,
   AnimSpeed,
   AnimLoop,
   Brightness,

--- a/source/Core/Src/Settings.cpp
+++ b/source/Core/Src/Settings.cpp
@@ -110,6 +110,7 @@ static const SettingConstants settingsConstants[(int)SettingsOptions::SettingsOp
     {                     1,                                                                    10,                 1,                            2}, // ProfileCooldownSpeed
     {                     0,                                                                    12,                 1,                            0}, // HallEffectSleepTime
     {                     0, (tipType_t::TIP_TYPE_MAX - 1) > 0 ? (tipType_t::TIP_TYPE_MAX - 1) : 0,                 1,                            0}, // SolderingTipType
+    {                     0,                                                                     1,                 1,                            1}, // ReverseButtonSettings
 };
 static_assert((sizeof(settingsConstants) / sizeof(SettingConstants)) == ((int)SettingsOptions::SettingsOptionsLength));
 

--- a/source/Core/Src/Settings.cpp
+++ b/source/Core/Src/Settings.cpp
@@ -110,7 +110,7 @@ static const SettingConstants settingsConstants[(int)SettingsOptions::SettingsOp
     {                     1,                                                                    10,                 1,                            2}, // ProfileCooldownSpeed
     {                     0,                                                                    12,                 1,                            0}, // HallEffectSleepTime
     {                     0, (tipType_t::TIP_TYPE_MAX - 1) > 0 ? (tipType_t::TIP_TYPE_MAX - 1) : 0,                 1,                            0}, // SolderingTipType
-    {                     0,                                                                     1,                 1,                            1}, // ReverseButtonSettings
+    {                     0,                                                                     1,                 1,                            0}, // ReverseButtonSettings
 };
 static_assert((sizeof(settingsConstants) / sizeof(SettingConstants)) == ((int)SettingsOptions::SettingsOptionsLength));
 

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -47,6 +47,7 @@ static void displayAdvancedSolderingScreens(void);
 static void displayAdvancedIDLEScreens(void);
 static void displayScrollSpeed(void);
 static void displayReverseButtonTempChangeEnabled(void);
+static void displayReverseButtonSettings(void);
 static void displayPowerLimit(void);
 
 #ifdef BLE_ENABLED
@@ -395,6 +396,8 @@ const menuitem UIMenu[] = {
   {SETTINGS_DESC(SettingsItemIndex::ScrollingSpeed), nullptr, displayScrollSpeed, nullptr, SettingsOptions::DescriptionScrollSpeed, SettingsItemIndex::ScrollingSpeed, 7},
   /* Reverse Temp change buttons +/- */
   {SETTINGS_DESC(SettingsItemIndex::ReverseButtonTempChange), nullptr, displayReverseButtonTempChangeEnabled, nullptr, SettingsOptions::ReverseButtonTempChangeEnabled, SettingsItemIndex::ReverseButtonTempChange, 7},
+  /* Reverse Settings menu buttons A/B */
+  {SETTINGS_DESC(SettingsItemIndex::ReverseButtonSettings), nullptr, displayReverseButtonSettings, nullptr, SettingsOptions::ReverseButtonSettings, SettingsItemIndex::ReverseButtonSettings, 7},
   /* Animation Speed adjustment */
   {SETTINGS_DESC(SettingsItemIndex::AnimSpeed), nullptr, displayAnimationSpeed, nullptr, SettingsOptions::AnimationSpeed, SettingsItemIndex::AnimSpeed, 7},
   /* Animation Loop switch */
@@ -852,6 +855,8 @@ static void displayCoolingBlinkEnabled(void) { OLED::drawCheckbox(getSettingValu
 static void displayScrollSpeed(void) { OLED::print(translatedString((getSettingValue(SettingsOptions::DescriptionScrollSpeed)) ? Tr->SettingFastChar : Tr->SettingSlowChar), FontStyle::LARGE); }
 
 static void displayReverseButtonTempChangeEnabled(void) { OLED::drawCheckbox(getSettingValue(SettingsOptions::ReverseButtonTempChangeEnabled)); }
+
+static void displayReverseButtonSettings(void) { OLED::drawCheckbox(getSettingValue(SettingsOptions::ReverseButtonSettings)); }
 
 static void displayAnimationSpeed(void) {
   switch (getSettingValue(SettingsOptions::AnimationSpeed)) {

--- a/source/Core/Threads/UI/logic/DebugMenu.cpp
+++ b/source/Core/Threads/UI/logic/DebugMenu.cpp
@@ -6,7 +6,7 @@ OperatingMode showDebugMenu(const ButtonState buttons, guiContext *cxt) {
   ui_draw_debug_menu(cxt->scratch_state.state1);
 
   if (buttons == BUTTON_B_SHORT) {
-    cxt->transitionMode = TransitionAnimation::Down;
+    cxt->transitionMode = TransitionAnimation::Up;
     return OperatingMode::HomeScreen;
   } else if (buttons == BUTTON_F_SHORT) {
     cxt->scratch_state.state1++;

--- a/source/Core/Threads/UI/logic/HomeScreen.cpp
+++ b/source/Core/Threads/UI/logic/HomeScreen.cpp
@@ -19,7 +19,7 @@ OperatingMode handleHomeButtons(const ButtonState buttons, guiContext *cxt) {
     break;
 
   case BUTTON_B_LONG:
-    cxt->transitionMode = TransitionAnimation::Up;
+    cxt->transitionMode = TransitionAnimation::Down;
     return OperatingMode::DebugMenuReadout;
     break;
   case BUTTON_F_LONG:

--- a/source/Core/Threads/UI/logic/SettingsMenu.cpp
+++ b/source/Core/Threads/UI/logic/SettingsMenu.cpp
@@ -193,11 +193,11 @@ OperatingMode gui_SettingsMenu(const ButtonState buttons, guiContext *cxt) {
   };
 
   // Set buttons actions according to the settings
-  bool    swapButtonsSettings = getSettingValue(SettingsOptions::ReverseButtonSettings);
-  uint8_t button_enter        = swapButtonsSettings ? BUTTON_B_SHORT : BUTTON_F_SHORT;
-  uint8_t button_enter_long   = swapButtonsSettings ? BUTTON_B_LONG : BUTTON_F_LONG;
-  uint8_t button_next         = swapButtonsSettings ? BUTTON_F_SHORT : BUTTON_B_SHORT;
-  uint8_t button_next_long    = swapButtonsSettings ? BUTTON_F_LONG : BUTTON_B_LONG;
+  bool    swapButtonSettings = getSettingValue(SettingsOptions::ReverseButtonSettings);
+  uint8_t button_enter       = swapButtonSettings ? BUTTON_B_SHORT : BUTTON_F_SHORT;
+  uint8_t button_enter_long  = swapButtonSettings ? BUTTON_B_LONG : BUTTON_F_LONG;
+  uint8_t button_next        = swapButtonSettings ? BUTTON_F_SHORT : BUTTON_B_SHORT;
+  uint8_t button_next_long   = swapButtonSettings ? BUTTON_F_LONG : BUTTON_B_LONG;
 
   OperatingMode newMode = OperatingMode::SettingsMenu;
   if (BUTTON_NONE == buttons) {


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Add option to swap A/B buttons in Settings menu with minimal changes.

* **What is the current behavior?**
In _Settings_ menu `B`/back button works as _next/scroll_ and `A`/front as _enter/change_, while to go to Settings a user must press `B`/back button from _Home screen_, therefore in the _Settings_ menu - to keep that mental model just created in a brain of a user - the further `B`/back button press should mean _"go in the setting further/change a setting (as enter)"_, while pressing `A`/front button should work as _scroll/going back_, since a user **on a reflex** would press front button, because physically & logically it's located as "back" button when a user in the Settings menu. At least already a few users reported, that they would like to have this feature as an option. [Original bug report](https://github.com/Ralim/IronOS/issues/2034)

* **What is the new behavior (if this is a feature change)?**
There is a new option to swap A/B buttons for Settings menu.

* **Other information**:
   - first of all, I wanted this feature for a long time myself, in fact I think it had to be by default since the beginning due to literally physiological reasons of ergonomics & usability described above;
   - second, I really like `switch/case` operator, I use it everywhere I can myself (partially because it's _the essence of **the infinite state machine** concept_), but in this case I don't know how much simpler to implement this option otherwise;
   - third, basically we have a trade-off: by swapping to `if/else` here, we get _**the less invasive solution possible**_ without a need to overwrite different parts of code all over the code base to track down presses and messing with other functions & methods, and to support all of that with a headache in the future;
   - fourth, for reasons discussed in the other pull-request, since it's `logic/SettingsMenu` and there is a logic for mechanics in _Settings menu_ including _**buttons processing**_ (**only** in the _Settings_ menu), I guess there is no more perfect spot to implement this option;
   - @Ralim, what do you think?
   - @discip, any comments about the option itself?