### PR TITLE
Update debug time stamp according to the official recommendation from reproducible builds initiative by @paulfertser suggestion

### DIFF
--- a/Translations/make_translation.py
+++ b/Translations/make_translation.py
@@ -10,7 +10,7 @@ import pickle
 import re
 import subprocess
 import sys
-from datetime import datetime
+import time
 from pathlib import Path
 from typing import Dict, List, Optional, TextIO, Tuple, Union
 from dataclasses import dataclass
@@ -152,7 +152,10 @@ def get_constants() -> List[Tuple[str, str]]:
 
 def get_debug_menu() -> List[str]:
     return [
-        datetime.today().strftime("%Y%m%d %H%M%S"),
+        time.strftime(
+            "%Y%m%d %H%M%S",
+            time.gmtime(int(os.environ.get("SOURCE_DATE_EPOCH", time.time()))),
+        ),
         "ID ",
         "ACC   ",
         "PWR   ",


### PR DESCRIPTION

<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Update debug time stamp according to the official recommendation from reproducible builds initiative by @paulfertser [suggestion](https://github.com/Ralim/IronOS/pull/2075#issuecomment-2655952051).

* **What is the current behavior?**
There is a build timestamp already, but the implemented approach doesn't consider [reproducible builds concept](https://reproducible-builds.org/docs/source-date-epoch/).

* **What is the new behavior (if this is a feature change)?**
As @paulfertser suggested, the implementation of build stamp has been updated according to [the official recommendations](https://reproducible-builds.org/docs/source-date-epoch/#reading-the-variable).

* **Other information**:
Local build has been compiled & tested successfully, updated Python code did pass all the linters.