### PR TITLE
Makefile: add diff output for python linter if there are some warnings

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -190,7 +190,7 @@ jobs:
         run: python3 -m pip install --break-system-packages bdflib flake8
 
       - name: Check python formatting with black
-        run: black --check Translations
+        run: black --diff --check Translations
 
       - name: Check python with flake8
         run: flake8 Translations

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ test-py:
 	@echo "---- Checking python code... ----"
 	@echo ""
 	flake8  Translations
-	black  --check  Translations
+	black  --diff  --check  Translations
 	@$(MAKE)  -C source/  Objects/host/brieflz/libbrieflz.so
 	./Translations/brieflz_test.py
 	./Translations/make_translation_test.py


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Add diff output for python linter if there are some warnings.

* **What is the current behavior?**
If there is a warning about python code style, then it will be just a generic summary warning, so to fix a code style, a contributor has to enable `--diff` option, run tests again, fix code style, run tests again, and remove `--diff` option.

* **What is the new behavior (if this is a feature change)?**
Add `--diff` option by default to build scripts, so just like in case with `clang-format`, a contributor could see file names and lines of code related to a warning.

* **Other information**:
Suggested approach makes workflow more convenient.