### PR TITLE
Add missing dependency

### DIFF
--- a/Documentation/Logo.md
+++ b/Documentation/Logo.md
@@ -26,11 +26,13 @@ It is easiest if you copy your logo file to be converted into this folder too, i
 
 The image can be in color and any size, but it will be resized and converted to 1-bit color. However, it looks best if you create a 96x16 image (`png` or `bmp`) in any image editor and color the pixels black & white manually. The thresholding used for converting colour to B&W may not always work as well as one would hope.
 
-The converter requires at least Python3 and Pillow apps. Follow online instructions for installing Python and Pillow on your machine. Any reasonably recent version should work well.
+The converter requires at least Python3 and Pillow apps as well as the IntelHex library for Python. Follow online instructions for installing Python, Pillow, and IntelHex on your machine. Any reasonably recent version should work well.
 
-When running the script on the Windows operating system; it is recommended to use `Powershell` rather than the old `Command Prompt`.
+When running the script on the Windows operating system it is recommended to use `Powershell` rather than the old `Command Prompt`.
 
-For installing pillow; you can install it via your package manager (Debian and similar distros) or via pip. To install via pip the command should be `python -m pip install pillow`.
+For installing pillow, you can install it via your package manager (Debian and similar distros) or via pip. To install via pip the command should be `python -m pip install pillow`.
+
+For installing IntelHex you can use the same pip command as above but replace `pillow` with `intelhex` so that it becomes `python -m pip install intelhex`.
 
 In your shell you can now execute `python img2logo.py input.png out -m ${model}` to convert the file `input.png` and create output files in the folder `out`.
 The model should be replaced by one of the following options:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [✓] The changes have been tested locally
- [✓] There are no breaking changes

* **What kind of change does this PR introduce?**
img2logo.py has IntelHex as a dependency which is not installed by default with Python3 or Pillow and so should be specified explicitly in the instructions, which this PR does.

* **What is the current behavior?**
Currently the documentation does not explicitly list IntelHex as a dependency.

* **What is the new behavior (if this is a feature change)?**
It adds IntelHex as an explicit dependency and makes minor grammatical changes to the documentation.