### PR TITLE
Added support for spaces in directory names

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -557,14 +557,14 @@ Core/Gen/Translation.%.cpp $(OUTPUT_DIR)/Core/Gen/translation.files/%.pickle: ..
 	@test -d $(OUTPUT_DIR)/Core/Gen/translation.files || mkdir -p $(OUTPUT_DIR)/Core/Gen/translation.files
 	@echo 'Generating translations for language $*'
 	@$(HOST_PYTHON) ../Translations/make_translation.py \
-		--macros $(CURDIR)/Core/Gen/macros.txt      \
-		-o $(CURDIR)/Core/Gen/Translation.$*.cpp    \
-		--output-pickled $(OUTPUT_DIR)/Core/Gen/translation.files/$*.pickle \
+		--macros "$(CURDIR)/Core/Gen/macros.txt"      \
+		-o "$(CURDIR)/Core/Gen/Translation.$*.cpp"    \
+		--output-pickled "$(OUTPUT_DIR)/Core/Gen/translation.files/$*.pickle" \
 		$*
 
 Core/Gen/macros.txt: Makefile
-	@test -d $(CURDIR)/Core/Gen || mkdir -p $(CURDIR)/Core/Gen
-	echo "#include <configuration.h>" | $(CC) -dM -E $(CFLAGS) -MF $(CURDIR)/Core/Gen/macros.tmp - > $(CURDIR)/Core/Gen/macros.txt
+	@test -d "$(CURDIR)/Core/Gen" || mkdir -p "$(CURDIR)/Core/Gen"
+	echo "#include <configuration.h>" | $(CC) -dM -E $(CFLAGS) -MF "$(CURDIR)/Core/Gen/macros.tmp" - > "$(CURDIR)/Core/Gen/macros.txt"
 
 # The recipes to produce compressed translation data
 
@@ -587,10 +587,10 @@ Core/Gen/Translation_brieflz.%.cpp: $(OUTPUT_DIR)/Core/Gen/translation.files/%.o
 	@test -d $(@D) || mkdir -p $(@D)
 	@echo Generating BriefLZ compressed translation for $*
 	@OBJCOPY=$(OBJCOPY) $(HOST_PYTHON) ../Translations/make_translation.py \
-		--macros $(CURDIR)/Core/Gen/macros.txt           \
-		-o $(CURDIR)/Core/Gen/Translation_brieflz.$*.cpp \
-		--input-pickled $(OUTPUT_DIR)/Core/Gen/translation.files/$*.pickle \
-		--strings-obj $(OUTPUT_DIR)/Core/Gen/translation.files/$*.o        \
+		--macros "$(CURDIR)/Core/Gen/macros.txt"           \
+		-o "$(CURDIR)/Core/Gen/Translation_brieflz.$*.cpp" \
+		--input-pickled "$(OUTPUT_DIR)/Core/Gen/translation.files/$*.pickle" \
+		--strings-obj "$(OUTPUT_DIR)/Core/Gen/translation.files/$*.o"        \
 		$*
 
 Core/Gen/Translation_brieflz_font.%.cpp: $(OUTPUT_DIR)/Core/Gen/translation.files/%.pickle $(HOST_OUTPUT_DIR)/brieflz/libbrieflz.so Core/Gen/macros.txt
@@ -642,9 +642,9 @@ Core/Gen/Translation_multi.$(1).cpp: $(patsubst %,../Translations/translation_%.
 	@test -d $(OUTPUT_DIR)/Core/Gen/translation.files || mkdir -p $(OUTPUT_DIR)/Core/Gen/translation.files
 	@echo 'Generating translations for multi-language $(2)'
 	@$(HOST_PYTHON) ../Translations/make_translation.py   \
-		--macros $(CURDIR)/Core/Gen/macros.txt           \
-		-o $(CURDIR)/Core/Gen/Translation_multi.$(1).cpp \
-		--output-pickled $(OUTPUT_DIR)/Core/Gen/translation.files/multi.$(1).pickle \
+		--macros "$(CURDIR)/Core/Gen/macros.txt"           \
+		-o "$(CURDIR)/Core/Gen/Translation_multi.$(1).cpp" \
+		--output-pickled "$(OUTPUT_DIR)/Core/Gen/translation.files/multi.$(1).pickle" \
 		$(3)
 
 $(OUTPUT_DIR)/Core/Gen/translation.files/multi.$(1).pickle: Core/Gen/Translation_multi.$(1).cpp
@@ -653,10 +653,10 @@ Core/Gen/Translation_brieflz_multi.$(1).cpp: $(OUTPUT_DIR)/Core/Gen/translation.
 	@test -d $$(@D) || mkdir -p $$(@D)
 	@echo Generating BriefLZ compressed translation for multi-language $(2)
 	@OBJCOPY=$(OBJCOPY) $(HOST_PYTHON) ../Translations/make_translation.py \
-		--macros $(CURDIR)/Core/Gen/macros.txt                   \
-		-o $(CURDIR)/Core/Gen/Translation_brieflz_multi.$(1).cpp \
-		--input-pickled $(OUTPUT_DIR)/Core/Gen/translation.files/multi.$(1).pickle \
-		--strings-obj $(OUTPUT_DIR)/Core/Gen/translation.files/multi.$(1).o        \
+		--macros "$(CURDIR)/Core/Gen/macros.txt"                   \
+		-o "$(CURDIR)/Core/Gen/Translation_brieflz_multi.$(1).cpp" \
+		--input-pickled "$(OUTPUT_DIR)/Core/Gen/translation.files/multi.$(1).pickle" \
+		--strings-obj "$(OUTPUT_DIR)/Core/Gen/translation.files/multi.$(1).o"        \
 		--compress-font \
 		$(3)
 


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
Bug fix for local compilation


* **What is the current behavior?**
<!-- (You can also just link to an open issue here) -->
Local compilation fails when the $(CURDIR) variable contains spaces

* **What is the new behavior (if this is a feature change)?**
Compilation succeeds normally

* **Other information**:
I've also wrapped $(OUTPUT_DIR) to be safe, but I haven't looked specifically for other places where this could cause an issue.
I only tested this for one pair Language-Model, and did not test it in docker container, but I'd be really surprised if it would cause an issue.
