### PR TITLE
Change `u8_t` to `uint8_t` to fix a build issue with Docker under macOS

### DIFF
--- a/source/Core/BSP/Pinecilv2/bl_mcu_sdk/components/ble/ble_stack/host/ecc.h
+++ b/source/Core/BSP/Pinecilv2/bl_mcu_sdk/components/ble/ble_stack/host/ecc.h
@@ -16,7 +16,7 @@ struct bt_pub_key_cb {
    *
    *  @param key The local public key, or NULL in case of no key.
    */
-  void (*func)(const u8_t key[64]);
+  void (*func)(const uint8_t key[64]);
 
   struct bt_pub_key_cb *_next;
 };
@@ -40,7 +40,7 @@ int bt_pub_key_gen(struct bt_pub_key_cb *cb);
  *
  *  @return Current key, or NULL if not available.
  */
-const u8_t *bt_pub_key_get(void);
+const uint8_t *bt_pub_key_get(void);
 
 /*  @typedef bt_dh_key_cb_t
  *  @brief Callback type for DH Key calculation.
@@ -49,7 +49,7 @@ const u8_t *bt_pub_key_get(void);
  *
  *  @param key The DH Key, or NULL in case of failure.
  */
-typedef void (*bt_dh_key_cb_t)(const u8_t key[32]);
+typedef void (*bt_dh_key_cb_t)(const uint8_t key[32]);
 
 /*  @brief Calculate a DH Key from a remote Public Key.
  *
@@ -60,4 +60,4 @@ typedef void (*bt_dh_key_cb_t)(const u8_t key[32]);
  *
  *  @return Zero on success or negative error code otherwise
  */
-int bt_dh_key_gen(const u8_t remote_pk[64], bt_dh_key_cb_t cb);
+int bt_dh_key_gen(const uint8_t remote_pk[64], bt_dh_key_cb_t cb);


### PR DESCRIPTION
This addresses issue #2149 .


<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
Bug fix



* **What is the current behavior?**
https://github.com/Ralim/IronOS/issues/2149

