### PR TITLE
Fix TS101 PD negotiation regression (v2.22 → v2.23)

### DIFF
--- a/source/Makefile
+++ b/source/Makefile
@@ -538,6 +538,11 @@ $(OUT_OBJS): $(OUTPUT_DIR)/%.o: %.c Makefile
 	@test -d $(@D) || mkdir -p $(@D)
 	@$(CC) -c $(CFLAGS) $< -o $@
 
+
+# Special rule for policy_engine.cpp - use O1 optimization
+$(OUTPUT_DIR)/Core/Drivers/usb-pd/src/policy_engine.o: Core/Drivers/usb-pd/src/policy_engine.cpp Makefile
+	@test -d $(@D) || mkdir -p $(@D)
+	@$(CPP) -c -O1 $(filter-out -Os -O3 -O2,$(CXXFLAGS)) $< -o $@
 $(OUTPUT_DIR)/%.o: %.cpp Makefile
 	@test -d $(@D) || mkdir -p $(@D)
 	@$(CPP) -c $(CXXFLAGS) $< -o $@


### PR DESCRIPTION
## Description
Fixes boot loops on TS101 when connected to USB-C power banks and bricks that worked with v2.22 but fail with v2.23+.

Addresses issue #2104 

This fix resolves the original issue where the TS101 continuously reboots during PD negotiation with certain modern USB-C power banks (e.g., Anker 735 Charger), preventing proper power delivery.

## Root Cause
Compiler update in commit 849d1f7d (Alpine 3.16 GCC 11.x → Alpine 3.19+ GCC 14.x) introduced aggressive optimizations that disrupt timing-critical I2C communication with the FUSB302 PD controller during PD negotiation.

## Solution
Add special build rule for `policy_engine.cpp` to use `-O1` optimization instead of `-Os`.

## Testing
- ✅ Tested on TS101 with Inui 140W USB-C PD 3.1 power bank and Anker 735
- ✅ Power source that **failed with v2.23 but worked with v2.22**
- ✅ No boot loops, stable PD negotiation
- ✅ ROM: 47020 B (69.57%)

## Impact
- **This only fixes regressions between v2.22 and v2.23**
- Resolves the boot loop issue experienced by users with modern PD 3.1 power banks or bricks

## Checklist
- [x] Tested on hardware
- [x] No new compiler warnings
- [x] Minimal change (one Makefile rule)