### PR TITLE
Pinecil: Enable TIP_TYPE_SUPPORT

### DIFF
--- a/source/Core/BSP/Pinecil/configuration.h
+++ b/source/Core/BSP/Pinecil/configuration.h
@@ -154,6 +154,7 @@
 #define POW_QC_20V         1
 #define ENABLE_QC2         1
 #define MAG_SLEEP_SUPPORT  1
+#define TIP_TYPE_SUPPORT           1 // Support for tips of different types, i.e. resistance
 #define TIPTYPE_T12        1 // Can manually pick a T12 tip
 #define TEMP_TMP36
 #define ACCEL_BMA


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**

Fixes 0a63b6b5df forgetting to enable this feature for the Pinecil v1 despite it supporting TIPTYPE_T12.

* **What is the current behavior?**
Pinecil v1 is unable to select and use short tips.

* **What is the new behavior (if this is a feature change)?**
Pinecil v1 can now select and use short tips.

* **Other information**:
I believe v2.22 supported this and this is a regression in v2.23.