### PR TITLE
BLE: add setting and basic write protection

### DIFF
--- a/Documentation/Bluetooth.md
+++ b/Documentation/Bluetooth.md
@@ -5,6 +5,14 @@ The Pinecilv2 has hardware support for Bluetooth Low Energy (BLE). This protocol
 The BLE interface advertises three services, these provide access to live telemetry as well as the ability to read/write settings.
 These are outlined in more detail below.
 
+## BLE Modes
+
+The BLE setting in the Advanced menu supports three modes:
+
+- **Off (0):** BLE is completely disabled. No advertising, no connections.
+- **On (1):** Full BLE access. All characteristics and settings can be read and written.
+- **Read-only (2):** BLE advertises and accepts connections. All characteristics can be read (live data, settings, bulk data). However, all write operations are rejected with a `WRITE_NOT_PERMITTED` error. This prevents remote users from changing settings, temperature, or triggering save/reset, while still allowing monitoring tools (e.g., fume extractors) to read temperature data. The BLE mode can only be changed from the physical device menu.
+
 Pinecil devices advertise themselves on BLE as `Pinecil-XXXXXXX`.
 They also include the UUID `9eae1000-9d0d-48c5-AA55-33e27f9bc533` in the advertisement packet to allow for filtering.
 

--- a/Documentation/Settings.md
+++ b/Documentation/Settings.md
@@ -383,11 +383,11 @@ Display detailed info in a smaller font on soldering screen
 
 ### Setting: Bluetooth 
 
-Should BLE be enabled at boot time.
+BLE mode: Off, full read/write access (+), or read-only mode (R) which blocks all writes over BLE.
 
 On device help text:
 
-Enables BLE
+Enables BLE (+=full access | R=read-only)
 
 ### Setting: Power limit
 

--- a/Translations/translation_BE.json
+++ b/Translations/translation_BE.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "Ч",
     "SettingStartSleepOffChar": "Х",
     "SettingLockBoostChar": "Т",
-    "SettingLockFullChar": "П"
+    "SettingLockFullChar": "П",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_BG.json
+++ b/Translations/translation_BG.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "С",
     "SettingStartSleepOffChar": "П",
     "SettingLockBoostChar": "Т",
-    "SettingLockFullChar": "П"
+    "SettingLockFullChar": "П",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_CS.json
+++ b/Translations/translation_CS.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "S",
     "SettingStartSleepOffChar": "M",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "U"
+    "SettingLockFullChar": "U",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_DA.json
+++ b/Translations/translation_DA.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "D",
     "SettingStartSleepOffChar": "R",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_DE.json
+++ b/Translations/translation_DE.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "R",
     "SettingStartSleepOffChar": "K",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "V"
+    "SettingLockFullChar": "V",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_EL.json
+++ b/Translations/translation_EL.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "Ζ",
     "SettingStartSleepOffChar": "Υ",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "Π"
+    "SettingLockFullChar": "Π",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_EN.json
+++ b/Translations/translation_EN.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "Z",
     "SettingStartSleepOffChar": "R",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {
@@ -309,7 +311,7 @@
     },
     "BluetoothLE": {
       "displayText": "Bluetooth\n",
-      "description": "Enables BLE"
+      "description": "Enables BLE (+=full access | R=read-only)"
     },
     "PowerLimit": {
       "displayText": "Power\nlimit",

--- a/Translations/translation_ES.json
+++ b/Translations/translation_ES.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "R",
     "SettingStartSleepOffChar": "F",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_ET.json
+++ b/Translations/translation_ET.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "Z",
     "SettingStartSleepOffChar": "P",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "T"
+    "SettingLockFullChar": "T",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_FI.json
+++ b/Translations/translation_FI.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "L",
     "SettingStartSleepOffChar": "H",
     "SettingLockBoostChar": "V",
-    "SettingLockFullChar": "K"
+    "SettingLockFullChar": "K",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_FR.json
+++ b/Translations/translation_FR.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "V",
     "SettingStartSleepOffChar": "O",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "V"
+    "SettingLockFullChar": "V",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_HR.json
+++ b/Translations/translation_HR.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "T",
     "SettingStartSleepOffChar": "H",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "Z"
+    "SettingLockFullChar": "Z",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_HU.json
+++ b/Translations/translation_HU.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "A",
     "SettingStartSleepOffChar": "Sz",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "T"
+    "SettingLockFullChar": "T",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_IT.json
+++ b/Translations/translation_IT.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "R",
     "SettingStartSleepOffChar": "A",
     "SettingLockBoostChar": "T",
-    "SettingLockFullChar": "C"
+    "SettingLockFullChar": "C",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_JA_JP.json
+++ b/Translations/translation_JA_JP.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "待",
     "SettingStartSleepOffChar": "室",
     "SettingLockBoostChar": "ブ",
-    "SettingLockFullChar": "全"
+    "SettingLockFullChar": "全",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_LT.json
+++ b/Translations/translation_LT.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "M",
     "SettingStartSleepOffChar": "K",
     "SettingLockBoostChar": "T",
-    "SettingLockFullChar": "V"
+    "SettingLockFullChar": "V",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_NB.json
+++ b/Translations/translation_NB.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "D",
     "SettingStartSleepOffChar": "R",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_NL.json
+++ b/Translations/translation_NL.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "S",
     "SettingStartSleepOffChar": "Z",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "V"
+    "SettingLockFullChar": "V",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_NL_BE.json
+++ b/Translations/translation_NL_BE.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "S",
     "SettingStartSleepOffChar": "K",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_PL.json
+++ b/Translations/translation_PL.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "Z",
     "SettingStartSleepOffChar": "O",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "P"
+    "SettingLockFullChar": "P",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_PT.json
+++ b/Translations/translation_PT.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "H",
     "SettingStartSleepOffChar": "A",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_RO.json
+++ b/Translations/translation_RO.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "Z",
     "SettingStartSleepOffChar": "R",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_RU.json
+++ b/Translations/translation_RU.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "С",
     "SettingStartSleepOffChar": "К",
     "SettingLockBoostChar": "Т",
-    "SettingLockFullChar": "П"
+    "SettingLockFullChar": "П",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_SK.json
+++ b/Translations/translation_SK.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "S",
     "SettingStartSleepOffChar": "I",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "P"
+    "SettingLockFullChar": "P",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_SL.json
+++ b/Translations/translation_SL.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "Z",
     "SettingStartSleepOffChar": "V",
     "SettingLockBoostChar": "L",
-    "SettingLockFullChar": "P"
+    "SettingLockFullChar": "P",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_SR_CYRL.json
+++ b/Translations/translation_SR_CYRL.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "С",
     "SettingStartSleepOffChar": "X",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_SR_LATN.json
+++ b/Translations/translation_SR_LATN.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "S",
     "SettingStartSleepOffChar": "X",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_SV.json
+++ b/Translations/translation_SV.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "V",
     "SettingStartSleepOffChar": "R",
     "SettingLockBoostChar": "T",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_TR.json
+++ b/Translations/translation_TR.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "U",
     "SettingStartSleepOffChar": "S",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_UK.json
+++ b/Translations/translation_UK.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "С",
     "SettingStartSleepOffChar": "К",
     "SettingLockBoostChar": "Т",
-    "SettingLockFullChar": "П"
+    "SettingLockFullChar": "П",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_UZ.json
+++ b/Translations/translation_UZ.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "U",
     "SettingStartSleepOffChar": "X",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "T"
+    "SettingLockFullChar": "T",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_VI.json
+++ b/Translations/translation_VI.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "Z",
     "SettingStartSleepOffChar": "R",
     "SettingLockBoostChar": "B",
-    "SettingLockFullChar": "F"
+    "SettingLockFullChar": "F",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_YUE_HK.json
+++ b/Translations/translation_YUE_HK.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "待",
     "SettingStartSleepOffChar": "室",
     "SettingLockBoostChar": "增",
-    "SettingLockFullChar": "全"
+    "SettingLockFullChar": "全",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_ZH_CN.json
+++ b/Translations/translation_ZH_CN.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "待",
     "SettingStartSleepOffChar": "室",
     "SettingLockBoostChar": "增",
-    "SettingLockFullChar": "全"
+    "SettingLockFullChar": "全",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translation_ZH_TW.json
+++ b/Translations/translation_ZH_TW.json
@@ -81,7 +81,9 @@
     "SettingStartSleepChar": "待",
     "SettingStartSleepOffChar": "室",
     "SettingLockBoostChar": "增",
-    "SettingLockFullChar": "全"
+    "SettingLockFullChar": "全",
+    "SettingBLEOnChar": "+",
+    "SettingBLEReadOnlyChar": "R"
   },
   "menuGroups": {
     "PowerMenu": {

--- a/Translations/translations_definitions.json
+++ b/Translations/translations_definitions.json
@@ -165,6 +165,18 @@
       "len": 1,
       "default": "F",
       "description": "Shown when the locking mode is set to lock all buttons."
+    },
+    {
+      "id": "SettingBLEOnChar",
+      "len": 1,
+      "default": "+",
+      "description": "Shown when BLE is set to full read/write mode."
+    },
+    {
+      "id": "SettingBLEReadOnlyChar",
+      "len": 1,
+      "default": "R",
+      "description": "Shown when BLE is set to read-only mode (writes blocked)."
     }
   ],
   "menuGroups": [
@@ -526,7 +538,7 @@
       "maxLen": 7,
       "maxLen2": 15,
       "include": ["BLE_ENABLED"],
-      "description": "Should BLE be enabled at boot time."
+      "description": "BLE mode: Off, full read/write access (+), or read-only mode (R) which blocks all writes over BLE."
     },
     {
       "id": "PowerLimit",

--- a/source/Core/BSP/Pinecilv2/ble_handlers.cpp
+++ b/source/Core/BSP/Pinecilv2/ble_handlers.cpp
@@ -232,6 +232,11 @@ int ble_char_read_setting_value_callback(struct bt_conn *conn, const struct bt_g
 
 int ble_char_write_setting_value_callback(struct bt_conn *conn, const struct bt_gatt_attr *attr, const void *buf, u16_t len, u16_t offset, u8_t flags) {
 
+  // Block all writes when BLE is in read-only mode
+  if (getSettingValue(SettingsOptions::BluetoothLE) == 2) {
+    return BT_GATT_ERR(BT_ATT_ERR_WRITE_NOT_PERMITTED);
+  }
+
   if (flags & BT_GATT_WRITE_FLAG_PREPARE) {
     // Don't use prepare write data, execute write will upload data again.
     BT_WARN((char *)"recv prepare write request\n");

--- a/source/Core/Inc/Settings.h
+++ b/source/Core/Inc/Settings.h
@@ -175,4 +175,7 @@ uint16_t    lookupHallEffectThreshold();
 #ifdef TIP_TYPE_SUPPORT
 const char *lookupTipName(); // Get the name string for the current soldering tip
 #endif /* TIP_TYPE_SUPPORT */
+#ifdef BLE_ENABLED
+void setBluetoothLE(void);
+#endif /* BLE_ENABLED */
 #endif                       /* SETTINGS_H_ */

--- a/source/Core/Inc/Translation.h
+++ b/source/Core/Inc/Translation.h
@@ -148,6 +148,8 @@ struct TranslationIndexTable {
   uint16_t SettingStartSleepOffChar;
   uint16_t SettingLockBoostChar;
   uint16_t SettingLockFullChar;
+  uint16_t SettingBLEOnChar;
+  uint16_t SettingBLEReadOnlyChar;
   uint16_t USBPDModeDefault;
   uint16_t USBPDModeNoDynamic;
   uint16_t USBPDModeSafe;

--- a/source/Core/Src/Settings.cpp
+++ b/source/Core/Src/Settings.cpp
@@ -114,6 +114,32 @@ static const SettingConstants settingsConstants[(int)SettingsOptions::SettingsOp
 };
 static_assert((sizeof(settingsConstants) / sizeof(SettingConstants)) == ((int)SettingsOptions::SettingsOptionsLength));
 
+#ifdef BLE_ENABLED
+static int16_t bleValueOnEntry = -1;
+
+void setBluetoothLE(void) {
+  if (bleValueOnEntry < 0) {
+    bleValueOnEntry = getSettingValue(SettingsOptions::BluetoothLE);
+  }
+  nextSettingValue(SettingsOptions::BluetoothLE);
+}
+
+static void checkBLERebootNeeded(void) {
+  if (bleValueOnEntry < 0)
+    return;
+  uint16_t current = getSettingValue(SettingsOptions::BluetoothLE);
+  bool     wasOff  = (bleValueOnEntry == 0);
+  bool     isOff   = (current == 0);
+  bleValueOnEntry  = -1;
+  if (wasOff != isOff) {
+    while (getButtonA() || getButtonB()) {
+      // Wait for buttons to be released so the bootloader isn't entered
+    }
+    reboot();
+  }
+}
+#endif
+
 void saveSettings() {
 #ifdef CANT_DIRECT_READ_SETTINGS
   // For these devices flash is not 1:1 mapped, so need to read into staging buffer
@@ -129,6 +155,9 @@ void saveSettings() {
   }
 
 #endif /* CANT_DIRECT_READ_SETTINGS */
+#ifdef BLE_ENABLED
+  checkBLERebootNeeded();
+#endif
 }
 
 bool loadSettings() {

--- a/source/Core/Src/Settings.cpp
+++ b/source/Core/Src/Settings.cpp
@@ -92,7 +92,7 @@ static const SettingConstants settingsConstants[(int)SettingsOptions::SettingsOp
     {        MIN_BRIGHTNESS,                                                        MAX_BRIGHTNESS,   BRIGHTNESS_STEP,           DEFAULT_BRIGHTNESS}, // OLEDBrightness
     {                     0,                                                                     6,                 1,                            1}, // LOGOTime
     {                     0,                                                                     1,                 1,                            0}, // CalibrateCJC
-    {                     0,                                                                     1,                 1,                            0}, // BluetoothLE
+    {                     0,                                                                     2,                 1,                            0}, // BluetoothLE
     {                     0,                                                                     2,                 1,                            0}, // USBPDMode
     {                     1,                                                                     5,                 1,                            4}, // ProfilePhases
     {            MIN_TEMP_C,                                                            MAX_TEMP_F,                 5,                           90}, // ProfilePreheatTemp

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -430,7 +430,7 @@ const menuitem advancedMenu[] = {
    */
 #ifdef BLE_ENABLED
   /* Toggle BLE */
-  {SETTINGS_DESC(SettingsItemIndex::BluetoothLE), nullptr, displayBluetoothLE, nullptr, SettingsOptions::BluetoothLE, SettingsItemIndex::BluetoothLE, 7},
+  {SETTINGS_DESC(SettingsItemIndex::BluetoothLE), setBluetoothLE, displayBluetoothLE, nullptr, SettingsOptions::BluetoothLE, SettingsItemIndex::BluetoothLE, 7},
 #endif /* BLE_ENABLED */
   /* Power limit */
   {SETTINGS_DESC(SettingsItemIndex::PowerLimit), nullptr, displayPowerLimit, nullptr, SettingsOptions::PowerLimit, SettingsItemIndex::PowerLimit, 4},

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -913,7 +913,22 @@ static void displayAdvancedIDLEScreens(void) { OLED::drawCheckbox(getSettingValu
 static void displayAdvancedSolderingScreens(void) { OLED::drawCheckbox(getSettingValue(SettingsOptions::DetailedSoldering)); }
 
 #ifdef BLE_ENABLED
-static void displayBluetoothLE(void) { OLED::drawCheckbox(getSettingValue(SettingsOptions::BluetoothLE)); }
+static void displayBluetoothLE(void) {
+  switch (getSettingValue(SettingsOptions::BluetoothLE)) {
+  case 0:
+    OLED::drawUnavailableIcon();
+    break;
+  case 1:
+    OLED::print(translatedString(Tr->SettingBLEOnChar), FontStyle::LARGE);
+    break;
+  case 2:
+    OLED::print(translatedString(Tr->SettingBLEReadOnlyChar), FontStyle::LARGE);
+    break;
+  default:
+    OLED::drawUnavailableIcon();
+    break;
+  }
+}
 #endif /* BLE_ENABLED */
 
 static void displayPowerLimit(void) {


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [x] The changes have been tested locally
- [x] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->

Read-only ble mode for Pinecil v2. Fixes #2203.

* **What is the current behavior?**
<!-- (You can also just link to an open issue here) -->

Currently, if Bluetooth is activated, clients can change all settings and temperature.

* **What is the new behavior (if this is a feature change)?**

With read-only, clients trying any write action will receive an error.

* **Other information**:

Disclaimer: this has been done mostly by Claude Opus 4.6. That said, being a developer myself (sadly not C++), I reviewed the code and it looks ok. I deployed it on my Pinecil and it smells ok as well.

Also, poking around I found another possibly interesting change. Currently, if bluetooth is enabled, in order to disable it one should change it in settings, exit the menus, then unplug and replug the iron, which is not really "intuitive" (one would think that as most settings this would apply immediately).