### PR TITLE
Add Uzbek Soldering Tip Type Translation

### DIFF
--- a/Translations/translation_UZ.json
+++ b/Translations/translation_UZ.json
@@ -346,8 +346,8 @@
       "description": ""
     },
     "SolderingTipType": {
-      "displayText": "Soldering\nTip Type",
-      "description": "Select the tip type fitted"
+      "displayText": "Lehimlash\nuchi turi",
+      "description": "O'rnatilgan uchi turini tanlang"
     }
   }
 }


### PR DESCRIPTION
I don't speak uzbek, so I used a machine translator, I hope that's okay. Should be correct, though (I cross-referenced)


<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- (N/A) The changes have been tested locally
- [X] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->
Docs update


* **What is the current behavior?**
<!-- (You can also just link to an open issue here) -->
translation_UZ.json had English translations for SolderingTipType

* **What is the new behavior (if this is a feature change)?**

SolderingTipType is now translated

* **Other information**:
I don't speak uzbek, so I used a machine translator, I hope that's okay. Should be correct, though (I cross-referenced)