### PR TITLE
fix: PID invalid integration of negative target_delta

### DIFF
--- a/source/Core/Threads/PIDThread.cpp
+++ b/source/Core/Threads/PIDThread.cpp
@@ -130,7 +130,7 @@ template <class T, T Kp, T Ki, T Kd, T integral_limit_scale> struct PID {
     // Thus we multiply this out by the interval time to ~= dv/dt
     // Then the shift by 1000 is ms -> Seconds
 
-    integration_running_sum += (target_delta * interval_ms * Ki) / 1000;
+    integration_running_sum += (target_delta * (T)interval_ms * Ki) / 1000;
 
     // We constrain integration_running_sum to limit windup
     // This is not overly required for most use cases but can prevent large overshoot in constrained implementations


### PR DESCRIPTION
(cherry picked from commit 6b4164c3409ca414f6e2ae6987d7c1836bbb750a)


<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [X] The changes have been tested locally
- [X] There are no breaking changes

* **What kind of change does this PR introduce?**
Bug fix

* **What is the current behavior?**
interval_ms is TickType_t which is UNSIGNED. Multiplication (target_delta * interval_ms * Ki) gives wrong results when target_delta is negative. 

* **What is the new behavior (if this is a feature change)?**
Mathematically correct result.

* **Other information**:
Example: https://www.programiz.com/online-compiler/4s9BkH6P4IPr2
Explanation: https://stackoverflow.com/a/50632
