### PR TITLE
S60P is 128K flash

### DIFF
--- a/source/Core/BSP/Sequre/configuration.h
+++ b/source/Core/BSP/Sequre/configuration.h
@@ -239,9 +239,13 @@
 #define MODEL_HAS_DCDC // We dont have DC/DC but have reallly fast PWM that gets us roughly the same place
 #endif                 /* T55 */
 
+#ifdef MODEL_S60P
+#define FLASH_LOGOADDR      (0x08000000 + (126 * 1024))
+#define SETTINGS_START_PAGE (0x08000000 + (127 * 1024))
+#else
 #define FLASH_LOGOADDR      (0x08000000 + (62 * 1024))
 #define SETTINGS_START_PAGE (0x08000000 + (63 * 1024))
-
+#endif /* Logo offset for S60P */
 // Defaults
 
 #ifndef MIN_CALIBRATION_OFFSET

--- a/source/Makefile
+++ b/source/Makefile
@@ -141,11 +141,12 @@ CPUFLAGS=-mcpu=cortex-m3  \
          -mthumb          \
          -mfloat-abi=soft
 
-flash_size=62k
 ifeq ($(model), S60P)
 bootldr_size=0x5000
 DEVICE_DFU_ADDRESS=0x08005000
+flash_size=126k
 else
+flash_size=62k
 # S60 or T55
 bootldr_size=0x4400
 DEVICE_DFU_ADDRESS=0x08004400


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- [] The changes have been tested locally
- [] There are no breaking changes

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->

Fixing size for the S60P flash. Will cause a settings reset on upgrade though.

* **What is the current behavior?**
<!-- (You can also just link to an open issue here) -->

Running low on flash space.

* **What is the new behaviour (if this is a feature change)?**

We get more flash space.

* **Other information**:

Confirmed by photograph taken [here](https://github.com/Ralim/IronOS/discussions/1806)
So we know this IC is 128K flash. 