### PR TITLE
centralise the larger text vertically

### DIFF
--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -180,13 +180,25 @@ void OLED::drawChar(const uint16_t charCode, const FontStyle fontStyle, const ui
     index       = 0;
     switch (fontStyle) {
     case FontStyle::SMALL:
+      // 128x32 panels use the larger Terminus 8x16 small font.
+#ifdef OLED_128x32
+      fontHeight = 16;
+      fontWidth  = 8;
+#else
       fontHeight = 8;
       fontWidth  = 6;
+#endif
       break;
     case FontStyle::LARGE:
     default:
+      // 128x32 panels use the larger Terminus 12x24 large font.
+#ifdef OLED_128x32
+      fontHeight = 24;
+      fontWidth  = 12;
+#else
       fontHeight = 16;
       fontWidth  = 12;
+#endif
       break;
     }
     if (charCode == '\x01' && cursor_y == 0) { // 0x01 is used as new line char
@@ -201,7 +213,33 @@ void OLED::drawChar(const uint16_t charCode, const FontStyle fontStyle, const ui
     break;
   }
   const uint8_t *charPointer = currentFont + ((fontWidth * (fontHeight / 8)) * index);
-  drawArea(cursor_x, cursor_y, fontWidth, fontHeight, charPointer);
+  const uint8_t  shift       = cursor_y & 7;
+  if (shift == 0) {
+    drawArea(cursor_x, cursor_y, fontWidth, fontHeight, charPointer);
+  } else {
+    // y is not strip-aligned: shift each column across strips so a glyph can be
+    // vertically centred (e.g. a 24px large readout at y=4 on a 32px panel).
+    const uint8_t srcStrips = fontHeight / 8;
+    const int16_t baseStrip = cursor_y / 8;
+    for (uint8_t col = 0; col < fontWidth; col++) {
+      const int16_t x = cursor_x + col;
+      if (x < 0 || x >= OLED_WIDTH) {
+        continue;
+      }
+      uint32_t bits = 0;
+      for (uint8_t s = 0; s < srcStrips; s++) {
+        bits |= (uint32_t)charPointer[(s * fontWidth) + col] << (8 * s);
+      }
+      bits <<= shift;
+      for (uint8_t s = 0; s <= srcStrips; s++) {
+        const int16_t destStrip = baseStrip + s;
+        if (destStrip < 0 || destStrip >= (OLED_HEIGHT / 8)) {
+          continue;
+        }
+        stripPointers[destStrip][x] = (bits >> (8 * s)) & 0xFF;
+      }
+    }
+  }
   cursor_x += fontWidth;
 }
 

--- a/source/Core/Drivers/OLED.hpp
+++ b/source/Core/Drivers/OLED.hpp
@@ -134,8 +134,11 @@ public:
   static void clearScreen() { memset(stripPointers[0], 0, OLED_WIDTH * (OLED_HEIGHT / 8)); }
   // Draws the battery level symbol
   static void drawBattery(uint8_t state) { drawSymbol(3 + (state > 10 ? 10 : state)); }
-  // Draws a checkbox
-  static void drawCheckbox(bool state) { drawSymbol((state) ? 16 : 17); }
+  // Draws a checkbox, vertically centred for the panel (y=0 on 96x16, y=8 on 128x32)
+  static void drawCheckbox(bool state) {
+    setCursor(getCursorX(), (OLED_HEIGHT - 16) / 2);
+    drawSymbol((state) ? 16 : 17);
+  }
   inline static void drawUnavailableIcon() { drawArea(OLED_WIDTH - OLED_HEIGHT - 2, 0, OLED_HEIGHT, OLED_HEIGHT, UnavailableIcon); }
   static void debugNumber(int32_t val, FontStyle fontStyle);
   static void drawHex(uint32_t x, FontStyle fontStyle, uint8_t digits);

--- a/source/Core/Inc/ScrollMessage.hpp
+++ b/source/Core/Inc/ScrollMessage.hpp
@@ -21,4 +21,7 @@
  */
 void drawScrollingText(const char *message, TickType_t currentTickOffset);
 
+// Pixel width a message occupies in the menu font (panel-dependent).
+uint16_t messageWidth(const char *message);
+
 #endif /* SCROLL_MESSAGE_HPP_ */

--- a/source/Core/Inc/ScrollMessage.hpp
+++ b/source/Core/Inc/ScrollMessage.hpp
@@ -21,7 +21,4 @@
  */
 void drawScrollingText(const char *message, TickType_t currentTickOffset);
 
-// Pixel width a message occupies in the menu font (panel-dependent).
-uint16_t messageWidth(const char *message);
-
 #endif /* SCROLL_MESSAGE_HPP_ */

--- a/source/Core/Src/ScrollMessage.cpp
+++ b/source/Core/Src/ScrollMessage.cpp
@@ -34,7 +34,13 @@ static uint16_t str_display_len(const char *const str) {
  *
  * @param message The null-terminated message string.
  */
-uint16_t messageWidth(const char *message) { return FONT_12_WIDTH * str_display_len(message); }
+uint16_t messageWidth(const char *message) {
+#ifdef OLED_128x32
+  return 8 * str_display_len(message); // descriptions use the 8x16 small font on 128x32
+#else
+  return FONT_12_WIDTH * str_display_len(message);
+#endif
+}
 
 void drawScrollingText(const char *message, TickType_t currentTickOffset) {
   OLED::clearScreen();
@@ -56,6 +62,12 @@ void drawScrollingText(const char *message, TickType_t currentTickOffset) {
   }
 
   //^ Rolling offset based on time
+#ifdef OLED_128x32
+  // Use the 8x16 small font, vertically centred, so the description isn't oversized
+  OLED::setCursor((OLED_WIDTH - messageOffset), 8);
+  OLED::print(message, FontStyle::SMALL);
+#else
   OLED::setCursor((OLED_WIDTH - messageOffset), 0);
   OLED::print(message, FontStyle::LARGE);
+#endif
 }

--- a/source/Core/Src/ScrollMessage.cpp
+++ b/source/Core/Src/ScrollMessage.cpp
@@ -34,7 +34,13 @@ static uint16_t str_display_len(const char *const str) {
  *
  * @param message The null-terminated message string.
  */
-static uint16_t messageWidth(const char *message) { return FONT_12_WIDTH * str_display_len(message); }
+static uint16_t messageWidth(const char *message) {
+#ifdef OLED_128x32
+  return 8 * str_display_len(message); // descriptions use the 8x16 small font on 128x32
+#else
+  return FONT_12_WIDTH * str_display_len(message);
+#endif
+}
 
 void drawScrollingText(const char *message, TickType_t currentTickOffset) {
   OLED::clearScreen();
@@ -57,11 +63,12 @@ void drawScrollingText(const char *message, TickType_t currentTickOffset) {
 
   //^ Rolling offset based on time
 #ifdef OLED_128x32
-  // Descriptions are encoded against the large-font symbol table, so they must be
-  // drawn with the large font; centre the 24px glyphs vertically on the 32px panel.
-  OLED::setCursor((OLED_WIDTH - messageOffset), 4);
+  // make_translation.py encodes descriptions against the small font on 128x32,
+  // so draw them with the small font, vertically centred on the 32px panel.
+  OLED::setCursor((OLED_WIDTH - messageOffset), 8);
+  OLED::print(message, FontStyle::SMALL);
 #else
   OLED::setCursor((OLED_WIDTH - messageOffset), 0);
-#endif
   OLED::print(message, FontStyle::LARGE);
+#endif
 }

--- a/source/Core/Src/ScrollMessage.cpp
+++ b/source/Core/Src/ScrollMessage.cpp
@@ -34,13 +34,7 @@ static uint16_t str_display_len(const char *const str) {
  *
  * @param message The null-terminated message string.
  */
-uint16_t messageWidth(const char *message) {
-#ifdef OLED_128x32
-  return 8 * str_display_len(message); // descriptions use the 8x16 small font on 128x32
-#else
-  return FONT_12_WIDTH * str_display_len(message);
-#endif
-}
+static uint16_t messageWidth(const char *message) { return FONT_12_WIDTH * str_display_len(message); }
 
 void drawScrollingText(const char *message, TickType_t currentTickOffset) {
   OLED::clearScreen();
@@ -63,11 +57,11 @@ void drawScrollingText(const char *message, TickType_t currentTickOffset) {
 
   //^ Rolling offset based on time
 #ifdef OLED_128x32
-  // Use the 8x16 small font, vertically centred, so the description isn't oversized
-  OLED::setCursor((OLED_WIDTH - messageOffset), 8);
-  OLED::print(message, FontStyle::SMALL);
+  // Descriptions are encoded against the large-font symbol table, so they must be
+  // drawn with the large font; centre the 24px glyphs vertically on the 32px panel.
+  OLED::setCursor((OLED_WIDTH - messageOffset), 4);
 #else
   OLED::setCursor((OLED_WIDTH - messageOffset), 0);
-  OLED::print(message, FontStyle::LARGE);
 #endif
+  OLED::print(message, FontStyle::LARGE);
 }

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -810,7 +810,13 @@ static void setTempF(void) {
 #endif /* PROFILE_SUPPORT */
 }
 
-static void displayTempF(void) { OLED::printSymbolDeg(FontStyle::LARGE); }
+static void displayTempF(void) {
+#ifdef OLED_128x32
+  // "°C"/"°F" is two 12px large glyphs; right-align it so it stays on screen, centred
+  OLED::setCursor(OLED_WIDTH - (2 * 12) - 2, 4);
+#endif
+  OLED::printSymbolDeg(FontStyle::LARGE);
+}
 
 #ifndef NO_DISPLAY_ROTATE
 

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -769,7 +769,10 @@ static void displayHallEffectSleepTime(void) {
 
 #ifdef TIP_TYPE_SUPPORT
 static void displaySolderingTipType(void) {
-  // TODO wrapping X value
+#ifdef OLED_128x32
+  // Right-align the variable-width tip name so it stays on screen, centred for the 16px font
+  OLED::setCursor(OLED_WIDTH - messageWidth(lookupTipName()) - 2, 8);
+#endif
   OLED::print(lookupTipName(), FontStyle::SMALL, 255, OLED::getCursorX());
 }
 // If there is no detection, and no options, max is 0

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -773,12 +773,47 @@ static void displayHallEffectSleepTime(void) {
 #endif /* HALL_SENSOR */
 
 #ifdef TIP_TYPE_SUPPORT
+#ifdef OLED_128x32
+// Width in pixels of the widest line of a (possibly two-line) tip name. Tip names
+// embed a newline (0x01), e.g. "Auto\nSense"; the small font is 8px per glyph.
+static uint16_t tipNameBlockWidth(const char *name) {
+  const uint8_t *p   = reinterpret_cast<const uint8_t *>(name);
+  uint16_t       cur = 0, widest = 0;
+  while (p[0]) {
+    if (p[0] == 0x01) { // newline marker
+      if (cur > widest) {
+        widest = cur;
+      }
+      cur = 0;
+      p++;
+    } else if (p[0] <= 0xF0) {
+      cur++;
+      p++;
+    } else {
+      if (!p[1]) {
+        break;
+      }
+      cur++;
+      p += 2;
+    }
+  }
+  if (cur > widest) {
+    widest = cur;
+  }
+  return widest * 8;
+}
+#endif
 static void displaySolderingTipType(void) {
 #ifdef OLED_128x32
-  // Right-align the variable-width tip name so it stays on screen, centred for the 16px font
-  OLED::setCursor(OLED_WIDTH - messageWidth(lookupTipName()) - 2, 8);
-#endif
+  // Tip names embed a newline; drawChar only wraps at y==0, so anchor a
+  // right-aligned, two-line block at the top of the panel.
+  const char *name = lookupTipName();
+  OLED::setCursor(OLED_WIDTH - tipNameBlockWidth(name) - 2, 0);
+  OLED::print(name, FontStyle::SMALL, 255, OLED::getCursorX());
+#else
+  // TODO wrapping X value
   OLED::print(lookupTipName(), FontStyle::SMALL, 255, OLED::getCursorX());
+#endif
 }
 // If there is no detection, and no options, max is 0
 static bool showSolderingTipType(void) { return tipType_t::TIP_TYPE_MAX != 0; }

--- a/source/Core/Src/settingsGUI.cpp
+++ b/source/Core/Src/settingsGUI.cpp
@@ -554,6 +554,11 @@ static void displayUSBPDMode(void) {
    *  NO_DYNAMIC, 0 = PPS + EPR disabled, fixed PDO only
    */
 
+#ifdef OLED_128x32
+  // Values wrap to two lines (e.g. "Default\nMode"); give them the right part of
+  // the panel and let the newline fill both 16px rows instead of overflowing.
+  OLED::setCursor(OLED_WIDTH - 64, 0);
+#endif
   switch (getSettingValue(SettingsOptions::USBPDMode)) {
   case usbpdMode_t::DEFAULT:
     OLED::print(translatedString(Tr->USBPDModeDefault), FontStyle::SMALL, 255, OLED::getCursorX());

--- a/source/Core/Threads/UI/logic/SettingsMenu.cpp
+++ b/source/Core/Threads/UI/logic/SettingsMenu.cpp
@@ -23,9 +23,14 @@ static void printShortDescription(SettingsItemIndex settingsItemIndex, uint16_t 
   uint8_t shortDescIndex = static_cast<uint8_t>(settingsItemIndex);
   OLED::printWholeScreen(translatedString(Tr->SettingsShortNames[shortDescIndex]));
 
-  // prepare cursor for value
-  // make room for scroll indicator
+  // prepare cursor for value (make room for the scroll indicator)
+#ifdef OLED_128x32
+  // The per-setting column is tuned for a 96px panel; on the wider 128px panel
+  // shift the value right to keep it edge-aligned, and centre the 24px font.
+  OLED::setCursor((cursorCharPosition * FONT_12_WIDTH - 2) + (OLED_WIDTH - 96), 4);
+#else
   OLED::setCursor(cursorCharPosition * FONT_12_WIDTH - 2, 0);
+#endif
 }
 
 // Render a menu, based on the position given


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

* **Please check if the PR fulfills these requirements**
- ⛔ The changes have been tested locally
-  ✅ There are no breaking changes

I tested the partial changes on my TS100 and TS101 and I can say because of the fixes from the 3rd PR are missing, the text is still showing mangled on the TS101.

<img width="4096" height="1331" alt="PR2" src="https://github.com/user-attachments/assets/929587a3-1017-4466-9cef-7984227f1160" />

* **What kind of change does this PR introduce?**
<!-- (Bug fix, feature, docs update, ...) -->

centralise the larger text vertically

* **What is the current behavior?**
<!-- (You can also just link to an open issue here) -->

#2212 #2063 

* **What is the new behavior (if this is a feature change)?**

It's part of a larger change to be introduced by separate future PRs.

* **Other information**:

Breaking the change into 3 smaller PRs as requrested in #2215 