### PR TITLE
WIP: Negotiate a 5V PD profile even without a tip, then re-negotiate up after

### DIFF
--- a/source/Core/BSP/Pinecilv2/ble_handlers.cpp
+++ b/source/Core/BSP/Pinecilv2/ble_handlers.cpp
@@ -155,7 +155,7 @@ int ble_char_read_bulk_value_callback(struct bt_conn *conn, const struct bt_gatt
           (uint32_t)TipThermoModel::getTipInC(),                               // 0  - Current temp
           getSettingValue(SettingsOptions::SolderingTemp),                     // 1  - Setpoint
           getInputVoltageX10(getSettingValue(SettingsOptions::VoltageDiv), 0), // 2  - Input voltage
-          getHandleTemperature(0),                                             // 3  - Handle X10 Temp in C
+          (uint32_t)getHandleTemperature(0),                                   // 3  - Handle X10 Temp in C
           X10WattsToPWM(x10WattHistory.average()),                             // 4  - Power as PWM level
           getPowerSrc(),                                                       // 5  - power src
           getTipResistanceX10(),                                               // 6  - Tip resistance

--- a/source/Core/Drivers/USBPD.cpp
+++ b/source/Core/Drivers/USBPD.cpp
@@ -45,6 +45,7 @@ bool USBPowerDelivery::start() {
 }
 void    USBPowerDelivery::IRQOccured() { pe.IRQOccured(); }
 bool    USBPowerDelivery::negotiationHasWorked() { return pe.pdHasNegotiated(); }
+void    USBPowerDelivery::renegotiate() { pe.renegotiate(); }
 uint8_t USBPowerDelivery::getStateNumber() { return pe.currentStateCode(true); }
 void    USBPowerDelivery::step() {
   while (pe.thread()) {
@@ -132,11 +133,16 @@ bool parseCapabilitiesArray(const uint8_t numCaps, uint8_t *bestIndex, uint16_t 
   // Walk the given capabilities array; and select the best option
   // Given assumption of fixed tip resistance; this can be simplified to highest voltage selection
   *bestIndex   = 0xFF; // Mark unselected
-  *bestVoltage = 5000; // Default 5V
+  *bestVoltage = 0;    // Default 0V
 
   // Fudge of 0.5 ohms to round up a little to account for us always having off periods in PWM
-  uint8_t     tipResistance = getTipResistanceX10();
-  usbpdMode_t pd_mode       = (usbpdMode_t)getSettingValue(SettingsOptions::USBPDMode);
+  uint8_t     tipResistance   = getTipResistanceX10();
+  bool        isFirstPassSafe = (tipResistance == 0);
+  usbpdMode_t pd_mode         = (usbpdMode_t)getSettingValue(SettingsOptions::USBPDMode);
+  // In the first pass safe, we just want basic profiles
+  if (isFirstPassSafe) {
+    pd_mode = usbpdMode_t::NO_DYNAMIC;
+  }
   if (pd_mode == usbpdMode_t::DEFAULT) {
     tipResistance += 5;
   }
@@ -170,6 +176,13 @@ bool parseCapabilitiesArray(const uint8_t numCaps, uint8_t *bestIndex, uint16_t 
                 *bestIsAVS   = false;
               }
             }
+          }
+          if (isFirstPassSafe && voltage_mv <= 9000 && (voltage_mv > *bestVoltage)) {
+            *bestIndex   = i;
+            *bestVoltage = voltage_mv;
+            *bestCurrent = current_a_x100;
+            *bestIsPPS   = false;
+            *bestIsAVS   = false;
           }
         }
       }

--- a/source/Core/Drivers/USBPD.h
+++ b/source/Core/Drivers/USBPD.h
@@ -20,6 +20,7 @@ public:
   static uint8_t   getStateNumber();          // Debugging - Get the internal state number
   static bool      isVBUSConnected();         // Is the VBus pin connected on the FUSB302
   static uint32_t *getLastSeenCapabilities(); // returns pointer to the last seen capabilities from the powersource
+  static void      renegotiate();             // Renegotiate the PD contract
 private:
   //
   static int detectionState;

--- a/source/Core/Src/main.cpp
+++ b/source/Core/Src/main.cpp
@@ -48,11 +48,11 @@ int main(void) {
   /* Create the thread(s) */
 
   /* definition and creation of PIDTask - Heating control*/
-  osThreadStaticDef(PIDTask, startPIDTask, osPriorityRealtime, 0, PIDTaskStackSize, PIDTaskBuffer, &PIDTaskControlBlock);
+  osThreadStaticDef(PIDTask, startPIDTask, osPriorityAboveNormal, 0, PIDTaskStackSize, PIDTaskBuffer, &PIDTaskControlBlock);
   PIDTaskHandle = osThreadCreate(osThread(PIDTask), NULL);
 
   /* definition and creation of POWTask - Power management for QC / PD */
-  osThreadStaticDef(POWTask, startPOWTask, osPriorityAboveNormal, 0, POWTaskStackSize, POWTaskBuffer, &POWTaskControlBlock);
+  osThreadStaticDef(POWTask, startPOWTask, osPriorityRealtime, 0, POWTaskStackSize, POWTaskBuffer, &POWTaskControlBlock);
   POWTaskHandle = osThreadCreate(osThread(POWTask), NULL);
 
   /* definition and creation of MOVTask - Accelerometer management */

--- a/source/Core/Threads/POWThread.cpp
+++ b/source/Core/Threads/POWThread.cpp
@@ -19,28 +19,38 @@
 #include "stdlib.h"
 #include "task.h"
 
+volatile bool hasDoneSecondStagePDRenegotiate = false;
 // Small worker thread to handle power (PD + QC) related steps
 
 void startPOWTask(void const *argument __unused) {
-
   // Init any other misc sensors
   postRToSInit();
-  while (preStartChecksDone() == 0) {
-    osDelay(3);
-  }
-  // You have to run this once we are willing to answer PD messages
-  // Setting up too early can mean that we miss the ~20ms window to respond on some chargers
+  BaseType_t res;
 #ifdef POW_PD
   USBPowerDelivery::start();
-  // Crank the handle at boot until we are stable and waiting for IRQ
+  // Crank the handle at boot until we are stable
   USBPowerDelivery::step();
 #endif
+
+  while (preStartChecksDone() == 0) {
+#ifdef POW_PD
+    USBPowerDelivery::step();
+    if (!getFUS302IRQLow()) {
+      res = xTaskNotifyWait(0x0, 0xFFFFFF, NULL, TICKS_100MS / 4);
+    }
+    if (res != pdFALSE || getFUS302IRQLow()) {
+      USBPowerDelivery::IRQOccured();
+    }
+    USBPowerDelivery::step();
+#else
+    osDelay(3);
+#endif
+  }
 #if POW_PD_EXT == 2
   FS2711::start();
   FS2711::negotiate();
 #endif
 
-  BaseType_t res;
   for (;;) {
     res = pdFALSE;
     // While the interrupt is low, dont delay
@@ -57,6 +67,10 @@ void startPOWTask(void const *argument __unused) {
 #ifdef POW_PD
     if (res != pdFALSE || getFUS302IRQLow()) {
       USBPowerDelivery::IRQOccured();
+    }
+    if (USBPowerDelivery::negotiationHasWorked() && !hasDoneSecondStagePDRenegotiate) {
+      USBPowerDelivery::renegotiate();
+      hasDoneSecondStagePDRenegotiate = true;
     }
     USBPowerDelivery::PPSTimerCallback();
     USBPowerDelivery::step();


### PR DESCRIPTION
<!-- Please try and fill out this template where possible, not all fields are required and can be removed. -->

- **Please check if the PR fulfills these requirements**

* [x] The changes have been tested locally
* [] There are no breaking changes

- **What kind of change does this PR introduce?**

<!-- (Bug fix, feature, docs update, ...) -->

- **What is the current behaviour?**
#2050 

- **What is the new behaviour (if this is a feature change)?**
Trying a new theory, we negotiate known safe profiles (5/9V) until tip resistance settles; then re-negotiate up.

Still WIP, needs some debugging around behaviour for renegotiation
This also means that PD negotiation
- **Other information**:
