### PR TITLE
Fix messageWidth calculation for messages displayed in large font

### DIFF
--- a/source/Core/Src/ScrollMessage.cpp
+++ b/source/Core/Src/ScrollMessage.cpp
@@ -35,6 +35,11 @@ static uint16_t str_display_len(const char *const str) {
  * @param message The null-terminated message string.
  */
 static uint16_t messageWidth(const char *message) {
+  const uint8_t *msgBytes = reinterpret_cast<const uint8_t *>(message);
+  if (msgBytes[0] == 0x01) {
+    // Leading 0x01 selects large font (see OLED::print)
+    return FONT_12_WIDTH * str_display_len(message + 1);
+  }
 #ifdef OLED_128x32
   return 8 * str_display_len(message); // descriptions use the 8x16 small font on 128x32
 #else


### PR DESCRIPTION
- **What kind of change does this PR introduce?**
Bug fix.
- **What is the current behaviour?**
For 128x32 OLED resolution, `messageWidth` assumes that all messages are displayed in a small font. However for warning messages, the message string is prepended with `0x01` which tells `OLED::print` to select large font. This results into an issue that warning messages do not auto scroll to the ending of the message. This issue was discovered while attempting to perform CJC calibration, the warning message didn't display the "...room temperature!" part.
<!-- (You can also just link to an open issue here) -->

- **What is the new behaviour (if this is a feature change)?**
Warning messages auto scroll to the ending of the message text.