### PR TITLE
TS101: fix OLED partial-screen rendering and vertical offset

### DIFF
--- a/source/Core/BSP/Miniware/configuration.h
+++ b/source/Core/BSP/Miniware/configuration.h
@@ -226,6 +226,15 @@
 #define HAS_POWER_DEBUG_MENU
 #define DEBUG_POWER_MENU_BUTTON_B
 
+// This panel does not reliably refresh over the shared bulk 0x80-continuation I2C
+// transaction (I2C_CLASS::Transmit/writeRegistersBulk): it only ever refreshes the
+// top-left portion of the panel. Send each command/data chunk as its own I2C
+// transaction instead (see OLED.cpp).
+#define OLED_I2C_PER_BYTE_TRANSFERS 1
+// This panel needs a non-zero, orientation-dependent SSD1306 vertical Display
+// Offset (0xD3); without it the image renders shifted by half the screen height.
+#define OLED_DISPLAY_OFFSET_QUIRK 1
+
 #endif /* TS101 */
 
 #if defined(MODEL_TS80) + defined(MODEL_TS80P) > 0

--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -42,10 +42,14 @@ I2C_CLASS::I2C_REG OLED_Setup_Array[] = {
     {0x80,  OLED_HEIGHT - 1, 0}, /* Multiplex ratio adjusts how far down the matrix it scans */
     {0x80,             0xC0, 0}, /* Set COM Scan direction */
     {0x80,             0xD3, 0}, /* Set vertical Display offset */
+#ifdef OLED_SEGMENT_MAP_REVERSED
+    {0x80,             0x30, 0}, /* Offset (128x32 panel needs a non-zero offset; see setRotation) */
+#else
     {0x80,             0x00, 0}, /* 0 Offset */
+#endif
     {0x80,             0x40, 0}, /* Set Display start line to 0 */
 #ifdef OLED_SEGMENT_MAP_REVERSED
-    {0x80,             0xA1, 0}, /* Set Segment remap to normal */
+    {0x80,             0xA0, 0}, /* Set Segment remap to normal */
 #else
     {0x80, 0xA0, 0}, /* Set Segment remap to normal */
 #endif
@@ -537,10 +541,18 @@ void OLED::setRotation(bool leftHanded) {
     return;
   }
 #ifdef OLED_SEGMENT_MAP_REVERSED
-  if (!leftHanded) {
+  // Segment-remap, COM-scan-direction and vertical Display-Offset (0xD3) as a matched
+  // triplet, taken from the official Miniware TS101 firmware disassembly: on the 128x32
+  // panel, changing orientation without also re-sending the Display-Offset leaves the
+  // image shifted by half the screen height.
+  if (leftHanded) {
     OLED_Setup_Array[9].val = 0xA1;
+    OLED_Setup_Array[5].val = 0xC8;
+    OLED_Setup_Array[7].val = 0x10;
   } else {
     OLED_Setup_Array[9].val = 0xA0;
+    OLED_Setup_Array[5].val = 0xC0;
+    OLED_Setup_Array[7].val = 0x30;
   }
 #else
   if (leftHanded) {
@@ -548,13 +560,13 @@ void OLED::setRotation(bool leftHanded) {
   } else {
     OLED_Setup_Array[9].val = 0xA0;
   }
-#endif /* OLED_SEGMENT_MAP_REVERSED */
   // send command struct again with changes
   if (leftHanded) {
     OLED_Setup_Array[5].val = 0xC8; // c1?
   } else {
     OLED_Setup_Array[5].val = 0xC0;
   }
+#endif /* OLED_SEGMENT_MAP_REVERSED */
   I2C_CLASS::writeRegistersBulk(DEVICEADDR_OLED, OLED_Setup_Array, sizeof(OLED_Setup_Array) / sizeof(OLED_Setup_Array[0]));
   osDelay(TICKS_10MS);
   inLeftHandedMode = leftHanded;

--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -42,13 +42,15 @@ I2C_CLASS::I2C_REG OLED_Setup_Array[] = {
     {0x80,  OLED_HEIGHT - 1, 0}, /* Multiplex ratio adjusts how far down the matrix it scans */
     {0x80,             0xC0, 0}, /* Set COM Scan direction */
     {0x80,             0xD3, 0}, /* Set vertical Display offset */
-#ifdef OLED_SEGMENT_MAP_REVERSED
-    {0x80,             0x30, 0}, /* Offset (128x32 panel needs a non-zero offset; see setRotation) */
+#ifdef MODEL_TS101
+    {0x80,             0x30, 0}, /* Offset (TS101's 128x32 panel needs a non-zero offset; see setRotation) */
 #else
     {0x80,             0x00, 0}, /* 0 Offset */
 #endif
     {0x80,             0x40, 0}, /* Set Display start line to 0 */
-#ifdef OLED_SEGMENT_MAP_REVERSED
+#if defined(OLED_SEGMENT_MAP_REVERSED) && !defined(MODEL_TS101)
+    {0x80,             0xA1, 0}, /* Set Segment remap to normal */
+#elif defined(MODEL_TS101)
     {0x80,             0xA0, 0}, /* Set Segment remap to normal */
 #else
     {0x80, 0xA0, 0}, /* Set Segment remap to normal */
@@ -120,6 +122,46 @@ static uint16_t easeInOutTiming(uint16_t t) { return t * t * (300 - 2 * t) / 100
  */
 static uint16_t lerp(uint16_t a, uint16_t b, uint16_t t) { return a + t * (b - a) / 100; }
 
+#ifdef MODEL_TS101
+// The TS101's 128x32 panel does not tolerate the bulk 0x80-continuation transmission
+// used by everything else on this bus (REFRESH_COMMANDS / I2C_CLASS::Transmit): it only
+// ever refreshes the top-left portion of the panel and the display offset never takes.
+// This alternate path sends each command as its own single-byte I2C transaction, matching
+// the addressing sequence used by the official Miniware TS101 firmware (reverse engineered
+// from TS101AppV220.hex, official firmware routine around 0x0800db54).
+static void i2c_send_command_byte(uint8_t cmd) { I2C_CLASS::I2C_RegisterWrite(DEVICEADDR_OLED, 0x00, cmd); }
+
+static void i2c_send_bulk(const uint8_t *buf, int len) { I2C_CLASS::Mem_Write(DEVICEADDR_OLED, 0x40, buf, len); }
+
+static void oled_bulk_write(uint32_t posx, uint32_t posy, int sizex, int sizey, const uint8_t *buf) {
+  uint32_t page      = (posy & 7) == 0 ? (posy >> 3) : (posy >> 3) + 1;
+  uint32_t pageEnd    = (posy + sizey) & 0xff;
+  pageEnd             = ((posy + sizey) & 7) == 0 ? (pageEnd >> 3) : (pageEnd >> 3) + 1;
+  for (; page < pageEnd; page = (page + 1) & 0xff) {
+    i2c_send_command_byte(page + 0xb0);
+    i2c_send_command_byte((posx >> 4) | 0x10);
+    i2c_send_command_byte(posx & 0xf);
+    i2c_send_bulk(buf, sizex);
+    buf += sizex;
+  }
+}
+
+void OLED::refresh() {
+  if (checkDisplayBufferChecksum()) {
+    oled_bulk_write(0, 0, OLED_WIDTH, OLED_HEIGHT, screenBuffer + FRAMEBUFFER_START);
+    // I2C is soft i2c, do not have to wait here
+  }
+}
+
+void OLED::setDisplayState(DisplayState state) {
+  if (state != displayState) {
+    displayState = state;
+    i2c_send_command_byte(state == ON ? OLED_ON : OLED_OFF);
+    osDelay(TICKS_10MS);
+  }
+}
+#endif /* MODEL_TS101 */
+
 void OLED::initialize() {
   cursor_x = cursor_y = 0;
   inLeftHandedMode    = false;
@@ -136,17 +178,26 @@ void OLED::initialize() {
 
 #endif /* OLED_128x32 */
   displayOffset = 0;
+#ifndef MODEL_TS101
   memcpy(&screenBuffer[0], &REFRESH_COMMANDS[0], sizeof(REFRESH_COMMANDS));
   memcpy(&secondFrameBuffer[0], &REFRESH_COMMANDS[0], sizeof(REFRESH_COMMANDS));
+#endif /* MODEL_TS101 */
 
   // Set the display to be ON once the settings block is sent and send the
   // initialisation data to the OLED.
 
+#ifdef MODEL_TS101
+  // Sent as individual command-byte writes; see i2c_send_command_byte above.
+  for (uint8_t i = 0; i < sizeof(OLED_Setup_Array) / sizeof(OLED_Setup_Array[0]); i++) {
+    i2c_send_command_byte(OLED_Setup_Array[i].val);
+  }
+#else
   for (int tries = 0; tries < 10; tries++) {
     if (I2C_CLASS::writeRegistersBulk(DEVICEADDR_OLED, OLED_Setup_Array, sizeof(OLED_Setup_Array) / sizeof(OLED_Setup_Array[0]))) {
       tries = 11;
     }
   }
+#endif /* MODEL_TS101 */
   setDisplayState(DisplayState::ON);
   initDone = true;
 }
@@ -292,6 +343,10 @@ void OLED::maskScrollIndicatorOnOLED() {
   // The right-most column depends on the screen rotation, so just take
   // it from the screen buffer which is updated by `OLED::setRotation`.
   uint8_t rightmostColumn = screenBuffer[7];
+#ifdef MODEL_TS101
+  static const uint8_t zeroColumn[OLED_HEIGHT / 8] = {0}; // Clears the full column height (all pages)
+  oled_bulk_write(rightmostColumn, 0, 1, OLED_HEIGHT, zeroColumn);
+#else
   uint8_t maskCommands[]  = {
       // Set column address:
       //  A[6:0] - Column start address = rightmost column
@@ -314,6 +369,7 @@ void OLED::maskScrollIndicatorOnOLED() {
       0x00,
   };
   I2C_CLASS::Transmit(DEVICEADDR_OLED, maskCommands, sizeof(maskCommands));
+#endif /* MODEL_TS101 */
 }
 
 /**
@@ -540,7 +596,7 @@ void OLED::setRotation(bool leftHanded) {
   if (inLeftHandedMode == leftHanded) {
     return;
   }
-#ifdef OLED_SEGMENT_MAP_REVERSED
+#ifdef MODEL_TS101
   // Segment-remap, COM-scan-direction and vertical Display-Offset (0xD3) as a matched
   // triplet, taken from the official Miniware TS101 firmware disassembly: on the 128x32
   // panel, changing orientation without also re-sending the Display-Offset leaves the
@@ -554,20 +610,34 @@ void OLED::setRotation(bool leftHanded) {
     OLED_Setup_Array[5].val = 0xC0;
     OLED_Setup_Array[7].val = 0x30;
   }
+  // Sent as individual command-byte writes; the bulk 0x80-continuation path below
+  // is what leaves the TS101 panel stuck on a partial refresh.
+  i2c_send_command_byte(OLED_Setup_Array[9].val);
+  i2c_send_command_byte(OLED_Setup_Array[5].val);
+  i2c_send_command_byte(OLED_Setup_Array[6].val); // 0xD3, Set Display Offset
+  i2c_send_command_byte(OLED_Setup_Array[7].val);
+#else
+#ifdef OLED_SEGMENT_MAP_REVERSED
+  if (!leftHanded) {
+    OLED_Setup_Array[9].val = 0xA1;
+  } else {
+    OLED_Setup_Array[9].val = 0xA0;
+  }
 #else
   if (leftHanded) {
     OLED_Setup_Array[9].val = 0xA1;
   } else {
     OLED_Setup_Array[9].val = 0xA0;
   }
+#endif /* OLED_SEGMENT_MAP_REVERSED */
   // send command struct again with changes
   if (leftHanded) {
     OLED_Setup_Array[5].val = 0xC8; // c1?
   } else {
     OLED_Setup_Array[5].val = 0xC0;
   }
-#endif /* OLED_SEGMENT_MAP_REVERSED */
   I2C_CLASS::writeRegistersBulk(DEVICEADDR_OLED, OLED_Setup_Array, sizeof(OLED_Setup_Array) / sizeof(OLED_Setup_Array[0]));
+#endif /* MODEL_TS101 */
   osDelay(TICKS_10MS);
   inLeftHandedMode = leftHanded;
 
@@ -576,8 +646,12 @@ void OLED::setRotation(bool leftHanded) {
   screenBuffer[7] = inLeftHandedMode ? OLED_GRAM_END_FLIP : OLED_GRAM_END;     // End address of the ram segment we are writing to (96 wide)
   screenBuffer[9] = inLeftHandedMode ? 0xC8 : 0xC0;
   // Force a screen refresh
+#ifdef MODEL_TS101
+  oled_bulk_write(0, 0, OLED_WIDTH, OLED_HEIGHT, screenBuffer + FRAMEBUFFER_START);
+#else
   const int len = FRAMEBUFFER_START + (OLED_WIDTH * (OLED_HEIGHT / 8));
   I2C_CLASS::Transmit(DEVICEADDR_OLED, screenBuffer, len);
+#endif /* MODEL_TS101 */
   osDelay(TICKS_10MS);
   checkDisplayBufferChecksum();
 }
@@ -585,7 +659,12 @@ void OLED::setRotation(bool leftHanded) {
 void OLED::setBrightness(uint8_t contrast) {
   if (OLED_Setup_Array[15].val != contrast) {
     OLED_Setup_Array[15].val = contrast;
+#ifdef MODEL_TS101
+    i2c_send_command_byte(OLED_Setup_Array[14].val); // 0x81, contrast-control command
+    i2c_send_command_byte(contrast);
+#else
     I2C_CLASS::writeRegistersBulk(DEVICEADDR_OLED, &OLED_Setup_Array[14], 2);
+#endif /* MODEL_TS101 */
   }
 }
 
@@ -593,7 +672,11 @@ void OLED::setInverseDisplay(bool inverse) {
   uint8_t normalInverseCmd = inverse ? 0xA7 : 0xA6;
   if (OLED_Setup_Array[21].val != normalInverseCmd) {
     OLED_Setup_Array[21].val = normalInverseCmd;
+#ifdef MODEL_TS101
+    i2c_send_command_byte(normalInverseCmd);
+#else
     I2C_CLASS::I2C_RegisterWrite(DEVICEADDR_OLED, 0x80, normalInverseCmd);
+#endif /* MODEL_TS101 */
   }
 }
 

--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -42,15 +42,15 @@ I2C_CLASS::I2C_REG OLED_Setup_Array[] = {
     {0x80,  OLED_HEIGHT - 1, 0}, /* Multiplex ratio adjusts how far down the matrix it scans */
     {0x80,             0xC0, 0}, /* Set COM Scan direction */
     {0x80,             0xD3, 0}, /* Set vertical Display offset */
-#ifdef MODEL_TS101
-    {0x80,             0x30, 0}, /* Offset (TS101's 128x32 panel needs a non-zero offset; see setRotation) */
+#ifdef OLED_DISPLAY_OFFSET_QUIRK
+    {0x80,             0x30, 0}, /* Offset (this panel needs a non-zero offset; see setRotation) */
 #else
     {0x80,             0x00, 0}, /* 0 Offset */
 #endif
     {0x80,             0x40, 0}, /* Set Display start line to 0 */
-#if defined(OLED_SEGMENT_MAP_REVERSED) && !defined(MODEL_TS101)
+#if defined(OLED_SEGMENT_MAP_REVERSED) && !defined(OLED_DISPLAY_OFFSET_QUIRK)
     {0x80,             0xA1, 0}, /* Set Segment remap to normal */
-#elif defined(MODEL_TS101)
+#elif defined(OLED_DISPLAY_OFFSET_QUIRK)
     {0x80,             0xA0, 0}, /* Set Segment remap to normal */
 #else
     {0x80, 0xA0, 0}, /* Set Segment remap to normal */
@@ -122,9 +122,9 @@ static uint16_t easeInOutTiming(uint16_t t) { return t * t * (300 - 2 * t) / 100
  */
 static uint16_t lerp(uint16_t a, uint16_t b, uint16_t t) { return a + t * (b - a) / 100; }
 
-#ifdef MODEL_TS101
-// The TS101's 128x32 panel does not tolerate the bulk 0x80-continuation transmission
-// used by everything else on this bus (REFRESH_COMMANDS / I2C_CLASS::Transmit): it only
+#ifdef OLED_I2C_PER_BYTE_TRANSFERS
+// This panel does not tolerate the bulk 0x80-continuation transmission used by
+// everything else on this bus (REFRESH_COMMANDS / I2C_CLASS::Transmit): it only
 // ever refreshes the top-left portion of the panel and the display offset never takes.
 // This alternate path sends each command as its own single-byte I2C transaction, matching
 // the addressing sequence used by the official Miniware TS101 firmware (reverse engineered
@@ -160,7 +160,7 @@ void OLED::setDisplayState(DisplayState state) {
     osDelay(TICKS_10MS);
   }
 }
-#endif /* MODEL_TS101 */
+#endif /* OLED_I2C_PER_BYTE_TRANSFERS */
 
 void OLED::initialize() {
   cursor_x = cursor_y = 0;
@@ -178,15 +178,15 @@ void OLED::initialize() {
 
 #endif /* OLED_128x32 */
   displayOffset = 0;
-#ifndef MODEL_TS101
+#ifndef OLED_I2C_PER_BYTE_TRANSFERS
   memcpy(&screenBuffer[0], &REFRESH_COMMANDS[0], sizeof(REFRESH_COMMANDS));
   memcpy(&secondFrameBuffer[0], &REFRESH_COMMANDS[0], sizeof(REFRESH_COMMANDS));
-#endif /* MODEL_TS101 */
+#endif /* OLED_I2C_PER_BYTE_TRANSFERS */
 
   // Set the display to be ON once the settings block is sent and send the
   // initialisation data to the OLED.
 
-#ifdef MODEL_TS101
+#ifdef OLED_I2C_PER_BYTE_TRANSFERS
   // Sent as individual command-byte writes; see i2c_send_command_byte above.
   for (uint8_t i = 0; i < sizeof(OLED_Setup_Array) / sizeof(OLED_Setup_Array[0]); i++) {
     i2c_send_command_byte(OLED_Setup_Array[i].val);
@@ -197,7 +197,7 @@ void OLED::initialize() {
       tries = 11;
     }
   }
-#endif /* MODEL_TS101 */
+#endif /* OLED_I2C_PER_BYTE_TRANSFERS */
   setDisplayState(DisplayState::ON);
   initDone = true;
 }
@@ -343,7 +343,7 @@ void OLED::maskScrollIndicatorOnOLED() {
   // The right-most column depends on the screen rotation, so just take
   // it from the screen buffer which is updated by `OLED::setRotation`.
   uint8_t rightmostColumn = screenBuffer[7];
-#ifdef MODEL_TS101
+#ifdef OLED_I2C_PER_BYTE_TRANSFERS
   static const uint8_t zeroColumn[OLED_HEIGHT / 8] = {0}; // Clears the full column height (all pages)
   oled_bulk_write(rightmostColumn, 0, 1, OLED_HEIGHT, zeroColumn);
 #else
@@ -369,7 +369,7 @@ void OLED::maskScrollIndicatorOnOLED() {
       0x00,
   };
   I2C_CLASS::Transmit(DEVICEADDR_OLED, maskCommands, sizeof(maskCommands));
-#endif /* MODEL_TS101 */
+#endif /* OLED_I2C_PER_BYTE_TRANSFERS */
 }
 
 /**
@@ -596,9 +596,9 @@ void OLED::setRotation(bool leftHanded) {
   if (inLeftHandedMode == leftHanded) {
     return;
   }
-#ifdef MODEL_TS101
+#ifdef OLED_DISPLAY_OFFSET_QUIRK
   // Segment-remap, COM-scan-direction and vertical Display-Offset (0xD3) as a matched
-  // triplet, taken from the official Miniware TS101 firmware disassembly: on the 128x32
+  // triplet, taken from the official Miniware TS101 firmware disassembly: on this
   // panel, changing orientation without also re-sending the Display-Offset leaves the
   // image shifted by half the screen height.
   if (leftHanded) {
@@ -610,12 +610,6 @@ void OLED::setRotation(bool leftHanded) {
     OLED_Setup_Array[5].val = 0xC0;
     OLED_Setup_Array[7].val = 0x30;
   }
-  // Sent as individual command-byte writes; the bulk 0x80-continuation path below
-  // is what leaves the TS101 panel stuck on a partial refresh.
-  i2c_send_command_byte(OLED_Setup_Array[9].val);
-  i2c_send_command_byte(OLED_Setup_Array[5].val);
-  i2c_send_command_byte(OLED_Setup_Array[6].val); // 0xD3, Set Display Offset
-  i2c_send_command_byte(OLED_Setup_Array[7].val);
 #else
 #ifdef OLED_SEGMENT_MAP_REVERSED
   if (!leftHanded) {
@@ -636,8 +630,17 @@ void OLED::setRotation(bool leftHanded) {
   } else {
     OLED_Setup_Array[5].val = 0xC0;
   }
+#endif /* OLED_DISPLAY_OFFSET_QUIRK */
+#ifdef OLED_I2C_PER_BYTE_TRANSFERS
+  // Sent as individual command-byte writes; the bulk 0x80-continuation path below
+  // is what leaves this panel stuck on a partial refresh.
+  i2c_send_command_byte(OLED_Setup_Array[9].val);
+  i2c_send_command_byte(OLED_Setup_Array[5].val);
+  i2c_send_command_byte(OLED_Setup_Array[6].val); // 0xD3, Set Display Offset
+  i2c_send_command_byte(OLED_Setup_Array[7].val);
+#else
   I2C_CLASS::writeRegistersBulk(DEVICEADDR_OLED, OLED_Setup_Array, sizeof(OLED_Setup_Array) / sizeof(OLED_Setup_Array[0]));
-#endif /* MODEL_TS101 */
+#endif /* OLED_I2C_PER_BYTE_TRANSFERS */
   osDelay(TICKS_10MS);
   inLeftHandedMode = leftHanded;
 
@@ -646,12 +649,12 @@ void OLED::setRotation(bool leftHanded) {
   screenBuffer[7] = inLeftHandedMode ? OLED_GRAM_END_FLIP : OLED_GRAM_END;     // End address of the ram segment we are writing to (96 wide)
   screenBuffer[9] = inLeftHandedMode ? 0xC8 : 0xC0;
   // Force a screen refresh
-#ifdef MODEL_TS101
+#ifdef OLED_I2C_PER_BYTE_TRANSFERS
   oled_bulk_write(0, 0, OLED_WIDTH, OLED_HEIGHT, screenBuffer + FRAMEBUFFER_START);
 #else
   const int len = FRAMEBUFFER_START + (OLED_WIDTH * (OLED_HEIGHT / 8));
   I2C_CLASS::Transmit(DEVICEADDR_OLED, screenBuffer, len);
-#endif /* MODEL_TS101 */
+#endif /* OLED_I2C_PER_BYTE_TRANSFERS */
   osDelay(TICKS_10MS);
   checkDisplayBufferChecksum();
 }
@@ -659,12 +662,12 @@ void OLED::setRotation(bool leftHanded) {
 void OLED::setBrightness(uint8_t contrast) {
   if (OLED_Setup_Array[15].val != contrast) {
     OLED_Setup_Array[15].val = contrast;
-#ifdef MODEL_TS101
+#ifdef OLED_I2C_PER_BYTE_TRANSFERS
     i2c_send_command_byte(OLED_Setup_Array[14].val); // 0x81, contrast-control command
     i2c_send_command_byte(contrast);
 #else
     I2C_CLASS::writeRegistersBulk(DEVICEADDR_OLED, &OLED_Setup_Array[14], 2);
-#endif /* MODEL_TS101 */
+#endif /* OLED_I2C_PER_BYTE_TRANSFERS */
   }
 }
 
@@ -672,11 +675,11 @@ void OLED::setInverseDisplay(bool inverse) {
   uint8_t normalInverseCmd = inverse ? 0xA7 : 0xA6;
   if (OLED_Setup_Array[21].val != normalInverseCmd) {
     OLED_Setup_Array[21].val = normalInverseCmd;
-#ifdef MODEL_TS101
+#ifdef OLED_I2C_PER_BYTE_TRANSFERS
     i2c_send_command_byte(normalInverseCmd);
 #else
     I2C_CLASS::I2C_RegisterWrite(DEVICEADDR_OLED, 0x80, normalInverseCmd);
-#endif /* MODEL_TS101 */
+#endif /* OLED_I2C_PER_BYTE_TRANSFERS */
   }
 }
 

--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -45,13 +45,13 @@ I2C_CLASS::I2C_REG OLED_Setup_Array[] = {
 #ifdef OLED_DISPLAY_OFFSET_QUIRK
     {0x80,             0x30, 0}, /* Offset (this panel needs a non-zero offset; see setRotation) */
 #else
-    {0x80,             0x00, 0}, /* 0 Offset */
+    {0x80, 0x00, 0}, /* 0 Offset */
 #endif
     {0x80,             0x40, 0}, /* Set Display start line to 0 */
 #if defined(OLED_SEGMENT_MAP_REVERSED) && !defined(OLED_DISPLAY_OFFSET_QUIRK)
     {0x80,             0xA1, 0}, /* Set Segment remap to normal */
 #elif defined(OLED_DISPLAY_OFFSET_QUIRK)
-    {0x80,             0xA0, 0}, /* Set Segment remap to normal */
+    {0x80, 0xA0, 0}, /* Set Segment remap to normal */
 #else
     {0x80, 0xA0, 0}, /* Set Segment remap to normal */
 #endif
@@ -134,9 +134,9 @@ static void i2c_send_command_byte(uint8_t cmd) { I2C_CLASS::I2C_RegisterWrite(DE
 static void i2c_send_bulk(const uint8_t *buf, int len) { I2C_CLASS::Mem_Write(DEVICEADDR_OLED, 0x40, buf, len); }
 
 static void oled_bulk_write(uint32_t posx, uint32_t posy, int sizex, int sizey, const uint8_t *buf) {
-  uint32_t page      = (posy & 7) == 0 ? (posy >> 3) : (posy >> 3) + 1;
-  uint32_t pageEnd    = (posy + sizey) & 0xff;
-  pageEnd             = ((posy + sizey) & 7) == 0 ? (pageEnd >> 3) : (pageEnd >> 3) + 1;
+  uint32_t page    = (posy & 7) == 0 ? (posy >> 3) : (posy >> 3) + 1;
+  uint32_t pageEnd = (posy + sizey) & 0xff;
+  pageEnd          = ((posy + sizey) & 7) == 0 ? (pageEnd >> 3) : (pageEnd >> 3) + 1;
   for (; page < pageEnd; page = (page + 1) & 0xff) {
     i2c_send_command_byte(page + 0xb0);
     i2c_send_command_byte((posx >> 4) | 0x10);
@@ -157,6 +157,25 @@ void OLED::setDisplayState(DisplayState state) {
   if (state != displayState) {
     displayState = state;
     i2c_send_command_byte(state == ON ? OLED_ON : OLED_OFF);
+    osDelay(TICKS_10MS);
+  }
+}
+#else
+void OLED::refresh() {
+  if (checkDisplayBufferChecksum()) {
+    const int len = FRAMEBUFFER_START + (OLED_WIDTH * (OLED_HEIGHT / 8));
+    I2C_CLASS::Transmit(DEVICEADDR_OLED, screenBuffer, len);
+    // DMA tx time is ~ 20mS Ensure after calling this you delay for at least 25ms
+    // or we need to goto double buffering
+  }
+}
+
+void OLED::setDisplayState(DisplayState state) {
+  if (state != displayState) {
+    displayState    = state;
+    screenBuffer[1] = (state == ON) ? OLED_ON : OLED_OFF;
+    // Dump the screen state change out _now_
+    I2C_CLASS::Transmit(DEVICEADDR_OLED, screenBuffer, FRAMEBUFFER_START - 1);
     osDelay(TICKS_10MS);
   }
 }
@@ -347,7 +366,7 @@ void OLED::maskScrollIndicatorOnOLED() {
   static const uint8_t zeroColumn[OLED_HEIGHT / 8] = {0}; // Clears the full column height (all pages)
   oled_bulk_write(rightmostColumn, 0, 1, OLED_HEIGHT, zeroColumn);
 #else
-  uint8_t maskCommands[]  = {
+  uint8_t maskCommands[] = {
       // Set column address:
       //  A[6:0] - Column start address = rightmost column
       //  B[6:0] - Column end address = rightmost column
@@ -632,12 +651,13 @@ void OLED::setRotation(bool leftHanded) {
   }
 #endif /* OLED_DISPLAY_OFFSET_QUIRK */
 #ifdef OLED_I2C_PER_BYTE_TRANSFERS
-  // Sent as individual command-byte writes; the bulk 0x80-continuation path below
-  // is what leaves this panel stuck on a partial refresh.
-  i2c_send_command_byte(OLED_Setup_Array[9].val);
+  // Sent as individual command-byte writes, in the same order they appear in
+  // OLED_Setup_Array; the bulk 0x80-continuation path below is what leaves
+  // this panel stuck on a partial refresh.
   i2c_send_command_byte(OLED_Setup_Array[5].val);
   i2c_send_command_byte(OLED_Setup_Array[6].val); // 0xD3, Set Display Offset
   i2c_send_command_byte(OLED_Setup_Array[7].val);
+  i2c_send_command_byte(OLED_Setup_Array[9].val);
 #else
   I2C_CLASS::writeRegistersBulk(DEVICEADDR_OLED, OLED_Setup_Array, sizeof(OLED_Setup_Array) / sizeof(OLED_Setup_Array[0]));
 #endif /* OLED_I2C_PER_BYTE_TRANSFERS */

--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -49,11 +49,9 @@ I2C_CLASS::I2C_REG OLED_Setup_Array[] = {
 #endif
     {0x80,             0x40, 0}, /* Set Display start line to 0 */
 #if defined(OLED_SEGMENT_MAP_REVERSED) && !defined(OLED_DISPLAY_OFFSET_QUIRK)
-    {0x80,             0xA1, 0}, /* Set Segment remap to normal */
-#elif defined(OLED_DISPLAY_OFFSET_QUIRK)
-    {0x80, 0xA0, 0}, /* Set Segment remap to normal */
+    {0x80,             0xA1, 0}, /* Set Segment remap (reversed) */
 #else
-    {0x80, 0xA0, 0}, /* Set Segment remap to normal */
+    {0x80,             0xA0, 0}, /* Set Segment remap to normal */
 #endif
     {0x80,             0x8D, 0}, /* Charge Pump */
     {0x80,             0x14, 0}, /* Charge Pump settings */

--- a/source/Core/Drivers/OLED.cpp
+++ b/source/Core/Drivers/OLED.cpp
@@ -51,7 +51,7 @@ I2C_CLASS::I2C_REG OLED_Setup_Array[] = {
 #if defined(OLED_SEGMENT_MAP_REVERSED) && !defined(OLED_DISPLAY_OFFSET_QUIRK)
     {0x80,             0xA1, 0}, /* Set Segment remap (reversed) */
 #else
-    {0x80,             0xA0, 0}, /* Set Segment remap to normal */
+    {0x80, 0xA0, 0}, /* Set Segment remap to normal */
 #endif
     {0x80,             0x8D, 0}, /* Charge Pump */
     {0x80,             0x14, 0}, /* Charge Pump settings */

--- a/source/Core/Drivers/OLED.hpp
+++ b/source/Core/Drivers/OLED.hpp
@@ -84,8 +84,8 @@ public:
   static void initialize(); // Startup the I2C coms (brings screen out of reset etc)
   static bool isInitDone();
   // Draw the buffer out to the LCD if any content has changed.
-#ifdef MODEL_TS101
-  // TS101's panel needs the per-byte command path (see OLED.cpp); the shared
+#ifdef OLED_I2C_PER_BYTE_TRANSFERS
+  // This panel needs the per-byte command path (see OLED.cpp); the shared
   // bulk Transmit() below leaves it stuck on a partial-screen refresh.
   static void refresh();
 #else
@@ -100,7 +100,7 @@ public:
   }
 #endif
 
-#ifdef MODEL_TS101
+#ifdef OLED_I2C_PER_BYTE_TRANSFERS
   static void setDisplayState(DisplayState state);
 #else
   static void setDisplayState(DisplayState state) {

--- a/source/Core/Drivers/OLED.hpp
+++ b/source/Core/Drivers/OLED.hpp
@@ -84,35 +84,10 @@ public:
   static void initialize(); // Startup the I2C coms (brings screen out of reset etc)
   static bool isInitDone();
   // Draw the buffer out to the LCD if any content has changed.
-#ifdef OLED_I2C_PER_BYTE_TRANSFERS
-  // This panel needs the per-byte command path (see OLED.cpp); the shared
-  // bulk Transmit() below leaves it stuck on a partial-screen refresh.
+  // (see OLED.cpp: OLED_I2C_PER_BYTE_TRANSFERS selects between the per-byte
+  // command path some panels need and the shared bulk Transmit() path)
   static void refresh();
-#else
-  static void refresh() {
-
-    if (checkDisplayBufferChecksum()) {
-      const int len = FRAMEBUFFER_START + (OLED_WIDTH * (OLED_HEIGHT / 8));
-      I2C_CLASS::Transmit(DEVICEADDR_OLED, screenBuffer, len);
-      // DMA tx time is ~ 20mS Ensure after calling this you delay for at least 25ms
-      // or we need to goto double buffering
-    }
-  }
-#endif
-
-#ifdef OLED_I2C_PER_BYTE_TRANSFERS
   static void setDisplayState(DisplayState state);
-#else
-  static void setDisplayState(DisplayState state) {
-    if (state != displayState) {
-      displayState    = state;
-      screenBuffer[1] = (state == ON) ? OLED_ON : OLED_OFF;
-      // Dump the screen state change out _now_
-      I2C_CLASS::Transmit(DEVICEADDR_OLED, screenBuffer, FRAMEBUFFER_START - 1);
-      osDelay(TICKS_10MS);
-    }
-  }
-#endif
 
   // Set the rotation for the screen
   static void setRotation(bool leftHanded);

--- a/source/Core/Drivers/OLED.hpp
+++ b/source/Core/Drivers/OLED.hpp
@@ -84,6 +84,11 @@ public:
   static void initialize(); // Startup the I2C coms (brings screen out of reset etc)
   static bool isInitDone();
   // Draw the buffer out to the LCD if any content has changed.
+#ifdef MODEL_TS101
+  // TS101's panel needs the per-byte command path (see OLED.cpp); the shared
+  // bulk Transmit() below leaves it stuck on a partial-screen refresh.
+  static void refresh();
+#else
   static void refresh() {
 
     if (checkDisplayBufferChecksum()) {
@@ -93,7 +98,11 @@ public:
       // or we need to goto double buffering
     }
   }
+#endif
 
+#ifdef MODEL_TS101
+  static void setDisplayState(DisplayState state);
+#else
   static void setDisplayState(DisplayState state) {
     if (state != displayState) {
       displayState    = state;
@@ -103,6 +112,7 @@ public:
       osDelay(TICKS_10MS);
     }
   }
+#endif
 
   // Set the rotation for the screen
   static void setRotation(bool leftHanded);


### PR DESCRIPTION
- **Please check if the PR fulfills these requirements**

* [x] The changes have been tested locally
* [x] There are no breaking changes known

- **What kind of change does this PR introduce?**

Bug fix (TS101 OLED driver).

- **What is the current behaviour?**

On stock TS101 (`MODEL_TS101`), the shared OLED transmission path (`I2C_CLASS::Transmit`/`writeRegistersBulk`, a single bulk `0x80`-continuation-prefixed I2C transaction) does not reliably drive the full 128x32 SSD1306 panel: the boot splash stays on screen and the menu only renders in a small area at the top-left. Every other model on this driver (TS100, TS80, TS80P, Pinecil, Sequre S60/S60P/T55, ...) is unaffected — this is specific to the TS101's panel/wiring.

- **What is the new behaviour (if this is a feature change)?**

1. Ports the per-byte I2C command path from the community fork [IronOS-TS101-FullOLED](https://github.com/vtolvr/IronOS-TS101-FullOLED) — sends each command/data chunk as its own I2C transaction instead of one large bulk transfer. Applied to `refresh()`, `setDisplayState()`, `initialize()`, `setRotation()`, `setBrightness()`, `setInverseDisplay()` and `maskScrollIndicatorOnOLED()`.
2. Adds the missing SSD1306 "Set Display Offset" (`0xD3`) command with an orientation-dependent value, matching the official Miniware TS101 firmware disassembly (`TS101AppV220.hex`) — without it the panel can render shifted by half its screen height.
3. Per review feedback, replaced the raw `#ifdef MODEL_TS101` checks in the shared OLED driver with two descriptive flags defined in TS101's own `configuration.h`: `OLED_I2C_PER_BYTE_TRANSFERS` (bus can't do bulk transfers) and `OLED_DISPLAY_OFFSET_QUIRK` (needs the non-zero orientation-dependent offset). These are two independent concerns — another model could hit either issue on its own — and are no longer coupled to a specific `MODEL_` macro in the driver itself. No behaviour change for TS101 or any other model.

- **Other information**:

Verified end-to-end (EN and FR builds) on two physical TS101 units, on different bootloader/DFU versions (1.06 and 1.08): before this change the screen stayed on the boot splash with the menu confined to the top-left; after, the full 128x32 panel renders correctly in both orientations on both units, with brightness/inverse-display/rotation all working.

Test plan:
- [x] Builds cleanly for `model=TS101 firmware-EN` and `firmware-FR`
- [x] Builds cleanly for `model=TS100 firmware-EN` (regression check — new flags not defined, code path unchanged)
- [x] Confirmed fixes the partial-screen/offset issue on two physical TS101 units (DFU 1.06 and DFU 1.08), both orientations
- [ ] Not tested on other model

- **An LLM (AI) was used for some of this code**
- [x] An LLM was used, and I have manually audited the code. I understand what changes it made and why.
